### PR TITLE
[next] Highlight validators

### DIFF
--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -109,8 +109,6 @@ class CurrentList extends React.PureComponent<Props> {
 
     const address = _address.toString();
 
-    console.log('balance', address, balances[address], balances);
-
     return balances[address]
       ? [balances[address].stakingBalance, balances[address].nominatedBalance]
       : undefined;

--- a/packages/app-staking/src/StakeList/Account.tsx
+++ b/packages/app-staking/src/StakeList/Account.tsx
@@ -10,8 +10,7 @@ import BN from 'bn.js';
 import React from 'react';
 import Api from '@polkadot/api-observable';
 import { AccountId, Balance, Extrinsic } from '@polkadot/types';
-import { AddressMini, AddressSummary, Button, Icon } from '@polkadot/ui-app/index';
-import classes from '@polkadot/ui-app/util/classes';
+import { AddressMini, AddressSummary, Button } from '@polkadot/ui-app/index';
 import { withMulti, withObservable } from '@polkadot/ui-react-rx/with/index';
 
 import Nominating from './Nominating';
@@ -45,16 +44,11 @@ class Account extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { accountId, intentions, isValidator, name } = this.props;
+    const { accountId, intentions, name } = this.props;
     const { isNominateOpen } = this.state;
 
     return (
       <article className='staking--Account'>
-        <Icon
-          className={classes('staking--Account-validating', isValidator ? 'isValidator' : '')}
-          name='certificate'
-          size='large'
-        />
         <Nominating
           isOpen={isNominateOpen}
           onClose={this.toggleNominate}

--- a/packages/apps/src/NodeInfo.tsx
+++ b/packages/apps/src/NodeInfo.tsx
@@ -6,31 +6,22 @@ import { BareProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 
-import { Text } from '@polkadot/types';
-import keyring from '@polkadot/ui-keyring/index';
+import { AccountId } from '@polkadot/types';
 import { BestNumber, Chain, NodeName, NodeVersion } from '@polkadot/ui-react-rx/index';
-import { isTestChain } from '@polkadot/ui-react-rx/util/index';
+import { withMulti, withObservable } from '@polkadot/ui-react-rx/with/index';
 
-type Props = BareProps & {};
+type Props = BareProps & {
+  sessionValidators?: Array<AccountId>
+};
 
 const pkgJson = require('../package.json');
 
-function updateTestInfo (chain?: Text) {
-  keyring.setDevMode(
-    isTestChain(
-      chain
-        ? chain.toString()
-        : ''
-    )
-  );
-}
-
-export default class NodeInfo extends React.PureComponent<Props> {
+class NodeInfo extends React.PureComponent<Props> {
   render () {
     return (
       <div className='apps--NodeInfo'>
         <div className='apps--NodeInfo-inline'>
-          <Chain rxChange={updateTestInfo} />&nbsp;
+          <Chain />&nbsp;
           <BestNumber label='#' />
         </div>
         <div className='apps--NodeInfo-inline'>
@@ -42,3 +33,11 @@ export default class NodeInfo extends React.PureComponent<Props> {
     );
   }
 }
+
+// NOTE While these are not used internally to this specific component, we are loading them
+// to have them warmed-up globally. This means when accessing in other components, the values
+// are already there
+export default withMulti(
+  NodeInfo,
+  withObservable('sessionValidators')
+);

--- a/packages/ui-app/src/AddressMini.tsx
+++ b/packages/ui-app/src/AddressMini.tsx
@@ -8,6 +8,7 @@ import BN from 'bn.js';
 import React from 'react';
 import { AccountId, AccountIndex, Address, Balance } from '@polkadot/types';
 import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
+import { withMulti, withObservable } from '@polkadot/ui-react-rx/with/index';
 
 import classes from './util/classes';
 import toShortAddress from './util/toShortAddress';
@@ -18,17 +19,23 @@ type Props = BareProps & {
   children?: React.ReactNode,
   isPadded?: boolean,
   isShort?: boolean,
+  sessionValidators?: Array<AccountId>,
   value?: AccountId | AccountIndex | Address | string,
   withBalance?: boolean
 };
 
-export default class AddressMini extends React.PureComponent<Props> {
+class AddressMini extends React.PureComponent<Props> {
   render () {
-    const { children, className, isPadded = true, isShort = true, style, value } = this.props;
+    const { children, className, isPadded = true, isShort = true, sessionValidators = [], style, value } = this.props;
 
     if (!value) {
       return null;
     }
+
+    const address = value.toString();
+    const isValidator = sessionValidators.find((validator) =>
+      validator.toString() === address
+    );
 
     return (
       <div
@@ -37,10 +44,11 @@ export default class AddressMini extends React.PureComponent<Props> {
       >
         <div className='ui--AddressMini-info'>
           <IdentityIcon
+            isHighlight={!!isValidator}
             size={24}
-            value={value.toString()}
+            value={address}
           />
-          <div className='ui--AddressMini-address'>{isShort ? toShortAddress(value) : value}</div>
+          <div className='ui--AddressMini-address'>{isShort ? toShortAddress(address) : address}</div>
           {children}
         </div>
         {this.renderBalance()}
@@ -64,3 +72,8 @@ export default class AddressMini extends React.PureComponent<Props> {
     );
   }
 }
+
+export default withMulti(
+  AddressMini,
+  withObservable('sessionValidators')
+);

--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -3,7 +3,7 @@
 // of the ISC license. See the LICENSE file for details.
 
 import React from 'react';
-import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
+import { withMulti, withObservable } from '@polkadot/ui-react-rx/with/index';
 
 import classes from './util/classes';
 import { AddressSummary } from './AddressSummary';
@@ -11,7 +11,7 @@ import translate from './translate';
 
 class AddressRow extends AddressSummary {
   render () {
-    const { className, style, identIconSize, value } = this.props;
+    const { className, style, identIconSize = 64, value } = this.props;
 
     return (
       <div
@@ -19,11 +19,7 @@ class AddressRow extends AddressSummary {
         style={style}
       >
         <div className='ui--AddressRow-base'>
-          <IdentityIcon
-            className='ui--AddressRow-icon'
-            size={identIconSize}
-            value={(value || '').toString()}
-          />
+          {this.renderIcon('ui--AddressRow-icon', identIconSize)}
           <div className='ui--AddressRow-details'>
             {this.renderAddress()}
             {this.renderBalance()}
@@ -36,4 +32,8 @@ class AddressRow extends AddressSummary {
   }
 }
 
-export default translate(AddressRow);
+export default withMulti(
+  translate(AddressRow),
+  withObservable('accountIdAndIndex', { paramProp: 'value' }),
+  withObservable('sessionValidators')
+);

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -25,7 +25,8 @@ export type Props = I18nProps & {
   withBalance?: boolean,
   withIndex?: boolean,
   identIconSize?: number,
-  isShort?: boolean
+  isShort?: boolean,
+  sessionValidators?: Array<AccountId>,
   withCopy?: boolean,
   withIcon?: boolean,
   withNonce?: boolean
@@ -162,17 +163,24 @@ class AddressSummary extends React.PureComponent<Props> {
     );
   }
 
-  protected renderIcon () {
-    const { identIconSize = 96, value, withIcon = true } = this.props;
+  protected renderIcon (className: string = 'ui--AddressSummary-icon', size?: number) {
+    const { accountIdAndIndex = [], identIconSize = 96, sessionValidators = [], value, withIcon = true } = this.props;
 
     if (!withIcon) {
       return null;
     }
 
+    const [_accountId] = accountIdAndIndex;
+    const accountId = (_accountId || '').toString();
+    const isValidator = sessionValidators.find((validator) =>
+      validator.toString() === accountId
+    );
+
     return (
       <IdentityIcon
-        className='ui--AddressSummary-icon'
-        size={identIconSize}
+        className={className}
+        isHighlight={!!isValidator}
+        size={size || identIconSize}
         value={value ? value.toString() : DEFAULT_ADDR}
       />
     );
@@ -220,5 +228,6 @@ export {
 
 export default withMulti(
   translate(AddressSummary),
-  withObservable('accountIdAndIndex', { paramProp: 'value' })
+  withObservable('accountIdAndIndex', { paramProp: 'value' }),
+  withObservable('sessionValidators')
 );

--- a/packages/ui-keyring/src/options/KeyPair.tsx
+++ b/packages/ui-keyring/src/options/KeyPair.tsx
@@ -5,35 +5,50 @@
 import './KeyPair.css';
 
 import React from 'react';
-
+import { AccountId } from '@polkadot/types';
 import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
+import { withMulti, withObservable } from '@polkadot/ui-react-rx/with/index';
 
 type Props = {
   address: string,
   className?: string,
   name: string,
+  sessionValidators?: Array<AccountId>,
   style?: {
     [index: string]: string
   }
 };
 
-export default function KeyPair ({ address, className, name, style }: Props) {
-  return (
-    <div
-      className={['ui--KeyPair', className].join(' ')}
-      style={style}
-    >
-      <IdentityIcon
-        className='ui--KeyPair-icon'
-        size={32}
-        value={address}
-      />
-      <div className='ui--KeyPair-name'>
-        {name}
+class KeyPair extends React.PureComponent<Props> {
+  render () {
+    const { address, className, name, sessionValidators = [], style } = this.props;
+    const isValidator = sessionValidators.find((validator) =>
+      validator.toString() === address
+    );
+
+    return (
+      <div
+        className={['ui--KeyPair', className].join(' ')}
+        style={style}
+      >
+        <IdentityIcon
+          className='ui--KeyPair-icon'
+          isHighlight={!!isValidator}
+          size={32}
+          value={address}
+        />
+        <div className='ui--KeyPair-name'>
+          {name}
+        </div>
+        <div className='ui--KeyPair-address'>
+          {address}
+        </div>
       </div>
-      <div className='ui--KeyPair-address'>
-        {address}
-      </div>
-    </div>
-  );
+    );
+  }
 }
+
+export default withMulti(
+  KeyPair,
+  withObservable('sessionValidators')
+);

--- a/packages/ui-react-rx/src/Api/index.tsx
+++ b/packages/ui-react-rx/src/Api/index.tsx
@@ -14,6 +14,7 @@ import WsProvider from '@polkadot/rpc-provider/ws';
 import RxApi from '@polkadot/rpc-rx';
 import settings from '@polkadot/ui-app/settings';
 import keyring from '@polkadot/ui-keyring/index';
+import { isTestChain } from '@polkadot/ui-react-rx/util/index';
 import { Header, Method } from '@polkadot/types';
 
 import { balanceFormat } from '../util/index';
@@ -116,7 +117,8 @@ export default class ApiWrapper extends React.PureComponent<Props, State> {
       InputNumber.setUnit(found.unit);
       setAddressPrefix(found.chainId as any);
 
-      // load accounts only after prefix has been set
+      // setup keyringonly after prefix has been set
+      keyring.setDevMode(isTestChain(chain || ''));
       keyring.loadAll();
 
       this.setState({ chain });

--- a/packages/ui-react/src/IdentityIcon/IdentityIcon.css
+++ b/packages/ui-react/src/IdentityIcon/IdentityIcon.css
@@ -5,4 +5,28 @@
 .ui--IdentityIcon {
   cursor: copy;
   display: inline-block;
+  line-height: 0;
+
+  > div {
+    position: relative;
+
+    > div,
+    > svg {
+      position: relative;
+    }
+
+    &:before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border-radius: 50%;
+      content: '';
+    }
+  }
+
+  &.highlight > div:before {
+    box-shadow: 0 0 5px 2px red;
+  }
 }

--- a/packages/ui-react/src/IdentityIcon/IdentityIcon.css
+++ b/packages/ui-react/src/IdentityIcon/IdentityIcon.css
@@ -22,6 +22,7 @@
       right: 0;
       bottom: 0;
       border-radius: 50%;
+      box-shadow: 0 0 5px 2px #e0e0e0;
       content: '';
     }
   }

--- a/packages/ui-react/src/IdentityIcon/Polkadot.tsx
+++ b/packages/ui-react/src/IdentityIcon/Polkadot.tsx
@@ -21,6 +21,12 @@ export default class Polkadot extends React.PureComponent<Props> {
     }
 
     // @ts-ignore Published version does not match up with actual repo version
-    return <Identicon account={value} size={size} />;
+    const icon = <Identicon account={value} size={size} />;
+
+    return (
+      <div>
+        {icon}
+      </div>
+    );
   }
 }

--- a/packages/ui-react/src/IdentityIcon/index.tsx
+++ b/packages/ui-react/src/IdentityIcon/index.tsx
@@ -13,7 +13,7 @@ import Polkadot from './Polkadot';
 import Substrate from './Substrate';
 
 type Props = BaseProps & {
-  isHighligt?: boolean,
+  isHighlight?: boolean,
   size?: number,
   value?: string | Uint8Array | null
 };

--- a/packages/ui-react/src/IdentityIcon/index.tsx
+++ b/packages/ui-react/src/IdentityIcon/index.tsx
@@ -13,6 +13,7 @@ import Polkadot from './Polkadot';
 import Substrate from './Substrate';
 
 type Props = BaseProps & {
+  isHighligt?: boolean,
   size?: number,
   value?: string | Uint8Array | null
 };
@@ -24,7 +25,7 @@ const Component = settings.uiTheme === 'substrate'
 
 export default class IdentityIcon extends React.PureComponent<Props> {
   render () {
-    const { className, size = DEFAULT_SIZE, style, value } = this.props;
+    const { className, isHighlight = false, size = DEFAULT_SIZE, style, value } = this.props;
 
     if (!value) {
       return null;
@@ -32,7 +33,7 @@ export default class IdentityIcon extends React.PureComponent<Props> {
 
     return (
       <div
-        className={['ui--IdentityIcon', className].join(' ')}
+        className={['ui--IdentityIcon', isHighlight ? 'highlight' : '', className].join(' ')}
         key={value.toString()}
         style={style}
       >


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/382
- Add isHiglight to IdentityIcon

TODOs: 
- ~~Highlight does not display in dropdown lists~~
- ~~Highlight does not display in AddressMini~~

AddressSummary -

<img width="1065" alt="polkadot apps portal 2018-11-05 18-53-36" src="https://user-images.githubusercontent.com/1424473/48016614-55420200-e12c-11e8-908f-f4f8f61188e2.png">

AddressRow -

<img width="403" alt="polkadot apps portal 2018-11-06 10-25-42" src="https://user-images.githubusercontent.com/1424473/48054796-5b78c280-e1ae-11e8-9c09-85374b46f535.png">

AddressMini -

![image](https://user-images.githubusercontent.com/1424473/48054754-413ee480-e1ae-11e8-8735-032304bfc8ca.png)

Input -

<img width="801" alt="polkadot apps portal 2018-11-06 11-11-27" src="https://user-images.githubusercontent.com/1424473/48057666-e066da80-e1b4-11e8-8e66-f888ae20b414.png">
