### PR TITLE
feat: Fixes #75. Add edit icon from semantic-ui to account name input field

### DIFF
--- a/packages/app-accounts/src/Editor.js
+++ b/packages/app-accounts/src/Editor.js
@@ -135,6 +135,7 @@ class Editor extends React.PureComponent<Props, State> {
               })}
               onChange={this.onChangeName}
               value={editedName}
+              isEditable={true}
             />
           </div>
         </div>

--- a/packages/app-accounts/src/Editor.js
+++ b/packages/app-accounts/src/Editor.js
@@ -130,12 +130,12 @@ class Editor extends React.PureComponent<Props, State> {
           <div className='ui--row'>
             <Input
               className='full'
+              isEditable
               label={t('editor.name', {
                 defaultValue: 'identified by the name'
               })}
               onChange={this.onChangeName}
               value={editedName}
-              isEditable
             />
           </div>
         </div>

--- a/packages/app-accounts/src/Editor.js
+++ b/packages/app-accounts/src/Editor.js
@@ -135,7 +135,7 @@ class Editor extends React.PureComponent<Props, State> {
               })}
               onChange={this.onChangeName}
               value={editedName}
-              isEditable={true}
+              isEditable
             />
           </div>
         </div>

--- a/packages/ui-app/src/Input.js
+++ b/packages/ui-app/src/Input.js
@@ -62,6 +62,7 @@ export default class Input extends React.PureComponent<Props, State> {
       >
         <SUIInput
           action={isAction}
+          className={isEditable ? 'ui icon input edit' : ''}
           defaultValue={defaultValue}
           disabled={isDisabled}
           id={name}
@@ -79,7 +80,6 @@ export default class Input extends React.PureComponent<Props, State> {
           placeholder={placeholder}
           type={type}
           value={value}
-          className={isEditable ? 'ui icon input edit' : ''}
         >
           <input
             autoComplete={

--- a/packages/ui-app/src/Input.js
+++ b/packages/ui-app/src/Input.js
@@ -62,7 +62,7 @@ export default class Input extends React.PureComponent<Props, State> {
       >
         <SUIInput
           action={isAction}
-          className={isEditable ? 'ui icon input edit' : ''}
+          className={isEditable ? 'edit icon' : ''}
           defaultValue={defaultValue}
           disabled={isDisabled}
           id={name}

--- a/packages/ui-app/src/Input.js
+++ b/packages/ui-app/src/Input.js
@@ -49,7 +49,7 @@ export default class Input extends React.PureComponent<Props, State> {
   };
 
   render (): React$Node {
-    const { children, className, defaultValue, icon, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, min, placeholder, style, type = 'text', value, withLabel } = this.props;
+    const { children, className, defaultValue, icon, isEditable = false, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, min, placeholder, style, type = 'text', value, withLabel } = this.props;
     const { name } = this.state;
 
     return (
@@ -78,6 +78,7 @@ export default class Input extends React.PureComponent<Props, State> {
           placeholder={placeholder}
           type={type}
           value={value}
+          className={isEditable ? "ui icon input edit" : ""}
         >
           <input
             autoComplete={
@@ -86,6 +87,7 @@ export default class Input extends React.PureComponent<Props, State> {
                 : 'off'
             }
           />
+          {isEditable ? <i className="edit icon"></i> : null}
           {icon}
           {children}
         </SUIInput>

--- a/packages/ui-app/src/Input.js
+++ b/packages/ui-app/src/Input.js
@@ -20,6 +20,7 @@ type Props = BareProps & {
   icon?: React$Node,
   isAction?: boolean,
   isDisabled?: boolean,
+  isEditable?: boolean,
   isError?: boolean,
   isHidden?: boolean,
   label?: React$Node,
@@ -78,7 +79,7 @@ export default class Input extends React.PureComponent<Props, State> {
           placeholder={placeholder}
           type={type}
           value={value}
-          className={isEditable ? "ui icon input edit" : ""}
+          className={isEditable ? 'ui icon input edit' : ''}
         >
           <input
             autoComplete={
@@ -87,7 +88,7 @@ export default class Input extends React.PureComponent<Props, State> {
                 : 'off'
             }
           />
-          {isEditable ? <i className="edit icon"></i> : null}
+          {isEditable ? <i className='edit icon' /> : null}
           {icon}
           {children}
         </SUIInput>


### PR DESCRIPTION
Adding an edit icon that is embedded in the account name input field makes it more obvious to the user that the input field isn't read-only, and that there is a way to "click before doing" (i.e. editing the input field that is identified as being editable before the ability to save changes is granted). Some users may click the edit icon itself thinking it toggles the ability to edit the input field, whilst others may just recognise that the edit icon means the input field is editable. In either case just having the edit icon should suffice as being the initial "call to action" for a user wishing to edit the input field, and since the Reset and Save buttons illuminate when the account name is modified, they'll recognise that a further step is required to save their changes.
Screenshot of text field now with edit icon is shown below:
![screen shot 2018-06-09 at 7 27 53 pm](https://user-images.githubusercontent.com/6226175/41198334-1b4695d0-6c78-11e8-9bf5-54e168580a8a.png)
