### PR TITLE
fix: Fixes #297. Toggles Creator menu tab before initial mount when no addresses exist

### DIFF
--- a/packages/app-addresses/src/Editor.tsx
+++ b/packages/app-addresses/src/Editor.tsx
@@ -39,7 +39,8 @@ class Editor extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { isForgetOpen, current } = this.state;
+    const { current, isForgetOpen } = this.state;
+
     return (
       <div className='addresses--Editor'>
         <Forgetting
@@ -97,9 +98,7 @@ class Editor extends React.PureComponent<Props, State> {
     const { current, editedName } = this.state;
 
     if (!addressAll || !Object.keys(addressAll).length) {
-      return t('editor.none', {
-        defaultValue: 'There are no saved addresses. Add some first.'
-      });
+      return null;
     }
 
     const address = current

--- a/packages/app-addresses/src/index.tsx
+++ b/packages/app-addresses/src/index.tsx
@@ -37,7 +37,15 @@ const Components: { [index: string]: React.ComponentType<any> } = {
 class AddressesApp extends React.PureComponent<Props, State> {
   state: State = { action: 'edit' };
 
+  componentWillMount () {
+    this.toggleCreateForNoAddresses();
+  }
+
   componentDidUpdate () {
+    this.toggleCreateForNoAddresses();
+  }
+
+  toggleCreateForNoAddresses = () => {
     const { addressAll } = this.props;
     const { action } = this.state;
 

--- a/packages/app-addresses/src/index.tsx
+++ b/packages/app-addresses/src/index.tsx
@@ -25,7 +25,8 @@ type Props = I18nProps & {
 type Actions = 'create' | 'edit';
 
 type State = {
-  action: Actions
+  action: Actions,
+  isLoading: boolean
 };
 
 // FIXME React-router would probably be the best route, not home-grown
@@ -35,10 +36,17 @@ const Components: { [index: string]: React.ComponentType<any> } = {
 };
 
 class AddressesApp extends React.PureComponent<Props, State> {
-  state: State = { action: 'edit' };
+  state: State = {
+    action: 'edit',
+    isLoading: true
+  };
 
   componentWillMount () {
     this.toggleCreateForNoAddresses();
+  }
+
+  componentDidMount () {
+    this.setState({ isLoading: false });
   }
 
   componentDidUpdate () {
@@ -56,7 +64,12 @@ class AddressesApp extends React.PureComponent<Props, State> {
 
   render () {
     const { addressAll, t } = this.props;
-    const { action } = this.state;
+    const { action, isLoading } = this.state;
+
+    if (isLoading) {
+      return null;
+    }
+
     const Component = Components[action];
     const items = [
       {


### PR DESCRIPTION
* Fixes bug introduced by PR #292 that didn't cater for switching to the Creator menu tab on initial mount when no accounts exist.
The user shouldn't need to be notified and have to manually switch menu tabs when there aren't any addresses, the UI should do the work for the user and switch automatically depending on the current state.
It only catered for updates to the available addresses (i.e. forgetting an address when it was the only one remaining would toggle displaying the Creator menu tab)
https://github.com/polkadot-js/apps/pull/292