### PR TITLE
Additional webpack splitting config

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typescript": "^3.0.1"
   },
   "scripts": {
+    "analyze": "yarn run build && cd packages/apps && yarn run source-map-explorer build/main.*.js",
     "build": "polkadot-dev-build-ts",
     "check": "tslint --project . && tsc --noEmit",
     "clean": "polkadot-dev-clean-build",

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -142,11 +142,17 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
       runtimeChunk: 'single',
       splitChunks: {
         cacheGroups: {
+          crypto: {
+            chunks: 'initial',
+            enforce: true,
+            name: 'crypto',
+            test: /node_modules\/(libsodium)/
+          },
           vendor: {
             chunks: 'initial',
             enforce: true,
             name: 'vendor',
-            test: /node_modules\/(bn\.js|i18next|lodash|react|semantic-ui)/
+            test: /node_modules\/(bn\.js|i18next|lodash|react|rxjs|semantic-ui)/
           }
         }
       }
@@ -155,6 +161,7 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
       hints: false
     },
     plugins: plugins.concat([
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new webpack.DefinePlugin({
         'process.env': {
           NODE_ENV: JSON.stringify(ENV),

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -145,19 +145,19 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
           vendorOther: {
             chunks: 'initial',
             enforce: true,
-            name: 'vendor-other',
+            name: 'vendor',
             test: /node_modules\/(asn1|bn\.js|buffer|cuint|elliptic|lodash|moment|readable-stream|rxjs)/
           },
           vendorReact: {
             chunks: 'initial',
             enforce: true,
-            name: 'vendor-react',
+            name: 'react',
             test: /node_modules\/(chart|i18next|react|semantic-ui)/
           },
           vendorSodium: {
             chunks: 'initial',
             enforce: true,
-            name: 'vendor-sodium',
+            name: 'sodium',
             test: /node_modules\/(libsodium)/
           }
         }

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -142,17 +142,23 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
       runtimeChunk: 'single',
       splitChunks: {
         cacheGroups: {
-          crypto: {
+          vendorOther: {
             chunks: 'initial',
             enforce: true,
-            name: 'crypto',
-            test: /node_modules\/(libsodium)/
+            name: 'vendor-other',
+            test: /node_modules\/(asn1|bn\.js|buffer|cuint|elliptic|lodash|moment|readable-stream|rxjs)/
           },
-          vendor: {
+          vendorReact: {
             chunks: 'initial',
             enforce: true,
-            name: 'vendor',
-            test: /node_modules\/(bn\.js|i18next|lodash|react|rxjs|semantic-ui)/
+            name: 'vendor-react',
+            test: /node_modules\/(chart|i18next|react|semantic-ui)/
+          },
+          vendorSodium: {
+            chunks: 'initial',
+            enforce: true,
+            name: 'vendor-sodium',
+            test: /node_modules\/(libsodium)/
           }
         }
       }


### PR DESCRIPTION
- Better parallelize JS downloads
- Don't bundle moment locales (~200K savings)
- Split libsodium into an own bundle - in this case not much that can be done, it is a WASM bundle
- Split all UI-related 3rd party libraries into single bundle
- Adjust general 3rd party libraries in vendor bundle
- Main bundle size dropped from 1.8MB initial value

Current results -

```
$ ls -al packages/apps/build/*.js             
-rw-r--r--  1 jacogreeff  staff  586532 Aug 22 16:50 packages/apps/build/main.be814289.js
-rw-r--r--  1 jacogreeff  staff  515002 Aug 22 16:50 packages/apps/build/react.f8b82fe2.js
-rw-r--r--  1 jacogreeff  staff    1494 Aug 22 16:50 packages/apps/build/runtime.74ea5d42.js
-rw-r--r--  1 jacogreeff  staff  579105 Aug 22 16:50 packages/apps/build/sodium.a8bec706.js
-rw-r--r--  1 jacogreeff  staff  432820 Aug 22 16:50 packages/apps/build/vendor.2b2f9500.js
```

Additionally, gzip compression is now enabled on poc-2.polkadot.io (polkadot.js.org has br from CF)