### PR TITLE
fix: Fixes #163 Concat index before value for queries with array response

### DIFF
--- a/packages/ui-app/src/Params/valueToText.ts
+++ b/packages/ui-app/src/Params/valueToText.ts
@@ -35,8 +35,8 @@ function arrayToText (type: Param$Type$Array, value: Array<any>, withBound: bool
       return `${value.length}`;
     }
 
-    return value.map((value) =>
-      valueToText(type[0], value, false)
+    return value.map((value, index) =>
+      `${index}: ${valueToText(type[0], value, false)}`
     ).join(', ');
   }
 


### PR DESCRIPTION
Applies to queries that are made to storage @polkadot/storage/ such as staking.ts and session.ts that have type ['AccountId'].