### PR TITLE
[next] Retrieve hash instead of calculating (slower)

### DIFF
--- a/packages/app-explorer/src/BlockHeader/BlockHash.tsx
+++ b/packages/app-explorer/src/BlockHeader/BlockHash.tsx
@@ -11,8 +11,8 @@ import { withObservable } from '@polkadot/ui-react-rx/with/index';
 import { BlockNumber, Hash } from '@polkadot/types';
 
 type Props = I18nProps & {
+  blockNumber: BlockNumber,
   getBlockHash?: Hash,
-  value: BlockNumber,
   withLink?: boolean
 };
 
@@ -34,6 +34,8 @@ class BlockHash extends React.PureComponent<Props> {
   }
 }
 
-export default withObservable(
-  'rawCall', { params: [jsonrpc.chain.methods.getBlockHash], paramProp: 'value', propName: 'getBlockHash' }
-)(BlockHash);
+export default withObservable('rawCall', {
+  params: [jsonrpc.chain.methods.getBlockHash],
+  paramProp: 'blockNumber',
+  propName: 'getBlockHash'
+})(BlockHash);

--- a/packages/app-explorer/src/BlockHeader/BlockHash.tsx
+++ b/packages/app-explorer/src/BlockHeader/BlockHash.tsx
@@ -1,0 +1,39 @@
+// Copyright 2017-2018 @polkadot/app-explorer authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import jsonrpc from '@polkadot/jsonrpc';
+import { withObservable } from '@polkadot/ui-react-rx/with/index';
+import { BlockNumber, Hash } from '@polkadot/types';
+
+type Props = I18nProps & {
+  getBlockHash?: Hash,
+  value: BlockNumber,
+  withLink?: boolean
+};
+
+class BlockHash extends React.PureComponent<Props> {
+  render () {
+    const { getBlockHash, withLink } = this.props;
+
+    if (!getBlockHash) {
+      return null;
+    }
+
+    const hashHex = getBlockHash.toHex();
+
+    return (
+      withLink
+        ? <Link to={`/explorer/hash/${hashHex}`}>{hashHex}</Link>
+        : hashHex
+    );
+  }
+}
+
+export default withObservable(
+  'rawCall', { params: [jsonrpc.chain.methods.getBlockHash], paramProp: 'value', propName: 'getBlockHash' }
+)(BlockHash);

--- a/packages/app-explorer/src/BlockHeader/BlockHeader.css
+++ b/packages/app-explorer/src/BlockHeader/BlockHeader.css
@@ -18,6 +18,7 @@
   .header {
     color: rgba(0, 0, 0, 0.6);
     overflow: hidden;
+    text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
     vertical-align: middle;

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -30,16 +30,17 @@ export default class BlockHeader extends React.PureComponent<Props> {
       return null;
     }
 
-    const parentHex = value.parentHash.toHex();
+    const { blockNumber, extrinsicsRoot, parentHash, stateRoot } = value;
+    const parentHex = parentHash.toHex();
 
     return (
       <article className='explorer--BlockHeader'>
         <div className='details'>
           <div className='header'>
-            <div className='number'>{numberFormat(value.blockNumber.toBn())}&nbsp;</div>
+            <div className='number'>{numberFormat(blockNumber.toBn())}&nbsp;</div>
             <div className='hash'>
               <BlockHash
-                value={value.blockNumber}
+                blockNumber={blockNumber}
                 withLink={withLink}
               />
             </div>
@@ -55,11 +56,11 @@ export default class BlockHeader extends React.PureComponent<Props> {
             </div>
             <div>
               <div className='type'>extrinsicsRoot</div>
-              <div className='hash'>{value.extrinsicsRoot.toHex()}</div>
+              <div className='hash'>{extrinsicsRoot.toHex()}</div>
             </div>
             <div>
               <div className='type'>stateRoot</div>
-              <div className='hash'>{value.stateRoot.toHex()}</div>
+              <div className='hash'>{stateRoot.toHex()}</div>
             </div>
             {withExtrinsics
               ? <Extrinsics hash={value.hash} />

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -11,6 +11,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import numberFormat from '@polkadot/ui-react-rx/util/numberFormat';
 
+// FIXME 7 Nov 2018 Due to mismatches with block hashes between Substrate and BBQ,
+// the hashes are retrieved and not calculated (go back to calculated once resolved)
+import BlockHash from './BlockHash';
 import Extrinsics from './Extrinsics';
 
 type Props = BareProps & {
@@ -27,7 +30,6 @@ export default class BlockHeader extends React.PureComponent<Props> {
       return null;
     }
 
-    const hashHex = value.hash.toHex();
     const parentHex = value.parentHash.toHex();
 
     return (
@@ -35,11 +37,12 @@ export default class BlockHeader extends React.PureComponent<Props> {
         <div className='details'>
           <div className='header'>
             <div className='number'>{numberFormat(value.blockNumber.toBn())}&nbsp;</div>
-            <div className='hash'>{
-              withLink
-                ? <Link to={`/explorer/hash/${hashHex}`}>{hashHex}</Link>
-                : hashHex
-            }</div>
+            <div className='hash'>
+              <BlockHash
+                value={value.blockNumber}
+                withLink={withLink}
+              />
+            </div>
           </div>
           <div className='contains'>
             <div>


### PR DESCRIPTION
Cleans up block hash mismatch issues described in https://github.com/polkadot-js/apps/issues/414

Instead of calculating the hash, it now makes a call (move overhead, slower) to retrieve the hash based on the blockNumber. In future this should be reverted again, or maybe detected to see if there is a match - if not, then use this approach.