### PR TITLE
[WIP] Track extrinsics, don't allow until accountIndex is updated

### DIFF
--- a/packages/app-extrinsics/src/Selection.tsx
+++ b/packages/app-extrinsics/src/Selection.tsx
@@ -102,7 +102,7 @@ class Selection extends React.PureComponent<Props, State> {
     this.nextState({ accountNonce } as State);
   }
 
-  onChangeSender = (accountId: string): void => {
+  private onChangeSender = (accountId: string): void => {
     this.nextState({ accountId, accountNonce: new BN(0) } as State);
   }
 

--- a/packages/ui-signer/src/Extrinsic.tsx
+++ b/packages/ui-signer/src/Extrinsic.tsx
@@ -40,7 +40,7 @@ class Transaction extends React.PureComponent<Props> {
           <div className='expanded'>
             <p>
               <Trans i18nKey='decoded.short'>
-                You are about to sign a message from <span className='code'>{accountId}</span> calling <span className='code'>{section}.{method}</span> with an index of <span className='code'>{accountNonce.toString()}</span>
+                You are about to sign a message from <span className='code'>{accountId}</span> calling <span className='code'>{section}.{method}</span> with an index of <span className='code'>{accountNonce ? accountNonce.toString() : 0}</span>
               </Trans>
             </p>
             <Call value={extrinsic} />

--- a/packages/ui-signer/src/Queue.tsx
+++ b/packages/ui-signer/src/Queue.tsx
@@ -80,16 +80,9 @@ export default class Queue extends React.Component<Props, State> {
   }
 
   queueAdd = (value: QueueTx$Extrinsic | QueueTx$Rpc): QueueTx$Id => {
-    if (this.isDuplicateNonce(value)) {
-      this.queueSetStatus(nextId, 'error');
-      // TODO: Notify user to wait for prev txn to be finalized
-      console.error('Give it a second will ya');
-      return nextId; // unincremented id from the previous since we short circuit
-    }
-
     const id: QueueTx$Id = ++nextId;
 
-    console.log(`txn ${JSON.stringify(value)} with nonce -> `, value.accountNonce);
+    const _this = this;
 
     this.setState(
       (prevState: State): State => ({
@@ -99,7 +92,7 @@ export default class Queue extends React.Component<Props, State> {
             ? (value as QueueTx$Rpc).rpc
             : jsonrpc.author.methods.submitAndWatchExtrinsic,
           id,
-          status: 'queued'
+          status: _this.isDuplicateNonce(value) ? 'error' : 'queued'
         }])
       } as State)
     );
@@ -125,7 +118,9 @@ export default class Queue extends React.Component<Props, State> {
   }
 
   private isDuplicateNonce = (value: QueueTx$Extrinsic | QueueTx$Rpc): boolean => {
-    this.state.queue.find((item) => {
+    const { queue } = this.state;
+
+    return queue.find((item) => {
       return item.accountNonce === value.accountNonce
     });
   }

--- a/packages/ui-signer/src/Queue.tsx
+++ b/packages/ui-signer/src/Queue.tsx
@@ -80,7 +80,16 @@ export default class Queue extends React.Component<Props, State> {
   }
 
   queueAdd = (value: QueueTx$Extrinsic | QueueTx$Rpc): QueueTx$Id => {
+    if (this.isDuplicateNonce(value)) {
+      this.queueSetStatus(nextId, 'error');
+      // TODO: Notify user to wait for prev txn to be finalized
+      console.error('Give it a second will ya');
+      return nextId; // unincremented id from the previous since we short circuit
+    }
+
     const id: QueueTx$Id = ++nextId;
+
+    console.log(`txn ${JSON.stringify(value)} with nonce -> `, value.accountNonce);
 
     this.setState(
       (prevState: State): State => ({
@@ -112,6 +121,12 @@ export default class Queue extends React.Component<Props, State> {
       accountId,
       rpc,
       values
+    });
+  }
+
+  private isDuplicateNonce = (value: QueueTx$Extrinsic | QueueTx$Rpc): boolean => {
+    this.state.queue.find((item) => {
+      return item.accountNonce === value.accountNonce
     });
   }
 }


### PR DESCRIPTION
#304

Currently debugging but approaching this by:
1. onQueueExtrinsic -> check whether there is already a txn in queue with the same accountNonce
2. If yes -> then take current txn and set status to `blocked`
3. When result comes back from `submitAndWatchExtrinsic` set status to `queued`, with the nonce incremented and then re-sendExtrinsic

Another (easier) way [ the current WIP ] would be just to not queue txns before accountNonce is incremented, tell the user to wait a bit, and then tell them when they can try again.