### PR TITLE
Fix encoding to allow both poc-1 & poc-2 blocks

### DIFF
--- a/packages/app-democracy/package.json
+++ b/packages/app-democracy/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/storage": "^0.28.17",
+    "@polkadot/storage": "^0.28.18",
     "@polkadot/ui-react": "^0.19.37",
     "@polkadot/ui-react-rx": "^0.19.37",
     "@polkadot/util-keyring": "^0.28.3"

--- a/packages/app-example/package.json
+++ b/packages/app-example/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/storage": "^0.28.17",
+    "@polkadot/storage": "^0.28.18",
     "@polkadot/ui-react": "^0.19.37",
     "@polkadot/ui-react-rx": "^0.19.37",
     "@polkadot/util-keyring": "^0.28.3"

--- a/packages/app-explorer/package.json
+++ b/packages/app-explorer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/primitives": "^0.28.17",
+    "@polkadot/primitives": "^0.28.18",
     "@polkadot/ui-app": "^0.19.37",
     "@polkadot/util-crypto": "^0.28.3"
   }

--- a/packages/app-explorer/src/BlockByHash/BlockByHash.tsx
+++ b/packages/app-explorer/src/BlockByHash/BlockByHash.tsx
@@ -72,7 +72,7 @@ class BlockByHash extends React.PureComponent<Props> {
           defaultValue: 'extrinsics'
         })}</h1>
         <div className='explorer--BlockByHash-flexable'>
-          {extrinsics.map((extrinsic: any, index: number) => (
+          {extrinsics.map((extrinsic, index) => (
             <div
               className='explorer--BlockByHash-extrinsic'
               key={`${value}:extrinsic:${index}`}
@@ -90,9 +90,9 @@ class BlockByHash extends React.PureComponent<Props> {
                       ? extrinsic.address
                       : <AddressMini value={extrinsic.address} />
                     }</div>
-                    <div className='explorer--BlockByHash-accountIndex'>{t('block.nonce', {
+                    <div className='explorer--BlockByHash-accountIndex'>{t('block.accountIndex', {
                       defaultValue: 'index'
-                    })} {numberFormat(extrinsic.nonce)}</div>
+                    })} {numberFormat(extrinsic.accountIndex)}</div>
                   </div>
                 </div>
                 <Extrinsic value={extrinsic} />

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -39,9 +39,6 @@ class BlockHeader extends React.PureComponent<Props> {
     const { extrinsicsRoot, number, parentHash, stateRoot } = value;
     const hashHex = u8aToHex(hash);
     const parentHex = u8aToHex(parentHash);
-    const linkable = withLink
-      ? <Link to={`/explorer/hash/${hashHex}`}>{hashHex}</Link>
-      : hashHex;
 
     return (
       <div
@@ -52,30 +49,28 @@ class BlockHeader extends React.PureComponent<Props> {
           <div>{numberFormat(number)}</div>
         </div>
         <div className='details'>
-          <div className='hash'>
-            {linkable}
-          </div>
+          <div className='hash'>{
+            withLink
+              ? <Link to={`/explorer/hash/${hashHex}`}>{hashHex}</Link>
+              : hashHex
+          }</div>
           <table className='contains'>
             <tbody>
               <tr>
                 <td className='type'>parentHash</td>
-                <td className='hash'>
-                  <Link to={`/explorer/hash/${parentHex}`}>
-                    {parentHex}
-                  </Link>
-                </td>
+                <td className='hash'>{
+                  number.gtn(1)
+                    ? <Link to={`/explorer/hash/${parentHex}`}>{parentHex}</Link>
+                    : parentHex
+                }</td>
               </tr>
               <tr>
                 <td className='type'>extrinsicsRoot</td>
-                <td className='hash'>
-                  {u8aToHex(extrinsicsRoot)}
-                </td>
+                <td className='hash'>{u8aToHex(extrinsicsRoot)}</td>
               </tr>
               <tr>
                 <td className='type'>stateRoot</td>
-                <td className='hash'>
-                  {u8aToHex(stateRoot)}
-                </td>
+                <td className='hash'>{u8aToHex(stateRoot)}</td>
               </tr>
               {withExtrinsics
                 ? <Extrinsics hash={hash} />

--- a/packages/app-explorer/src/index.css
+++ b/packages/app-explorer/src/index.css
@@ -68,6 +68,7 @@
 
 .explorer--BlockByHash-justification-signature span {
   color: rgba(0, 0, 0, 0.6);
+  font-family: monospace;
   font-style: italic;
   padding-left: 0.5rem;
 }

--- a/packages/app-extrinsics/package.json
+++ b/packages/app-extrinsics/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.17",
+    "@polkadot/extrinsics": "^0.28.18",
     "@polkadot/ui-app": "^0.19.37",
     "@polkadot/ui-signer": "^0.19.37",
     "react-dropzone": "^4.3.0"

--- a/packages/app-staking/package.json
+++ b/packages/app-staking/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
     "@polkadot/app-extrinsics": "^0.19.37",
-    "@polkadot/storage": "^0.28.17",
+    "@polkadot/storage": "^0.28.18",
     "@polkadot/ui-app": "^0.19.37",
     "@polkadot/ui-keyring": "^0.19.37",
     "@polkadot/ui-react": "^0.19.37",

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.17",
-    "@polkadot/storage": "^0.28.17",
+    "@polkadot/extrinsics": "^0.28.18",
+    "@polkadot/storage": "^0.28.18",
     "@polkadot/ui-keyring": "^0.19.37",
     "@polkadot/ui-react": "^0.19.37",
     "@polkadot/ui-react-rx": "^0.19.37",

--- a/packages/ui-app/src/AddressMini.tsx
+++ b/packages/ui-app/src/AddressMini.tsx
@@ -39,7 +39,7 @@ export default class AddressMini extends React.PureComponent<Props> {
             size={24}
             value={value}
           />
-          <div>{isShort ? toShortAddress(value) : value}</div>
+          <div className='ui--AddressMini-address'>{isShort ? toShortAddress(value) : value}</div>
           {children}
         </div>
         {this.renderBalance()}

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -46,6 +46,10 @@
   vertical-align: middle;
 }
 
+.ui--AddressMini-address {
+  font-family: monospace;
+}
+
 .ui--AddressMini .ui--IdentityIcon {
   margin-left: 1rem;
   margin-right: 0.5rem;

--- a/packages/ui-react-rx/package.json
+++ b/packages/ui-react-rx/package.json
@@ -31,9 +31,9 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-react-rx#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/api-rx": "^0.28.17",
-    "@polkadot/extrinsics": "^0.28.17",
-    "@polkadot/storage": "^0.28.17",
+    "@polkadot/api-rx": "^0.28.18",
+    "@polkadot/extrinsics": "^0.28.18",
+    "@polkadot/storage": "^0.28.18",
     "rxjs-compat": "^6.2.2"
   },
   "devDependencies": {

--- a/packages/ui-signer/package.json
+++ b/packages/ui-signer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.17",
+    "@polkadot/extrinsics": "^0.28.18",
     "@polkadot/ui-app": "^0.19.37",
     "@polkadot/ui-keyring": "^0.19.37"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,22 +1291,22 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
-"@polkadot/api-format@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-format/-/api-format-0.28.17.tgz#b7fe73bf6e984842a1c419e93b30745108138b84"
+"@polkadot/api-format@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-format/-/api-format-0.28.18.tgz#4b09cd99a359edae2afebefc0f941526efb73272"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/jsonrpc" "^0.28.17"
-    "@polkadot/primitives" "^0.28.17"
+    "@polkadot/jsonrpc" "^0.28.18"
+    "@polkadot/primitives" "^0.28.18"
     "@polkadot/util" "^0.28.3"
     "@polkadot/util-keyring" "^0.28.3"
 
-"@polkadot/api-provider@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-provider/-/api-provider-0.28.17.tgz#8b178db819588e6a49568d1904b4cf1de309415b"
+"@polkadot/api-provider@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-provider/-/api-provider-0.28.18.tgz#5f6cb7f410aac94dee22958dc75e00da001da6c1"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/storage" "^0.28.17"
+    "@polkadot/storage" "^0.28.18"
     "@polkadot/util" "^0.28.3"
     "@polkadot/util-crypto" "^0.28.3"
     "@polkadot/util-keyring" "^0.28.3"
@@ -1315,25 +1315,25 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.25"
 
-"@polkadot/api-rx@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-rx/-/api-rx-0.28.17.tgz#6a42cca37df8bda5fdf8268a1cc3134b24f22eee"
+"@polkadot/api-rx@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-rx/-/api-rx-0.28.18.tgz#2817714eec45e08ccd1a7bc247b14206723bfda3"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/api" "^0.28.17"
-    "@polkadot/api-provider" "^0.28.17"
+    "@polkadot/api" "^0.28.18"
+    "@polkadot/api-provider" "^0.28.18"
     "@types/rx" "^4.1.1"
     rxjs "^6.2.2"
 
-"@polkadot/api@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.28.17.tgz#44184dfb62ab82463effac777968cbbbda0270f3"
+"@polkadot/api@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.28.18.tgz#4d3f18d4b8d34acef2672994ade62bce7d08faa9"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/api-format" "^0.28.17"
-    "@polkadot/api-provider" "^0.28.17"
-    "@polkadot/jsonrpc" "^0.28.17"
-    "@polkadot/params" "^0.28.17"
+    "@polkadot/api-format" "^0.28.18"
+    "@polkadot/api-provider" "^0.28.18"
+    "@polkadot/jsonrpc" "^0.28.18"
+    "@polkadot/params" "^0.28.18"
     "@polkadot/util" "^0.28.3"
 
 "@polkadot/dev-react@^0.20.16":
@@ -1401,48 +1401,48 @@
     typedoc "^0.11.1"
     typescript "^3.0.1"
 
-"@polkadot/extrinsics@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.28.17.tgz#d66777e6dbeb38dcad204aa29f2d75d0b6fa5682"
+"@polkadot/extrinsics@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.28.18.tgz#80e682e5ddfb9c148f37d7f41a5814c7392db5a0"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/params" "^0.28.17"
-    "@polkadot/primitives" "^0.28.17"
+    "@polkadot/params" "^0.28.18"
+    "@polkadot/primitives" "^0.28.18"
     "@polkadot/util" "^0.28.3"
 
-"@polkadot/jsonrpc@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.28.17.tgz#5f653e0de344c60ad6cac0a7f1420e900b265adc"
+"@polkadot/jsonrpc@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.28.18.tgz#bbebad1cc5fe175b0b722d612fe0fd19b30e0c8e"
   dependencies:
-    "@polkadot/params" "^0.28.17"
+    "@polkadot/params" "^0.28.18"
     babel-runtime "^6.26.0"
 
-"@polkadot/params@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/params/-/params-0.28.17.tgz#9eb493a8cff8961f977e1767edfb9a773fbc2221"
+"@polkadot/params@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/params/-/params-0.28.18.tgz#e4f98c9066f1064182c887c499928f1347718cf1"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/extrinsics" "^0.28.17"
-    "@polkadot/params" "^0.28.17"
-    "@polkadot/primitives" "^0.28.17"
+    "@polkadot/extrinsics" "^0.28.18"
+    "@polkadot/params" "^0.28.18"
+    "@polkadot/primitives" "^0.28.18"
     "@polkadot/util" "^0.28.3"
     "@polkadot/util-keyring" "^0.28.3"
 
-"@polkadot/primitives@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/primitives/-/primitives-0.28.17.tgz#4cd35c3a68990156dbb0490fa55c271aa44dfc79"
+"@polkadot/primitives@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/primitives/-/primitives-0.28.18.tgz#8b75c87ce4a662874829c353c85008f6ae52fedc"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
     "@polkadot/trie-hash" "^0.28.3"
     "@polkadot/util" "^0.28.3"
 
-"@polkadot/storage@^0.28.17":
-  version "0.28.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.28.17.tgz#3e00d7a22a0fdd8f117144c3dcaf115d6c4407f2"
+"@polkadot/storage@^0.28.18":
+  version "0.28.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.28.18.tgz#d536a054c00cc4bce7235dbfddc51495fd482e9e"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/params" "^0.28.17"
-    "@polkadot/primitives" "^0.28.17"
+    "@polkadot/params" "^0.28.18"
+    "@polkadot/primitives" "^0.28.18"
     "@polkadot/util" "^0.28.3"
     "@polkadot/util-crypto" "^0.28.3"
     "@polkadot/util-keyring" "^0.28.3"


### PR DESCRIPTION
- Updates dependencies to pull in https://github.com/polkadot-js/api/pull/138
- Closes https://github.com/polkadot-js/apps/issues/231
- Closes https://github.com/polkadot-js/apps/issues/232
- Addresses monospace alignment issue raised by @tomusdrw 

<img width="1255" alt="polkadot apps portal 2018-08-17 10-28-32" src="https://user-images.githubusercontent.com/1424473/44256235-ddd59400-a208-11e8-8026-2955d9f75ff1.png">

<img width="1262" alt="polkadot apps portal 2018-08-17 10-29-04" src="https://user-images.githubusercontent.com/1424473/44256242-e29a4800-a208-11e8-8f4a-3de00b5d7c81.png">

