### PR TITLE
Convert u8a pk to address for IdentityIcon

### DIFF
--- a/packages/ui-react/src/IdentityIcon/index.tsx
+++ b/packages/ui-react/src/IdentityIcon/index.tsx
@@ -26,7 +26,7 @@ const DEFAULT_SIZE = 64;
 export default class IdentityIcon extends React.PureComponent<Props, State> {
   state: State = {} as State;
 
-  static getDerivedStateFromProps ({ value, size }: Props, prevState: State): State | null {
+  static getDerivedStateFromProps ({ value }: Props, prevState: State): State | null {
     const address = isU8a(value) || isHex(value)
       ? encodeAddress(value)
       : value;

--- a/packages/ui-react/src/IdentityIcon/index.tsx
+++ b/packages/ui-react/src/IdentityIcon/index.tsx
@@ -8,39 +8,56 @@ import './IdentityIcon.css';
 
 import React from 'react';
 import identicon from '@polkadot/ui-identicon/index';
+import encodeAddress from '@polkadot/util-keyring/address/encode';
+import isHex from '@polkadot/util/is/hex';
+import isU8a from '@polkadot/util/is/u8a';
 
 type Props = BaseProps & {
   size?: number,
   value: string | Uint8Array
 };
 
+type State = {
+  address: string
+};
+
 const DEFAULT_SIZE = 64;
 
-export default class IdentityIcon extends React.PureComponent<Props> {
+export default class IdentityIcon extends React.PureComponent<Props, State> {
+  state: State = {} as State;
+
+  static getDerivedStateFromProps ({ value, size }: Props, prevState: State): State | null {
+    const address = isU8a(value) || isHex(value)
+      ? encodeAddress(value)
+      : value;
+
+    return address === prevState.address
+      ? null
+      : { address };
+  }
+
   render () {
-    const { className, style } = this.props;
+    const { className, style, value, size } = this.props;
+    const { address } = this.state;
 
     return (
       <div
         className={['ui--IdentityIcon', className].join(' ')}
+        key={address}
         ref={this.appendIcon}
         style={style}
       />
     );
   }
 
-  appendIcon = (node: Element | null): void => {
-    const { size = DEFAULT_SIZE, value } = this.props;
+  private appendIcon = (node: Element | null): void => {
+    const { size = DEFAULT_SIZE } = this.props;
+    const { address } = this.state;
 
-    // https://stackoverflow.com/a/22966637
-    if (node && node.parentNode) {
-      const cloned = node.cloneNode(false);
-
-      cloned.appendChild(
-        identicon(value, size)
+    if (node) {
+      node.appendChild(
+        identicon(address, size)
       );
-
-      node.parentNode.replaceChild(cloned, node);
     }
   }
 }

--- a/packages/ui-react/src/IdentityIcon/index.tsx
+++ b/packages/ui-react/src/IdentityIcon/index.tsx
@@ -37,7 +37,7 @@ export default class IdentityIcon extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { className, style, value, size } = this.props;
+    const { className, style } = this.props;
     const { address } = this.state;
 
     return (


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/195 - Account switch not updating icon
- Closes https://github.com/polkadot-js/apps/issues/193 - IdentityIcon can take ss58, hex & u8a (last 2 publicKey formats) inputs