### PR TITLE
Adjust header styling (font-weight)

### DIFF
--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -19,6 +19,6 @@ body {
 
 h1 {
   color: rgba(0, 0, 0, .6);
-  font-weight: 400;
+  font-weight: 100;
   text-transform: lowercase;
 }

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -152,6 +152,7 @@
 
 .ui--CardSummary-large {
   font-size: 3rem;
+  font-weight: 100;
   line-height: 3rem;
   text-align: right;
 }


### PR DESCRIPTION
Now -

<img width="345" alt="polkadot apps portal 2018-08-15 10-51-45" src="https://user-images.githubusercontent.com/1424473/44140092-62c8865e-a079-11e8-8152-d50976836742.png">

Previously -

<img width="352" alt="polkadot apps portal 2018-08-15 10-51-33" src="https://user-images.githubusercontent.com/1424473/44140105-68b4db3a-a079-11e8-9237-0b08ce06f670.png">
