### PR TITLE
WIP: Fixes #116 Show Storage query response with AccountId key in table

### DIFF
--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -41,10 +41,13 @@ class Query extends React.PureComponent<Props, State> {
         value as Storage$Key$Value
       );
 
+      const lineHeight = key.type[0] === 'AccountId' ? '2em' : '1em';
+
       cache[id] = withStorageDiv(key, { params: values })(
-        (value: any) =>
-          valueToText(key.type, value),
-        { className: 'ui--output' }
+        (value: any) => {
+          return valueToText(key.type, value);
+        },
+        { className: 'ui--output', style: { lineHeight: lineHeight } }
       );
     }
 

--- a/packages/ui-app/src/Params/accountId.tsx
+++ b/packages/ui-app/src/Params/accountId.tsx
@@ -1,0 +1,19 @@
+// Copyright 2017-2018 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import React from 'react';
+
+import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
+
+const AccountId: React.ComponentType<any> = (
+  (accountId: string): any => {
+    return (
+      <div>
+        <span><IdentityIcon size={24} value={accountId} />{accountId}</span>
+      </div>
+    );
+  }
+);
+
+export default AccountId;

--- a/packages/ui-app/src/Params/valueToText.ts
+++ b/packages/ui-app/src/Params/valueToText.ts
@@ -12,6 +12,7 @@ import isU8a from '@polkadot/util/is/u8a';
 import isUndefined from '@polkadot/util/is/undefined';
 
 import { textMap as thresholdTextMap } from './Param/VoteThreshold';
+import AccountId from './accountId';
 
 function proposalToText ({ extrinsic, params }: ExtrinsicDecoded): string {
   if (!extrinsic) {
@@ -25,7 +26,7 @@ function proposalToText ({ extrinsic, params }: ExtrinsicDecoded): string {
   return `${extrinsic.section}.${extrinsic.name}(${inputs})`;
 }
 
-function arrayToText (type: Param$Type$Array, value: Array<any>, withBound: boolean = true): string {
+function arrayToText (type: Param$Type$Array, value: Array<any>, withBound: boolean = true): any {
   if (value.length === 0) {
     return 'empty';
   }
@@ -33,6 +34,12 @@ function arrayToText (type: Param$Type$Array, value: Array<any>, withBound: bool
   if (type.length === 1) {
     if (type[0] === 'KeyValueStorage') {
       return `${value.length}`;
+    }
+
+    if (type[0] === 'AccountId') {
+      return value.map((value) => valueToText(type, value, false)).map((value) =>
+        <AccountId value={value} />
+      );
     }
 
     return value.map((value) =>
@@ -47,7 +54,7 @@ function arrayToText (type: Param$Type$Array, value: Array<any>, withBound: bool
   return `(${values})`;
 }
 
-function valueToText (type: Param$Types, value: any, swallowError: boolean = true): string {
+function valueToText (type: Param$Types, value: any, swallowError: boolean = true): any {
   try {
     if (type === 'bool') {
       return value ? 'Yes' : 'No';


### PR DESCRIPTION
Screenshot with changes shown:

![screen shot 2018-07-24 at 1 14 40 pm](https://user-images.githubusercontent.com/6226175/43137444-395feca0-8f4c-11e8-9f2e-459851a4d21d.png)

**Review Comments** (transferred over from https://github.com/polkadot-js/apps/pull/158)
* [ ] - Single values vs. Arrays. Work with the base formatter as indicated in the comments.
* [ ] - The  idea is right (associated with changes that were made in packages/app-storage/src/Query.tsx) - however, we should actually be extending https://github.com/polkadot-js/apps/blob/master/packages/ui-app/src/Params/valueToText.ts to return React.Node (or text, text just being a subset of Node)
* [ ] - This is not correct (in relation to logic like `if (key.type[0] === 'AccountId') {` being performed in packages/app-storage/src/Query.tsx), it only works for the specific instance and not for eg. Referendums where AccountId is not in that position. As per above, it needs to be on a single value (so each account, dfoesn't matter where gets rendered)
In some cases where we have tuples with AccountId first, we will now not display all info.
Correct place is here https://github.com/polkadot-js/apps/blob/master/packages/ui-app/src/Params/valueToText.ts#L64
* [ ] - When displaying (since we should not be using tables, rather render the single values - see other comments), in relation to changes that were made in packages/app-storage/src/Query.tsx, no need to have a header for Icon. (throw-away comment here since the implementation needs some work)
* [ ] - This should not be in here (in relation to `const accountIds: Array<string> = valueToText(key.type, value).split(', ');  ... if (key.type[0] === 'AccountId')` in packages/app-storage/src/Query.tsx) - the generic valueToText should just render this. There should be no specific rendering in here to do with types at all.
The above check would only work in some specific instances.
Basically - valueToText should now return a React.Node with AccountId rendering, pass pack a div/span with the icon & value. This https://github.com/polkadot-js/apps/blob/master/packages/ui-app/src/Params/valueToText.ts#L64 should be the only place where we actually check for the type, nowhere else.