### PR TITLE
fix: Fixes #340 prevent spaces in InputNumber

### DIFF
--- a/packages/ui-app/src/InputNumber.spec.js
+++ b/packages/ui-app/src/InputNumber.spec.js
@@ -87,8 +87,14 @@ describe('InputNumber', () => {
       it('throws an error if input value for comparison is not a string', () => {
         const invalidInputValueType = 340282366920938463463374607431768211456;
 
-        expect(() => { wrapper.instance().isValidNumber(invalidInputValueType, '0', DEFAULT_BITLENGTH); }).toThrow();
+        expect(() => { wrapper.instance().isValidNumber(invalidInputValueType, DEFAULT_BITLENGTH); }).toThrow();
       });
+    });
+
+    it('should not be valid when input contains spaces', () => {
+      const invalidInputValueType = '3 4';
+
+      expect(wrapper.instance().isValidNumber(invalidInputValueType, DEFAULT_BITLENGTH)).toBe(false);
     });
 
     it('should not be valid when user enters positive value greater than or equal to the 128 bit max for latest chain', () => {

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -126,9 +126,6 @@ class InputNumber extends React.PureComponent<Props, State> {
       }));
     }
 
-    // remove spaces even though not possible as user restricted from entering spacebar key in onKeyDown
-    input = input.toLowerCase().split(' ').join('');
-
     if (this.isNonInteger(input)) {
       return false;
     }


### PR DESCRIPTION
* currently user cannot enter "0 ", but this prevents user from entering a space after any digit, i.e. "3 4" or "3  " or "3   3  3  ". This bug snuck through in PR #221

* Removes second argument in another existing unit test that, since isValidNumber only accepts 2x arguments (not 3x arguments)