### PR TITLE
Bring back chain_getBlock checks (disabling on explorer)

### DIFF
--- a/packages/app-democracy/package.json
+++ b/packages/app-democracy/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/storage": "^0.28.19",
+    "@polkadot/storage": "^0.28.20",
     "@polkadot/ui-react": "^0.19.45",
     "@polkadot/ui-react-rx": "^0.19.45",
     "@polkadot/util-keyring": "^0.28.4"

--- a/packages/app-example/package.json
+++ b/packages/app-example/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/storage": "^0.28.19",
+    "@polkadot/storage": "^0.28.20",
     "@polkadot/ui-react": "^0.19.45",
     "@polkadot/ui-react-rx": "^0.19.45",
     "@polkadot/util-keyring": "^0.28.4"

--- a/packages/app-explorer/package.json
+++ b/packages/app-explorer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/primitives": "^0.28.19",
+    "@polkadot/primitives": "^0.28.20",
     "@polkadot/ui-app": "^0.19.45",
     "@polkadot/util-crypto": "^0.28.4"
   }

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -3,7 +3,7 @@
 // of the ISC license. See the LICENSE file for details.
 
 import { Header } from '@polkadot/primitives/header';
-import { I18nProps } from '@polkadot/ui-app/types';
+import { BareProps } from '@polkadot/ui-app/types';
 import { ApiProps } from '@polkadot/ui-react-rx/types';
 
 import './BlockHeader.css';
@@ -16,13 +16,9 @@ import numberFormat from '@polkadot/ui-react-rx/util/numberFormat';
 import withApi from '@polkadot/ui-react-rx/with/api';
 import u8aToHex from '@polkadot/util/u8a/toHex';
 
-import translate from '../translate';
-
-// NOTE This add unneeded load, for now just on click-through
 import Extrinsics from './Extrinsics';
-// <Extrinsics hash={hash} />
 
-type Props = ApiProps & I18nProps & {
+type Props = ApiProps & BareProps & {
   value?: Header,
   withExtrinsics?: boolean,
   withLink?: boolean
@@ -87,4 +83,4 @@ class BlockHeader extends React.PureComponent<Props> {
   }
 }
 
-export default translate(withApi(BlockHeader));
+export default withApi(BlockHeader);

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -4,6 +4,7 @@
 
 import { Header } from '@polkadot/primitives/header';
 import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-react-rx/types';
 
 import './BlockHeader.css';
 
@@ -12,6 +13,7 @@ import { Link } from 'react-router-dom';
 import headerHash from '@polkadot/primitives/codec/header/hash';
 import classes from '@polkadot/ui-app/util/classes';
 import numberFormat from '@polkadot/ui-react-rx/util/numberFormat';
+import withApi from '@polkadot/ui-react-rx/with/api';
 import u8aToHex from '@polkadot/util/u8a/toHex';
 
 import translate from '../translate';
@@ -20,7 +22,7 @@ import translate from '../translate';
 import Extrinsics from './Extrinsics';
 // <Extrinsics hash={hash} />
 
-type Props = I18nProps & {
+type Props = ApiProps & I18nProps & {
   value?: Header,
   withExtrinsics?: boolean,
   withLink?: boolean
@@ -28,12 +30,13 @@ type Props = I18nProps & {
 
 class BlockHeader extends React.PureComponent<Props> {
   render () {
-    const { className, value, style, withExtrinsics = false, withLink = false } = this.props;
+    const { apiMethods, className, value, style, withExtrinsics = false, withLink = false } = this.props;
 
     if (!value) {
       return null;
     }
 
+    const isLinkable = !!apiMethods.chain_getBlock;
     const hash = headerHash(value);
     // tslint:disable-next-line:variable-name
     const { extrinsicsRoot, number, parentHash, stateRoot } = value;
@@ -50,7 +53,7 @@ class BlockHeader extends React.PureComponent<Props> {
         </div>
         <div className='details'>
           <div className='hash'>{
-            withLink
+            isLinkable && withLink
               ? <Link to={`/explorer/hash/${hashHex}`}>{hashHex}</Link>
               : hashHex
           }</div>
@@ -59,7 +62,7 @@ class BlockHeader extends React.PureComponent<Props> {
               <tr>
                 <td className='type'>parentHash</td>
                 <td className='hash'>{
-                  number.gtn(1)
+                  isLinkable && number.gtn(1)
                     ? <Link to={`/explorer/hash/${parentHex}`}>{parentHex}</Link>
                     : parentHex
                 }</td>
@@ -84,4 +87,4 @@ class BlockHeader extends React.PureComponent<Props> {
   }
 }
 
-export default translate(BlockHeader);
+export default translate(withApi(BlockHeader));

--- a/packages/app-explorer/src/Query.tsx
+++ b/packages/app-explorer/src/Query.tsx
@@ -3,16 +3,18 @@
 // of the ISC license. See the LICENSE file for details.
 
 import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-react-rx/types';
 
 import React from 'react';
 import Button from '@polkadot/ui-app/Button';
 import Input from '@polkadot/ui-app/Input';
 import Labelled from '@polkadot/ui-app/Labelled';
+import withApi from '@polkadot/ui-react-rx/with/api';
 import isHex from '@polkadot/util/is/hex';
 
 import translate from './translate';
 
-type Props = I18nProps & {};
+type Props = ApiProps & I18nProps & {};
 
 type State = {
   hash: string
@@ -26,8 +28,12 @@ class Query extends React.PureComponent<Props, State> {
   };
 
   render () {
-    const { t } = this.props;
+    const { apiMethods, t } = this.props;
     const { hash, isValid } = this.state;
+
+    if (!apiMethods.chain_getBlock) {
+      return null;
+    }
 
     return (
       <div className='explorer--Query'>
@@ -70,4 +76,4 @@ class Query extends React.PureComponent<Props, State> {
   }
 }
 
-export default translate(Query);
+export default translate(withApi(Query));

--- a/packages/app-extrinsics/package.json
+++ b/packages/app-extrinsics/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.19",
+    "@polkadot/extrinsics": "^0.28.20",
     "@polkadot/ui-app": "^0.19.45",
     "@polkadot/ui-signer": "^0.19.45"
   }

--- a/packages/app-staking/package.json
+++ b/packages/app-staking/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
     "@polkadot/app-extrinsics": "^0.19.45",
-    "@polkadot/storage": "^0.28.19",
+    "@polkadot/storage": "^0.28.20",
     "@polkadot/ui-app": "^0.19.45",
     "@polkadot/ui-keyring": "^0.19.45",
     "@polkadot/ui-react": "^0.19.45",

--- a/packages/apps/src/NodeInfo.tsx
+++ b/packages/apps/src/NodeInfo.tsx
@@ -2,20 +2,19 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-import { I18nProps } from '@polkadot/ui-app/types';
+import { BareProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 
 import isTestChain from '@polkadot/ui-react-rx/util/isTestChain';
 import classes from '@polkadot/ui-app/util/classes';
 import keyring from '@polkadot/ui-keyring/index';
+import BestNumber from '@polkadot/ui-react-rx/BestNumber';
 import Chain from '@polkadot/ui-react-rx/Chain';
 import NodeName from '@polkadot/ui-react-rx/NodeName';
 import NodeVersion from '@polkadot/ui-react-rx/NodeVersion';
 
-import translate from './translate';
-
-type Props = I18nProps & {};
+type Props = BareProps & {};
 
 const pkgJson = require('../package.json');
 
@@ -23,31 +22,22 @@ function updateTestInfo (chain?: string) {
   keyring.setDevMode(isTestChain(chain));
 }
 
-class NodeInfo extends React.PureComponent<Props> {
+export default class NodeInfo extends React.PureComponent<Props> {
   render () {
-    const { className, style, t } = this.props;
+    const { className, style } = this.props;
 
     return (
       <div className={classes('apps--NodeInfo', className)} style={style}>
-        <Chain
-          label={t('info.chain', {
-            defaultValue: 'chain: '
-          })}
-          rxChange={updateTestInfo}
-        />
-        <NodeName label={t('info.clientName', {
-          defaultValue: 'client: '
-        })}
-        />
-        <NodeVersion label={t('info.clientVersion', {
-          defaultValue: 'client version: '
-        })} />
-        <div>{t('info.uiVersion', {
-          defaultValue: 'ui version:'
-        })} {pkgJson.version}</div>
+        <div className='apps--NodeInfo-inline'>
+          <Chain rxChange={updateTestInfo} />&nbsp;
+          <BestNumber label='#' />
+        </div>
+        <div className='apps--NodeInfo-inline'>
+          <NodeName />&nbsp;
+          <NodeVersion label='v' />
+        </div>
+        <div>polkadot-js-ui&nbsp;v{pkgJson.version}</div>
       </div>
     );
   }
 }
-
-export default translate(NodeInfo);

--- a/packages/apps/src/SideBar/SideBar.css
+++ b/packages/apps/src/SideBar/SideBar.css
@@ -14,7 +14,7 @@
 
 .apps--SideBar .ui.vertical.menu {
   margin: 0;
-  width: 13em;
+  width: auto;
 }
 
 .apps--SideBar-github {
@@ -25,7 +25,7 @@
 
 .apps--SideBar-logo {
   width: 100%;
-  margin: 0 0 0.75rem 0.5rem;
+  margin: 0 1.5rem 0.75rem 0.75rem;
   width: 10rem;
 }
 

--- a/packages/apps/src/index.css
+++ b/packages/apps/src/index.css
@@ -19,8 +19,9 @@
 
 .apps--NodeInfo {
   background: transparent;
+  display: inline-block;
   font-size: 0.75rem;
-  padding-right: 1em;
+  padding: 0 0.75rem;
   opacity: 0.5;
   text-align: right;
 }

--- a/packages/apps/src/index.css
+++ b/packages/apps/src/index.css
@@ -19,13 +19,20 @@
 
 .apps--NodeInfo {
   background: transparent;
-  display: inline-block;
   font-size: 0.75rem;
-  padding: 0 0.75rem;
+  padding: 0 1.5rem 0 0;
   opacity: 0.5;
   text-align: right;
 }
 
-.apps--NodeInfo div {
+.apps--NodeInfo > div {
   margin-bottom: -0.125em;
+}
+
+.apps--NodeInfo-inline > div {
+  display: inline-block;
+}
+
+.apps--NodeInfo div.rx--updated {
+  background: inherit !important;
 }

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.19",
-    "@polkadot/storage": "^0.28.19",
+    "@polkadot/extrinsics": "^0.28.20",
+    "@polkadot/storage": "^0.28.20",
     "@polkadot/ui-keyring": "^0.19.45",
     "@polkadot/ui-react": "^0.19.45",
     "@polkadot/ui-react-rx": "^0.19.45",

--- a/packages/ui-react-rx/package.json
+++ b/packages/ui-react-rx/package.json
@@ -31,9 +31,9 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-react-rx#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/api-rx": "^0.28.19",
-    "@polkadot/extrinsics": "^0.28.19",
-    "@polkadot/storage": "^0.28.19",
+    "@polkadot/api-rx": "^0.28.20",
+    "@polkadot/extrinsics": "^0.28.20",
+    "@polkadot/storage": "^0.28.20",
     "rxjs-compat": "^6.2.2"
   },
   "devDependencies": {

--- a/packages/ui-react-rx/src/Api/index.tsx
+++ b/packages/ui-react-rx/src/Api/index.tsx
@@ -14,10 +14,10 @@ import shouldUseLatestChain from '@polkadot/ui-react-rx/util/shouldUseLatestChai
 import WsProvider from '@polkadot/api-provider/ws';
 import createApi from '@polkadot/api-rx';
 import defaults from '@polkadot/api-rx/defaults';
+import isUndefined from '@polkadot/util/is/undefined';
 
 import ApiObservable from '../ApiObservable';
 import ApiContext from './Context';
-import { isUndefined } from 'util';
 
 type Props = {
   api?: RxApiInterface,

--- a/packages/ui-signer/package.json
+++ b/packages/ui-signer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
-    "@polkadot/extrinsics": "^0.28.19",
+    "@polkadot/extrinsics": "^0.28.20",
     "@polkadot/ui-app": "^0.19.45",
     "@polkadot/ui-keyring": "^0.19.45"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,22 +1317,22 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
-"@polkadot/api-format@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-format/-/api-format-0.28.19.tgz#0da330b2b0f668e628e43a0b7d895b8bdaf3b810"
+"@polkadot/api-format@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-format/-/api-format-0.28.20.tgz#af9e75d1b2cbb557b41c5d079cf4552bc15f7ed1"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/jsonrpc" "^0.28.19"
-    "@polkadot/primitives" "^0.28.19"
+    "@polkadot/jsonrpc" "^0.28.20"
+    "@polkadot/primitives" "^0.28.20"
     "@polkadot/util" "^0.28.4"
     "@polkadot/util-keyring" "^0.28.4"
 
-"@polkadot/api-provider@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-provider/-/api-provider-0.28.19.tgz#e2576f3c23fe329e8c7c5299ec7c3c61724ab89e"
+"@polkadot/api-provider@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-provider/-/api-provider-0.28.20.tgz#a9107c378babf0da2afc7a30983c51c2bcf60f3a"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/storage" "^0.28.19"
+    "@polkadot/storage" "^0.28.20"
     "@polkadot/util" "^0.28.4"
     "@polkadot/util-crypto" "^0.28.4"
     "@polkadot/util-keyring" "^0.28.4"
@@ -1341,25 +1341,25 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.25"
 
-"@polkadot/api-rx@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-rx/-/api-rx-0.28.19.tgz#f92e4b30b8cd5a9cbd612c217da764f3baab41d0"
+"@polkadot/api-rx@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-rx/-/api-rx-0.28.20.tgz#4583cccdff2f4d8fa643cd99de1a00a522d36daf"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/api" "^0.28.19"
-    "@polkadot/api-provider" "^0.28.19"
+    "@polkadot/api" "^0.28.20"
+    "@polkadot/api-provider" "^0.28.20"
     "@types/rx" "^4.1.1"
     rxjs "^6.2.2"
 
-"@polkadot/api@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.28.19.tgz#3640d47aef137fdaf302f6ffb63df85ed9990763"
+"@polkadot/api@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.28.20.tgz#355bbf1baa5725b8af72dd4e62ef7902d3021aa3"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/api-format" "^0.28.19"
-    "@polkadot/api-provider" "^0.28.19"
-    "@polkadot/jsonrpc" "^0.28.19"
-    "@polkadot/params" "^0.28.19"
+    "@polkadot/api-format" "^0.28.20"
+    "@polkadot/api-provider" "^0.28.20"
+    "@polkadot/jsonrpc" "^0.28.20"
+    "@polkadot/params" "^0.28.20"
     "@polkadot/util" "^0.28.4"
 
 "@polkadot/dev-react@^0.20.17":
@@ -1428,48 +1428,48 @@
     typedoc-plugin-markdown "^1.1.13"
     typescript "^3.0.1"
 
-"@polkadot/extrinsics@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.28.19.tgz#8b7f2f2d852ef285ac535e82d332e16c6d3cd037"
+"@polkadot/extrinsics@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.28.20.tgz#2da946077f803a5a9f4b16dc08804ba05ecf2277"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/params" "^0.28.19"
-    "@polkadot/primitives" "^0.28.19"
+    "@polkadot/params" "^0.28.20"
+    "@polkadot/primitives" "^0.28.20"
     "@polkadot/util" "^0.28.4"
 
-"@polkadot/jsonrpc@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.28.19.tgz#9c5bdbef6700c4e1ceb3bddeaaa0c8ae87438560"
+"@polkadot/jsonrpc@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.28.20.tgz#08dcf9067a224e30989215da8739dfafc1ed0426"
   dependencies:
-    "@polkadot/params" "^0.28.19"
+    "@polkadot/params" "^0.28.20"
     babel-runtime "^6.26.0"
 
-"@polkadot/params@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/params/-/params-0.28.19.tgz#568bea36cc5423a3ee08ebfa2197118e624c72d7"
+"@polkadot/params@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/params/-/params-0.28.20.tgz#6d4dcbc39422a9bb7472bf796de7352180204196"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/extrinsics" "^0.28.19"
-    "@polkadot/params" "^0.28.19"
-    "@polkadot/primitives" "^0.28.19"
+    "@polkadot/extrinsics" "^0.28.20"
+    "@polkadot/params" "^0.28.20"
+    "@polkadot/primitives" "^0.28.20"
     "@polkadot/util" "^0.28.4"
     "@polkadot/util-keyring" "^0.28.4"
 
-"@polkadot/primitives@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/primitives/-/primitives-0.28.19.tgz#b4c068fdbb590a9da4cd0b3332f56686e61bbc29"
+"@polkadot/primitives@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/primitives/-/primitives-0.28.20.tgz#f6c84e2632b206e274d7a524f5a32c1a9fe4e19b"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
     "@polkadot/trie-hash" "^0.28.4"
     "@polkadot/util" "^0.28.4"
 
-"@polkadot/storage@^0.28.19":
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.28.19.tgz#7a601ec546bc86cc512962ed09762c1705428564"
+"@polkadot/storage@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.28.20.tgz#09cfdde02c09d5fba137f476cd15361342201064"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
-    "@polkadot/params" "^0.28.19"
-    "@polkadot/primitives" "^0.28.19"
+    "@polkadot/params" "^0.28.20"
+    "@polkadot/primitives" "^0.28.20"
     "@polkadot/util" "^0.28.4"
     "@polkadot/util-crypto" "^0.28.4"
     "@polkadot/util-keyring" "^0.28.4"


### PR DESCRIPTION
- Enable block explorer view links (and search) based on existence of chain_getBlock method
- Cleanup info (version, chain, best) display on SideBar
- Closes https://github.com/polkadot-js/apps/issues/246