### PR TITLE
fix: Fixes #98 by running existing Node.js CLI script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "demo:rx": "webpack-serve --config packages/ui-react-rx/webpack.config.js --content packages/ui-react-rx --port 3000",
     "demo:ui": "webpack-serve --config packages/ui-react/webpack.config.js --content packages/ui-react --port 3000",
     "deploy:ghpages": "gh-pages -d packages/apps/build",
-    "postinstall": "polkadot-dev-yarn-only",
+    "postinstall": "./node_modules/@polkadot/dev/scripts/polkadot-dev-yarn-only.js",
     "vanitygen": "polkadot-dev-build-babel && node packages/app-vanitygen/build/generator/cli.js",
     "start": "cd packages/apps && webpack-serve --config webpack.config.js --port 3000",
     "test": "jest --coverage"


### PR DESCRIPTION
With the existing approach it is expecting to call a binary file in node_modules/.bin/polkadot-dev-yarn-only that is associated with a shell script would be in node_modules/dev/scripts/polkadot-dev-yarn-only.sh. This PR simply calls the Node.js CLI script directly