### PR TITLE
Fix AccountId display in labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@polkadot/dev-react": "^0.20.18",
-    "@polkadot/ts": "^0.1.23",
+    "@polkadot/ts": "^0.1.24",
     "autoprefixer": "^9.1.2",
     "babel-loader": "^8.0.0-beta.2",
     "css-loader": "^1.0.0",

--- a/packages/app-democracy/package.json
+++ b/packages/app-democracy/package.json
@@ -14,6 +14,6 @@
     "@polkadot/storage": "^0.28.25",
     "@polkadot/ui-react": "^0.19.55",
     "@polkadot/ui-react-rx": "^0.19.55",
-    "@polkadot/util-keyring": "^0.29.18"
+    "@polkadot/util-keyring": "^0.29.19"
   }
 }

--- a/packages/app-example/package.json
+++ b/packages/app-example/package.json
@@ -14,6 +14,6 @@
     "@polkadot/storage": "^0.28.25",
     "@polkadot/ui-react": "^0.19.55",
     "@polkadot/ui-react-rx": "^0.19.55",
-    "@polkadot/util-keyring": "^0.29.18"
+    "@polkadot/util-keyring": "^0.29.19"
   }
 }

--- a/packages/app-explorer/package.json
+++ b/packages/app-explorer/package.json
@@ -13,6 +13,6 @@
     "@babel/runtime": "^7.0.0-rc.1",
     "@polkadot/primitives": "^0.28.25",
     "@polkadot/ui-app": "^0.19.55",
-    "@polkadot/util-crypto": "^0.29.18"
+    "@polkadot/util-crypto": "^0.29.19"
   }
 }

--- a/packages/app-staking/package.json
+++ b/packages/app-staking/package.json
@@ -17,6 +17,6 @@
     "@polkadot/ui-keyring": "^0.19.55",
     "@polkadot/ui-react": "^0.19.55",
     "@polkadot/ui-react-rx": "^0.19.55",
-    "@polkadot/util-keyring": "^0.29.18"
+    "@polkadot/util-keyring": "^0.29.19"
   }
 }

--- a/packages/ui-app/src/CopyButton.tsx
+++ b/packages/ui-app/src/CopyButton.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 import Button from './Button';
+import classes from './util/classes';
 
 type Props = BareProps & {
   icon?: string,
@@ -25,7 +26,7 @@ export default class CopyButton extends React.PureComponent<Props> {
     return (
       <CopyToClipboard text={value}>
         <Button
-          className={className}
+          className={classes('ui--CopyButton', className)}
           icon={icon}
           isCircular={isCircular}
           isPrimary={isPrimary}

--- a/packages/ui-app/src/InputAddress/index.tsx
+++ b/packages/ui-app/src/InputAddress/index.tsx
@@ -171,8 +171,9 @@ class InputAddress extends React.PureComponent<Props, State> {
     onChange(transform(address));
   }
 
-  private onSearch = (filteredOptions: KeyringSectionOptions, query: string): KeyringSectionOptions => {
+  private onSearch = (filteredOptions: KeyringSectionOptions, _query: string): KeyringSectionOptions => {
     const { isInput = true } = this.props;
+    const query = _query.trim();
     const queryLower = query.toLowerCase();
     const matches = filteredOptions.filter((item) =>
       item.value === null ||

--- a/packages/ui-app/src/Params/valueToText.tsx
+++ b/packages/ui-app/src/Params/valueToText.tsx
@@ -14,6 +14,7 @@ import isBn from '@polkadot/util/is/bn';
 import isNull from '@polkadot/util/is/null';
 import isU8a from '@polkadot/util/is/u8a';
 import isUndefined from '@polkadot/util/is/undefined';
+import encodeAddress from '@polkadot/util-keyring/address/encode';
 
 import classes from '../util/classes';
 import { textMap as thresholdTextMap } from './Param/VoteThreshold';
@@ -37,7 +38,11 @@ function div ({ key, className }: DivProps, ...values: Array<React.ReactNode>): 
   );
 }
 
-function accountToText (address: string): React.ReactNode {
+function accountToText (_address: string | Uint8Array): React.ReactNode {
+  const address = isU8a(_address)
+    ? encodeAddress(_address)
+    : _address;
+
   return div(
     { className: 'nowrap', key: `account_${address}` },
     <IdentityIcon

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -160,3 +160,7 @@ header .ui--Button-Group {
 .ui--CardSummary-progress {
   margin: 0.25rem 0 -0.5rem !important;
 }
+
+.ui--CopyButton {
+  cursor: copy !important;
+}

--- a/packages/ui-identicon/package.json
+++ b/packages/ui-identicon/package.json
@@ -22,7 +22,7 @@
     "color": "^3.0.0"
   },
   "devDependencies": {
-    "@polkadot/util-crypto": "^0.29.18",
+    "@polkadot/util-crypto": "^0.29.19",
     "xmlserializer": "^0.6.1"
   }
 }

--- a/packages/ui-keyring/package.json
+++ b/packages/ui-keyring/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.1",
     "@polkadot/ui-react": "^0.19.55",
-    "@polkadot/util-keyring": "^0.29.18",
+    "@polkadot/util-keyring": "^0.29.19",
     "store": "^2.0.12"
   },
   "peerDependencies": {

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -15,7 +15,7 @@
     "polkadot-identicon": "^1.0.2"
   },
   "devDependencies": {
-    "@polkadot/util-keyring": "^0.29.18",
+    "@polkadot/util-keyring": "^0.29.19",
     "empty": "^0.10.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,9 +1483,9 @@
     "@polkadot/util-crypto" "^0.29.18"
     "@polkadot/util-rlp" "^0.29.18"
 
-"@polkadot/ts@^0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.23.tgz#8515963f514ef62c1fa97b656a18553c01c32530"
+"@polkadot/ts@^0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.24.tgz#a5202626f394114831851b476beba8a3a334ba79"
 
 "@polkadot/util-crypto@^0.29.18":
   version "0.29.18"
@@ -1493,6 +1493,17 @@
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
     "@polkadot/util" "^0.29.18"
+    blakejs "^1.1.0"
+    js-sha3 "^0.8.0"
+    tweetnacl "^1.0.0"
+    xxhashjs "^0.2.2"
+
+"@polkadot/util-crypto@^0.29.19":
+  version "0.29.19"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.29.19.tgz#544e150bea32d6f24f48641a25d4b711114c05ce"
+  dependencies:
+    "@babel/runtime" "^7.0.0-rc.1"
+    "@polkadot/util" "^0.29.19"
     blakejs "^1.1.0"
     js-sha3 "^0.8.0"
     tweetnacl "^1.0.0"
@@ -1508,6 +1519,16 @@
     "@types/bs58" "^3.0.30"
     bs58 "^4.0.1"
 
+"@polkadot/util-keyring@^0.29.19":
+  version "0.29.19"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-keyring/-/util-keyring-0.29.19.tgz#f1e962c260dbb63ee31439f3c92607b67147d617"
+  dependencies:
+    "@babel/runtime" "^7.0.0-rc.1"
+    "@polkadot/util" "^0.29.19"
+    "@polkadot/util-crypto" "^0.29.19"
+    "@types/bs58" "^3.0.30"
+    bs58 "^4.0.1"
+
 "@polkadot/util-rlp@^0.29.18":
   version "0.29.18"
   resolved "https://registry.yarnpkg.com/@polkadot/util-rlp/-/util-rlp-0.29.18.tgz#afbb7bb0c094e1d1c3ea7dc1e4ff654513de3bd7"
@@ -1518,6 +1539,21 @@
 "@polkadot/util@^0.29.18":
   version "0.29.18"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.29.18.tgz#5ae4bdd3d376d7030f174c30338fc36309c236d8"
+  dependencies:
+    "@babel/runtime" "^7.0.0-rc.1"
+    "@types/bn.js" "^4.11.1"
+    "@types/deasync" "^0.1.0"
+    "@types/ip-regex" "^2.0.0"
+    "@types/xxhashjs" "^0.1.1"
+    bn.js "^4.11.8"
+    chalk "^2.4.1"
+    deasync "^0.1.13"
+    ip-regex "^3.0.0"
+    moment "^2.22.2"
+
+"@polkadot/util@^0.29.19":
+  version "0.29.19"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.29.19.tgz#2d7f0cf1b06797c1a11e80dd1155e79cec3b1496"
   dependencies:
     "@babel/runtime" "^7.0.0-rc.1"
     "@types/bn.js" "^4.11.1"


### PR DESCRIPTION
- Allow encoding to handle both ss58 & u8a (publicKey) inputs. Closes https://github.com/polkadot-js/apps/issues/272 . This is a hold-over from the encoding changes, expected everything to come back as ss58. (However the param value is u8a, while what comes back from storage is ss58)
- Time InputAddress query values, part of https://github.com/polkadot-js/apps/issues/264
- Add `cursor: copy` to `CopyButton` - aligns with copyable `IdentityIcon`, i.e. anything where it copies to clipboard has the same cursor

<img width="1008" alt="polkadot apps portal 2018-09-04 15-06-16" src="https://user-images.githubusercontent.com/1424473/45033252-3b187480-b054-11e8-8ac5-acf9b8afeea3.png">
