### PR TITLE
Decode Proposals in block explorer

### DIFF
--- a/packages/app-democracy/src/Referendum.tsx
+++ b/packages/app-democracy/src/Referendum.tsx
@@ -110,6 +110,8 @@ class Referendum extends React.PureComponent<Props, State> {
       return null;
     }
 
+    console.error('Referendum:: best:', numberFormat(bestNumber), 'target:', numberFormat(blockNumber), 'remaining:', numberFormat(blockNumber.sub(bestNumber)));
+
     return (
       <div className='democracy--Referendum-info'>
         <Static label={t('referendum.endLabel', {

--- a/packages/ui-app/src/Extrinsic.tsx
+++ b/packages/ui-app/src/Extrinsic.tsx
@@ -19,12 +19,15 @@ export type Props = I18nProps & {
 
 class Extrinsic extends React.PureComponent<Props> {
   render () {
-    const { children, className, style, value: { extrinsic, params } } = this.props;
+    const { children, className, style, value } = this.props;
+    const { extrinsic, params } = value;
     const values: Array<RawParam> = extrinsic.params.map(({ type }, index) => ({
       isValid: true,
       value: params[index],
       type
     }));
+
+    console.log('Extrinsic', value);
 
     return (
       <div

--- a/packages/ui-app/src/Extrinsic.tsx
+++ b/packages/ui-app/src/Extrinsic.tsx
@@ -19,15 +19,12 @@ export type Props = I18nProps & {
 
 class Extrinsic extends React.PureComponent<Props> {
   render () {
-    const { children, className, style, value } = this.props;
-    const { extrinsic, params } = value;
+    const { children, className, style, value: { extrinsic, params } } = this.props;
     const values: Array<RawParam> = extrinsic.params.map(({ type }, index) => ({
       isValid: true,
       value: params[index],
       type
     }));
-
-    console.log('Extrinsic', value);
 
     return (
       <div

--- a/packages/ui-app/src/Params/Param/Bare.tsx
+++ b/packages/ui-app/src/Params/Param/Bare.tsx
@@ -9,16 +9,20 @@ import React from 'react';
 import classes from '../../util/classes';
 
 type Props = BareProps & {
-  children: any // node?
+  children: React.ReactNode
 };
 
-export default function Bare ({ children, className, style }: Props) {
-  return (
-    <div
-      className={classes('ui--row', className)}
-      style={style}
-    >
-      {children}
-    </div>
-  );
+export default class Bare extends React.PureComponent<Props> {
+  render () {
+    const { children, className, style } = this.props;
+
+    return (
+      <div
+        className={classes('ui--row', className)}
+        style={style}
+      >
+        {children}
+      </div>
+    );
+  }
 }

--- a/packages/ui-app/src/Params/Param/Base.tsx
+++ b/packages/ui-app/src/Params/Param/Base.tsx
@@ -18,19 +18,23 @@ type Props = BareProps & {
   withLabel?: boolean
 };
 
-export default function Base ({ children, className, isDisabled, label, size = 'medium', style, withLabel }: Props) {
-  return (
-    <Bare
-      className={className}
-      style={style}
-    >
-      <Labelled
-        className={isDisabled ? 'full' : size}
-        label={label}
-        withLabel={withLabel}
+export default class Base extends React.PureComponent<Props> {
+  render () {
+    const { children, className, isDisabled, label, size = 'medium', style, withLabel } = this.props;
+
+    return (
+      <Bare
+        className={className}
+        style={style}
       >
-        {children}
-      </Labelled>
-    </Bare>
-  );
+        <Labelled
+          className={isDisabled ? 'full' : size}
+          label={label}
+          withLabel={withLabel}
+        >
+          {children}
+        </Labelled>
+      </Bare>
+    );
+  }
 }

--- a/packages/ui-app/src/Params/Param/BaseBytes.tsx
+++ b/packages/ui-app/src/Params/Param/BaseBytes.tsx
@@ -27,7 +27,7 @@ export default class BaseBytes extends React.PureComponent<Props> {
   render () {
     const { className, defaultValue: { value }, isDisabled, isError, label, size = 'full', style, withLabel } = this.props;
     const defaultValue = value
-      ? u8aToHex(value as Uint8Array)
+      ? u8aToHex(value as Uint8Array, isDisabled ? 256 : -1)
       : undefined;
 
     return (

--- a/packages/ui-app/src/Params/Param/Hash.tsx
+++ b/packages/ui-app/src/Params/Param/Hash.tsx
@@ -8,20 +8,24 @@ import React from 'react';
 
 import BaseBytes from './BaseBytes';
 
-export default function Hash ({ className, defaultValue, isDisabled, isError, label, name, onChange, style, withLabel }: Props) {
-  return (
-    <BaseBytes
-      className={className}
-      defaultValue={defaultValue}
-      isDisabled={isDisabled}
-      isError={isError}
-      label={label}
-      length={32}
-      name={name}
-      onChange={onChange}
-      size={isDisabled ? 'full' : 'medium'}
-      style={style}
-      withLabel={withLabel}
-    />
-  );
+export default class Hash extends React.PureComponent<Props> {
+  render () {
+    const { className, defaultValue, isDisabled, isError, label, name, onChange, style, withLabel } = this.props;
+
+    return (
+      <BaseBytes
+        className={className}
+        defaultValue={defaultValue}
+        isDisabled={isDisabled}
+        isError={isError}
+        label={label}
+        length={32}
+        name={name}
+        onChange={onChange}
+        size={isDisabled ? 'full' : 'medium'}
+        style={style}
+        withLabel={withLabel}
+      />
+    );
+  }
 }

--- a/packages/ui-app/src/Params/Param/Proposal.tsx
+++ b/packages/ui-app/src/Params/Param/Proposal.tsx
@@ -1,0 +1,43 @@
+// Copyright 2017-2018 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { ExtrinsicDecoded } from '@polkadot/params/types';
+import { Props } from '../types';
+
+import React from 'react';
+
+import Extrinsic from '../../Extrinsic';
+import Static from '../../Static';
+import classes from '../../util/classes';
+import Bare from './Bare';
+import Unknown from './Unknown';
+
+export default class Proposal extends React.PureComponent<Props> {
+  render () {
+    const { className, defaultValue: { value }, isDisabled, label, style, withLabel } = this.props;
+
+    if (!isDisabled) {
+      return (
+        <Unknown {...this.props} />
+      );
+    }
+
+    const proposal = value as ExtrinsicDecoded;
+    const { extrinsic: { name, section } } = proposal;
+
+    return (
+      <Bare>
+        <Static
+          className={classes(className, 'full')}
+          label={label}
+          style={style}
+          withLabel={withLabel}
+        >
+          {section}.{name}
+        </Static>
+        <Extrinsic value={proposal} />
+      </Bare>
+    );
+  }
+}

--- a/packages/ui-app/src/Params/Param/StorageKeyValueArray.tsx
+++ b/packages/ui-app/src/Params/Param/StorageKeyValueArray.tsx
@@ -80,6 +80,7 @@ class StorageKeyValueArray extends React.PureComponent<Props, State> {
           return (
             <Bytes
               defaultValue={{ value } as RawParam}
+              isDisabled
               key={keyHex}
               label={keyHex}
               name={keyHex}

--- a/packages/ui-app/src/Params/Param/Unknown.tsx
+++ b/packages/ui-app/src/Params/Param/Unknown.tsx
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
+import { TranslationFunction } from 'i18next';
 import { Props as BareProps, RawParam } from '../types';
 
 import React from 'react';
@@ -13,38 +14,41 @@ import translate from '../../translate';
 import Base from './Base';
 
 type Props = BareProps & {
-  isDiabled?: boolean,
   defaultValue: RawParam,
-  t: any, // I18Next$Translate?
+  t: TranslationFunction,
   withLabel?: boolean
 };
 
-function Unknown ({ defaultValue: { value, type }, isDisabled, label, t, withLabel }: Props) {
-  if (isDisabled) {
+class Unknown extends React.PureComponent<Props> {
+  render () {
+    const { defaultValue: { value, type }, isDisabled, label, t, withLabel } = this.props;
+
+    if (isDisabled) {
+      return (
+        <Static
+          label={label}
+          value={(value && value.toString()) || t('unknown.empty', { defaultValue: 'empty' })}
+        />
+      );
+    }
+
     return (
-      <Static
+      <Base
+        size='full'
         label={label}
-        value={(value && value.toString()) || t('unknown.empty', { defaultValue: 'empty' })}
-      />
+        withLabel={withLabel}
+      >
+        <div className='ui--Param-Unknown ui dropdown error selection'>
+          {t('param.unknown', {
+            defaultValue: `ERROR: Unimplemented type '{{type}}' requested. No renderer exists`,
+            replace: {
+              type: typeToString(type)
+            }
+          })}
+        </div>
+      </Base>
     );
   }
-
-  return (
-    <Base
-      size='full'
-      label={label}
-      withLabel={withLabel}
-    >
-      <div className='ui--Param-Unknown ui dropdown error selection'>
-        {t('param.unknown', {
-          defaultValue: `ERROR: Unimplemented type '{{type}}' requested. No renderer exists`,
-          replace: {
-            type: typeToString(type)
-          }
-        })}
-      </div>
-    </Base>
-  );
 }
 
 export default translate(Unknown);

--- a/packages/ui-app/src/Params/Param/findComponent.ts
+++ b/packages/ui-app/src/Params/Param/findComponent.ts
@@ -11,6 +11,7 @@ import Bool from './Bool';
 import Bytes from './Bytes';
 import Code from './Code';
 import Hash from './Hash';
+import Proposal from './Proposal';
 import StorageKeyValue from './StorageKeyValue';
 import StorageKeyValueArray from './StorageKeyValueArray';
 import StringParam from './String';
@@ -35,7 +36,7 @@ const components: ComponentMap = {
   'MisbehaviorReport': Unknown,
   'ParachainId': Amount,
   'PropIndex': Amount,
-  'Proposal': Unknown,
+  'Proposal': Proposal,
   'ReferendumIndex': Amount,
   'SessionKey': Amount,
   'Signature': Hash,


### PR DESCRIPTION
- Decode Proposals, Closes https://github.com/polkadot-js/apps/issues/255
- Render decoded key/values as disabled fields (issue visible in screenshot from  https://github.com/polkadot-js/apps/issues/254)
- Swap functional components in Params to PureComponent
- Add extra logging for Referendum countdown

Fixed decoding from the linked block -

<img width="604" alt="polkadot apps portal 2018-08-23 12-45-49" src="https://user-images.githubusercontent.com/1424473/44521177-8769c900-a6d2-11e8-9201-dacb7564bdd5.png">
