### PR TITLE
Stretch SideBar to max height, relative i18next paths

### DIFF
--- a/packages/apps/src/index.css
+++ b/packages/apps/src/index.css
@@ -3,16 +3,16 @@
 /* of the ISC license. See the LICENSE file for details. */
 
 .apps--App {
+  align-items: stretch;
   box-sizing: border-box;
   display: flex;
-  height: 100%;
+  min-height: 100vh;
 }
 
 .apps--App .apps--Content,
 .apps--App .apps--SideBar, {
   display: flex;
   flex-direction: column;
-  height: 100%;
   flex-grow: 1;
   overflow-y: auto;
 }

--- a/packages/ui-app/src/i18n.ts
+++ b/packages/ui-app/src/i18n.ts
@@ -12,13 +12,16 @@ i18n
   .use(LanguageDetector)
   .use(reactI18nextModule)
   .init({
-    fallbackLng: 'en',
-    ns: ['ui'],
-    defaultNS: 'ui',
+    backend: {
+      loadPath: 'locales/{{lng}}/{{ns}}.json'
+    },
     debug: false,
+    defaultNS: 'ui',
+    fallbackLng: 'en',
     interpolation: {
       escapeValue: false
     },
+    ns: ['ui'],
     react: {
       wait: true
     }


### PR DESCRIPTION
- Currently the SideBar does not take up all vertical height in explorer (which is bigger than a single screen). `align-items: stretch` with `100vh` min height solves the issue. Closes https://github.com/polkadot-js/apps/issues/251
- Fix to use relative paths in i18next language pack loads. Closes https://github.com/polkadot-js/apps/issues/252