### PR TITLE
fix: Fixes Issue #144. Balance to submit with transaction changed to string

### DIFF
--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -25,6 +25,7 @@ type Props = BareProps & {
   label?: any, // node?
   max?: any,
   min?: any,
+  maxLength?: number,
   name?: string,
   onChange: (value: string) => void,
   placeholder?: string,
@@ -49,7 +50,7 @@ export default class Input extends React.PureComponent<Props, State> {
   };
 
   render () {
-    const { children, className, defaultValue, icon, isEditable = false, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, min, name, placeholder, style, type = 'text', value, withLabel } = this.props;
+    const { children, className, defaultValue, icon, isEditable = false, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, min, maxLength, name, placeholder, style, type = 'text', value, withLabel } = this.props;
 
     return (
       <Labelled
@@ -73,6 +74,7 @@ export default class Input extends React.PureComponent<Props, State> {
           hidden={isHidden}
           max={max}
           min={min}
+          maxLength={maxLength}
           name={name || this.state.name}
           onChange={this.onChange}
           placeholder={placeholder}

--- a/packages/ui-app/src/Params/Param/Balance.tsx
+++ b/packages/ui-app/src/Params/Param/Balance.tsx
@@ -4,14 +4,18 @@
 
 import { Props } from '../types';
 
+import isValidBalance from '../../util/isValidBalance';
+
+import BN from 'bn.js';
 import React from 'react';
 
 import Input from '../../Input';
 import Bare from './Bare';
 
-export default class StringBalance extends React.PureComponent<Props> {
+export default class Balance extends React.PureComponent<Props> {
   render () {
-    const { className, isDisabled, isError, label, style, withLabel } = this.props;
+    const { className, defaultValue: { value }, isDisabled, isError, label, style, withLabel } = this.props;
+    const defaultValue = String(new BN(String(value) || 0));
 
     return (
       <Bare
@@ -20,11 +24,12 @@ export default class StringBalance extends React.PureComponent<Props> {
       >
         <Input
           className='large'
+          defaultValue={defaultValue || String(0)}
           isDisabled={isDisabled}
           isError={isError}
           label={label}
           onChange={this.onChange}
-          placeholder='<any number between [0.000000000000001] and [available balance minus 1])>'
+          placeholder='<any number between 1 testnet DOT and the available testnet DOT balance minus 1>'
           type='text'
           withLabel={withLabel}
         />
@@ -35,11 +40,11 @@ export default class StringBalance extends React.PureComponent<Props> {
   onChange = (value: string): void => {
     const { onChange } = this.props;
 
-    const isValid = value.length !== 0;
+    const isValid = isValidBalance(value.trim());
 
     onChange({
       isValid,
-      value
+      value: String(new BN(String(value.trim()) || '0'))
     });
   }
 }

--- a/packages/ui-app/src/Params/Param/Balance.tsx
+++ b/packages/ui-app/src/Params/Param/Balance.tsx
@@ -2,7 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-import { Props } from '../types';
+import { Props as BareProps } from '../types';
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-react-rx/types';
 
 import isValidBalance from '../../util/isValidBalance';
 
@@ -12,9 +14,15 @@ import React from 'react';
 import Input from '../../Input';
 import Bare from './Bare';
 
-export default class Balance extends React.PureComponent<Props> {
+import withApi from '@polkadot/ui-react-rx/with/api';
+
+import translate from '../../translate';
+
+type Props = I18nProps & ApiProps & BareProps;
+
+class Balance extends React.PureComponent<Props> {
   render () {
-    const { className, defaultValue: { value }, isDisabled, isError, label, style, withLabel } = this.props;
+    const { apiSupport, className, defaultValue: { value }, isDisabled, isError, label, style, withLabel } = this.props;
     const defaultValue = String(new BN(String(value) || 0));
 
     return (
@@ -28,6 +36,7 @@ export default class Balance extends React.PureComponent<Props> {
           isDisabled={isDisabled}
           isError={isError}
           label={label}
+          maxLength={apiSupport === 'poc-1' ? 19 : 38}
           onChange={this.onChange}
           placeholder='<any number between 1 testnet DOT and the available testnet DOT balance minus 1>'
           type='text'
@@ -38,13 +47,15 @@ export default class Balance extends React.PureComponent<Props> {
   }
 
   onChange = (value: string): void => {
-    const { onChange } = this.props;
+    const { onChange, apiSupport } = this.props;
 
-    const isValid = isValidBalance(value.trim());
+    const isValid = isValidBalance(value.trim(), apiSupport);
 
     onChange({
       isValid,
-      value: String(new BN(String(value.trim()) || '0'))
+      value: new BN(String(value.trim()) || '0')
     });
   }
 }
+
+export default withApi(translate(Balance));

--- a/packages/ui-app/src/Params/Param/StringBalance.tsx
+++ b/packages/ui-app/src/Params/Param/StringBalance.tsx
@@ -1,0 +1,45 @@
+// Copyright 2017-2018 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { Props } from '../types';
+
+import React from 'react';
+
+import Input from '../../Input';
+import Bare from './Bare';
+
+export default class StringBalance extends React.PureComponent<Props> {
+  render () {
+    const { className, isDisabled, isError, label, style, withLabel } = this.props;
+
+    return (
+      <Bare
+        className={className}
+        style={style}
+      >
+        <Input
+          className='large'
+          isDisabled={isDisabled}
+          isError={isError}
+          label={label}
+          onChange={this.onChange}
+          placeholder='<any number between [0.000000000000001] and [available balance minus 1])>'
+          type='text'
+          withLabel={withLabel}
+        />
+      </Bare>
+    );
+  }
+
+  onChange = (value: string): void => {
+    const { onChange } = this.props;
+
+    const isValid = value.length !== 0;
+
+    onChange({
+      isValid,
+      value
+    });
+  }
+}

--- a/packages/ui-app/src/Params/Param/findComponent.ts
+++ b/packages/ui-app/src/Params/Param/findComponent.ts
@@ -14,12 +14,13 @@ import Hash from './Hash';
 import KeyValue from './KeyValue';
 import KeyValueStorageArray from './KeyValueStorageArray';
 import StringParam from './String';
+import StringBalance from './StringBalance';
 import Unknown from './Unknown';
 import VoteThreshold from './VoteThreshold';
 
 const components: ComponentMap = {
   'AccountId': Account,
-  'Balance': Amount,
+  'Balance': StringBalance,
   'BlockNumber': Amount,
   'bool': Bool,
   'Bytes': Bytes,

--- a/packages/ui-app/src/Params/Param/findComponent.ts
+++ b/packages/ui-app/src/Params/Param/findComponent.ts
@@ -14,13 +14,13 @@ import Hash from './Hash';
 import KeyValue from './KeyValue';
 import KeyValueStorageArray from './KeyValueStorageArray';
 import StringParam from './String';
-import StringBalance from './StringBalance';
+import Balance from './Balance';
 import Unknown from './Unknown';
 import VoteThreshold from './VoteThreshold';
 
 const components: ComponentMap = {
   'AccountId': Account,
-  'Balance': StringBalance,
+  'Balance': Balance,
   'BlockNumber': Amount,
   'bool': Bool,
   'Bytes': Bytes,

--- a/packages/ui-app/src/util/isValidBalance.spec.js
+++ b/packages/ui-app/src/util/isValidBalance.spec.js
@@ -7,19 +7,47 @@ import isValidBalance from './isValidBalance';
 describe('checks extrinsic balance', () => {
   it('detects invalid balance for balance with non-positive integers or whitespace', () => {
     const invalidBalance = ' f403% 9';
+    const chain = 'latest';
 
-    expect(isValidBalance(invalidBalance)).toEqual(false);
+    expect(isValidBalance(invalidBalance, chain)).toEqual(false);
   });
 
   it('detects invalid balance for input with no length', () => {
     const invalidBalance = '';
+    const chain = 'latest';
 
-    expect(isValidBalance(invalidBalance)).toEqual(false);
+    expect(isValidBalance(invalidBalance, chain)).toEqual(false);
+  });
+  it('detects invalid balance for balance with positive integers with spaces between', () => {
+    const invalidBalance = ' 05 9 ';
+    const chain = 'latest';
+
+    expect(isValidBalance(invalidBalance, chain)).toEqual(false);
   });
 
-  it('detects valid balance for balance with positive integers even with whitespace', () => {
-    const validBalance = ' 05 9 ';
+  it('detects valid balance for balance with positive integers', () => {
+    const validBalance = ' 059 ';
+    const chain = 'latest';
 
-    expect(isValidBalance(validBalance)).toEqual(true);
+    expect(isValidBalance(validBalance, chain)).toEqual(true);
+  });
+
+  // max balance size for different chains are specified in @polkadot/params/sizes.ts
+  it('detects valid balance is positive integers less than 128 bits maximum for latest chain', () => {
+    const chainLatest = 'latest';
+    const maxValidBalance128Bit = '340282366920938463463374607431768211455'; // 2^128 − 1
+    const invalidBalance = '340282366920938463463374607431768211456'; // 2^128
+
+    expect(isValidBalance(maxValidBalance128Bit, chainLatest)).toEqual(true);
+    expect(isValidBalance(invalidBalance, chainLatest)).toEqual(false);
+  });
+
+  it('detects valid balance is positive integers less than 64 bits maximum for poc-1 chain', () => {
+    const chainPoC1 = 'poc-1';
+    const maxValidBalance64Bit = '18446744073709551615'; // 2^64 − 1
+    const invalidBalance = '18446744073709551616'; // 2^64
+
+    expect(isValidBalance(maxValidBalance64Bit, chainPoC1)).toEqual(true);
+    expect(isValidBalance(invalidBalance, chainPoC1)).toEqual(false);
   });
 });

--- a/packages/ui-app/src/util/isValidBalance.spec.js
+++ b/packages/ui-app/src/util/isValidBalance.spec.js
@@ -1,0 +1,25 @@
+// Copyright 2017-2018 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import isValidBalance from './isValidBalance';
+
+describe('checks extrinsic balance', () => {
+  it('detects invalid balance for balance with non-positive integers or whitespace', () => {
+    const invalidBalance = ' f403% 9';
+
+    expect(isValidBalance(invalidBalance)).toEqual(false);
+  });
+
+  it('detects invalid balance for input with no length', () => {
+    const invalidBalance = '';
+
+    expect(isValidBalance(invalidBalance)).toEqual(false);
+  });
+
+  it('detects valid balance for balance with positive integers even with whitespace', () => {
+    const validBalance = ' 05 9 ';
+
+    expect(isValidBalance(validBalance)).toEqual(true);
+  });
+});

--- a/packages/ui-app/src/util/isValidBalance.ts
+++ b/packages/ui-app/src/util/isValidBalance.ts
@@ -2,9 +2,33 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-// RegEx Pattern: http://regexlib.com/REDetails.aspx?regexp_id=330
-const re = RegExp('^[0-9 ]+[0-9 ]*$');
+import BN from 'bn.js';
+import sizes from '@polkadot/params/sizes';
+import { EncodingVersions } from '@polkadot/params/types';
 
-export default function isValidBalance (input: string): boolean {
-  return input.trim().length !== 0 && re.test(input.trim());
+// RegEx Pattern (positive int): http://regexlib.com/REDetails.aspx?regexp_id=330
+const re = RegExp('^[0-9]+[0-9]*$');
+
+export default function isValidBalance (input: string, chain: string): boolean {
+  // apiSupport.chain is either 'poc-1' (64 bit) or 'latest' (128 bit)
+  const balanceSize: any = sizes.Balance.get(chain as EncodingVersions) || 64;
+  const max64Bit = 18446744073709551615;
+  const max128Bit = 340282366920938463463374607431768211455;
+  const maxBN64Bit = new BN(String(max64Bit));
+  const maxBN128Bit = new BN(String(max128Bit));
+  const inputBN = new BN(String(input));
+
+  if (input.trim().length === 0 || !re.test(input.trim())) {
+    return false;
+  }
+
+  if (chain === 'poc-1' && balanceSize === 64) { // && maxBN64Bit.gte(inputBN)
+    return true;
+  }
+
+  if (chain === 'latest' && balanceSize === 128) { // && maxBN128Bit.gte(inputBN)
+    return true;
+  }
+
+  return false;
 }

--- a/packages/ui-app/src/util/isValidBalance.ts
+++ b/packages/ui-app/src/util/isValidBalance.ts
@@ -1,0 +1,10 @@
+// Copyright 2017-2018 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+// RegEx Pattern: http://regexlib.com/REDetails.aspx?regexp_id=330
+const re = RegExp('^[0-9 ]+[0-9 ]*$');
+
+export default function isValidBalance (input: string): boolean {
+  return input.trim().length !== 0 && re.test(input.trim());
+}


### PR DESCRIPTION
- Placeholder indicates acceptable range of values to user in the interim until form validation incorporated.
- Max value must be the balance of the account minus one, otherwise the Polkadot Node will give error `Runtime: proposer's balance too low`.
- Min value must be above 0.000000000000001, otherwise the Polkadot Node will give error `Runtime: proposer's balance too low`

![screen shot 2018-07-12 at 9 53 03 pm](https://user-images.githubusercontent.com/6226175/42658835-cb7bcd90-8626-11e8-8723-4d3d0eb114c5.png)
