### PR TITLE
[next] Allow raw-key queries via the storage app

### DIFF
--- a/packages/app-democracy/package.json
+++ b/packages/app-democracy/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@polkadot/keyring": "^0.32.12",
-    "@polkadot/storage": "^0.31.97",
+    "@polkadot/storage": "^0.31.102",
     "@polkadot/ui-react": "^0.21.0",
     "@polkadot/ui-react-rx": "^0.21.0"
   }

--- a/packages/app-explorer/package.json
+++ b/packages/app-explorer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/types": "^0.31.97",
+    "@polkadot/types": "^0.31.102",
     "@polkadot/ui-app": "^0.21.0",
     "@polkadot/util-crypto": "^0.32.12"
   }

--- a/packages/app-extrinsics/package.json
+++ b/packages/app-extrinsics/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/types": "^0.31.97",
+    "@polkadot/types": "^0.31.102",
     "@polkadot/ui-app": "^0.21.0",
     "@polkadot/ui-signer": "^0.21.0"
   }

--- a/packages/app-staking/package.json
+++ b/packages/app-staking/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.0.0",
     "@polkadot/app-explorer": "^0.21.0",
     "@polkadot/keyring": "^0.32.12",
-    "@polkadot/storage": "^0.31.97",
+    "@polkadot/storage": "^0.31.102",
     "@polkadot/ui-app": "^0.21.0",
     "@polkadot/ui-keyring": "^0.21.0",
     "@polkadot/ui-react": "^0.21.0",

--- a/packages/app-storage/src/Queries.tsx
+++ b/packages/app-storage/src/Queries.tsx
@@ -3,7 +3,7 @@
 // of the ISC license. See the LICENSE file for details.
 
 import { BareProps } from '@polkadot/ui-app/types';
-import { StorageQuery } from './types';
+import { QueryTypes } from './types';
 
 import React from 'react';
 
@@ -11,7 +11,7 @@ import Query from './Query';
 
 type Props = BareProps & {
   onRemove: (id: number) => void,
-  value?: Array<StorageQuery>
+  value?: Array<QueryTypes>
 };
 
 export default class Queries extends React.PureComponent<Props> {

--- a/packages/app-storage/src/Selection/Modules.tsx
+++ b/packages/app-storage/src/Selection/Modules.tsx
@@ -6,17 +6,17 @@ import { TypeDef, getTypeDef } from '@polkadot/types/codec';
 import { StorageFunction } from '@polkadot/types/StorageKey';
 import { I18nProps } from '@polkadot/ui-app/types';
 import { RawParams } from '@polkadot/ui-app/Params/types';
-import { StorageQuery } from './types';
+import { PartialModuleQuery } from '../types';
 
 import React from 'react';
 import Api from '@polkadot/api-observable';
 import { Button, InputStorage, Labelled, Params } from '@polkadot/ui-app/index';
 import { isUndefined } from '@polkadot/util';
 
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
-  onAdd: (query: StorageQuery) => void
+  onAdd: (query: PartialModuleQuery) => void
 };
 
 type State = {
@@ -26,9 +26,7 @@ type State = {
   params: Array<{ type: TypeDef }>
 };
 
-let id = -1;
-
-class Selection extends React.PureComponent<Props, State> {
+class Modules extends React.PureComponent<Props, State> {
   private defaultValue: any;
   state: State;
 
@@ -49,7 +47,7 @@ class Selection extends React.PureComponent<Props, State> {
     const { isValid, params } = this.state;
 
     return (
-      <section className='storage--Selection storage--actionrow'>
+      <section className='storage--actionrow'>
         <div className='storage--actionrow-value'>
           <InputStorage
             defaultValue={this.defaultValue}
@@ -106,7 +104,6 @@ class Selection extends React.PureComponent<Props, State> {
     const { key, values } = this.state;
 
     onAdd({
-      id: ++id,
       key,
       params: values
     });
@@ -126,4 +123,4 @@ class Selection extends React.PureComponent<Props, State> {
   }
 }
 
-export default translate(Selection);
+export default translate(Modules);

--- a/packages/app-storage/src/Selection/Raw.tsx
+++ b/packages/app-storage/src/Selection/Raw.tsx
@@ -1,0 +1,81 @@
+// Copyright 2017-2018 @polkadot/app-storage authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { PartialRawQuery } from '../types';
+
+import React from 'react';
+import { Button, Input, Labelled } from '@polkadot/ui-app/index';
+
+import translate from '../translate';
+import { u8aToU8a } from '@polkadot/util';
+import { Compact } from '@polkadot/types/codec';
+
+type Props = I18nProps & {
+  onAdd: (query: PartialRawQuery) => void
+};
+
+type State = {
+  isValid: boolean,
+  key: Uint8Array
+};
+
+class Raw extends React.PureComponent<Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props);
+
+    this.state = {
+      isValid: false,
+      key: new Uint8Array([])
+    };
+  }
+
+  render () {
+    const { t } = this.props;
+    const { isValid } = this.state;
+
+    return (
+      <section className='storage--actionrow'>
+        <div className='storage--actionrow-value'>
+          <Input
+            autoFocus
+            label={t('raw.label', {
+              defaultValue: 'hex-encoded storage key'
+            })}
+            onChange={this.onChangeKey}
+          />
+        </div>
+        <Labelled className='storage--actionrow-button'>
+          <Button
+            icon='plus'
+            isDisabled={!isValid}
+            isPrimary
+            onClick={this.onAdd}
+          />
+        </Labelled>
+      </section>
+    );
+  }
+
+  private onAdd = (): void => {
+    const { onAdd } = this.props;
+    const { key } = this.state;
+
+    onAdd({ key });
+  }
+
+  private onChangeKey = (key: string): void => {
+    const u8a = u8aToU8a(key);
+    const isValid = u8a.length !== 0;
+
+    this.setState({
+      isValid,
+      key: Compact.addLengthPrefix(u8a)
+    });
+  }
+}
+
+export default translate(Raw);

--- a/packages/app-storage/src/Selection/index.tsx
+++ b/packages/app-storage/src/Selection/index.tsx
@@ -1,0 +1,88 @@
+// Copyright 2017-2018 @polkadot/app-storage authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { TabItem } from '@polkadot/ui-app/Tabs';
+import { QueryTypes, ParitalQueryTypes } from '../types';
+
+import React from 'react';
+import { Tabs } from '@polkadot/ui-app/index';
+
+import Modules from './Modules';
+import Raw from './Raw';
+import translate from '../translate';
+
+type Actions = 'modules' | 'raw';
+
+type Props = I18nProps & {
+  onAdd: (query: QueryTypes) => void
+};
+
+type State = {
+  action: Actions,
+  items: Array<TabItem>
+};
+
+const Components: { [index: string]: React.ComponentType<any> } = {
+  'modules': Modules,
+  'raw': Raw
+};
+
+let id = -1;
+
+class Selection extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
+    super(props);
+
+    const { t } = this.props;
+
+    this.state = {
+      action: 'modules',
+      items: [
+        {
+          name: 'modules',
+          text: t('select.modules', { defaultValue: 'Modules' })
+        },
+        {
+          name: 'raw',
+          text: t('select.raw', { defaultValue: 'Raw key' })
+        }
+      ]
+    };
+  }
+
+  render () {
+    const { action, items } = this.state;
+    const Component = Components[action];
+
+    return [
+      <header key='header'>
+        <Tabs
+          activeItem={action}
+          items={items}
+          onChange={this.onTabChange}
+        />
+      </header>,
+      <Component
+        key='component'
+        onAdd={this.onAdd}
+      />
+    ];
+  }
+
+  private onAdd = (query: ParitalQueryTypes) => {
+    const { onAdd } = this.props;
+
+    onAdd({
+      ...query,
+      id: ++id
+    });
+  }
+
+  private onTabChange = (action: Actions) => {
+    this.setState({ action });
+  }
+}
+
+export default translate(Selection);

--- a/packages/app-storage/src/index.tsx
+++ b/packages/app-storage/src/index.tsx
@@ -3,7 +3,7 @@
 // of the ISC license. See the LICENSE file for details.
 
 import { I18nProps } from '@polkadot/ui-app/types';
-import { StorageQuery } from './types';
+import { QueryTypes } from './types';
 
 import './index.css';
 
@@ -18,7 +18,7 @@ type Props = I18nProps & {
 };
 
 type State = {
-  queue: Array<StorageQuery>
+  queue: Array<QueryTypes>
 };
 
 class StorageApp extends React.PureComponent<Props, State> {
@@ -40,7 +40,7 @@ class StorageApp extends React.PureComponent<Props, State> {
     );
   }
 
-  private onAdd = (query: StorageQuery): void => {
+  private onAdd = (query: QueryTypes): void => {
     this.setState(
       (prevState: State): State => ({
         queue: [query].concat(prevState.queue)

--- a/packages/app-storage/src/types.d.ts
+++ b/packages/app-storage/src/types.d.ts
@@ -5,8 +5,23 @@
 import { StorageFunction } from '@polkadot/types/StorageKey';
 import { RawParams } from '@polkadot/ui-app/Params/types';
 
-export type StorageQuery = {
-  id: number,
+type IdQuery = {
+  id: number
+}
+
+export type PartialModuleQuery = {
   key: StorageFunction,
   params: RawParams
 }
+
+export type StorageModuleQuery = PartialModuleQuery & IdQuery;
+
+export type PartialRawQuery = {
+  key: Uint8Array
+}
+
+export type StorageRawQuery = PartialRawQuery & IdQuery;
+
+export type QueryTypes = StorageModuleQuery | StorageRawQuery;
+
+export type ParitalQueryTypes = PartialModuleQuery | PartialRawQuery;

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/types": "^0.31.97",
+    "@polkadot/types": "^0.31.102",
     "@polkadot/ui-keyring": "^0.21.0",
     "@polkadot/ui-react": "^0.21.0",
     "@polkadot/ui-react-rx": "^0.21.0",

--- a/packages/ui-app/src/Params/Param/StorageKeyValue.tsx
+++ b/packages/ui-app/src/Params/Param/StorageKeyValue.tsx
@@ -74,12 +74,12 @@ export default class StorageKeyValue extends React.PureComponent<Props, State> {
       u8a = new Uint8Array([]);
     }
 
-    const isValidLength = length !== -1
+    const isValid = length !== -1
       ? u8a.length === length
       : u8a.length !== 0;
 
     return {
-      isValid: isValidLength,
+      isValid,
       u8a: Compact.addLengthPrefix(u8a)
     };
   }

--- a/packages/ui-app/src/Params/valueToText.tsx
+++ b/packages/ui-app/src/Params/valueToText.tsx
@@ -5,7 +5,7 @@
 import './Params.css';
 
 import React from 'react';
-import { isNull, isUndefined } from '@polkadot/util';
+import { isNull, isUndefined, u8aToHex } from '@polkadot/util';
 // import { decodeAddress } from '@polkadot/keyring';
 // import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
 // import numberFormat from '@polkadot/ui-react-rx/util/numberFormat';
@@ -151,7 +151,12 @@ function valueToText (type: string, value: any, swallowError: boolean = true): R
 
   return isNull(value) || isUndefined(value)
     ? unknown
-    : div({}, value.toString());
+    : div(
+      {},
+      ['Bytes', 'Data'].includes(type)
+        ? u8aToHex(value.toU8a(true), 512)
+        : value.toString()
+    );
 }
 
 export default valueToText;

--- a/packages/ui-react-rx/package.json
+++ b/packages/ui-react-rx/package.json
@@ -31,9 +31,9 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-react-rx#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@polkadot/api-observable": "^0.31.97",
-    "@polkadot/rpc-rx": "^0.31.97",
-    "@polkadot/types": "^0.31.97",
+    "@polkadot/api-observable": "^0.31.102",
+    "@polkadot/rpc-rx": "^0.31.102",
+    "@polkadot/types": "^0.31.102",
     "rxjs-compat": "^6.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,16 +1344,16 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
-"@polkadot/api-observable@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-observable/-/api-observable-0.31.97.tgz#cb19c4fd858e548a31b95c3016ff92f5b36b2f8f"
-  integrity sha512-gtJ94gF2QGF7j2GneZ1nCQWPA60g38PEcsDoQWQptFc/5FOnNCiJ6m/qA5pf4DDdJ1sUrY6O01iSSt8k1IfBEA==
+"@polkadot/api-observable@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-observable/-/api-observable-0.31.102.tgz#fc318c50848013a71927cedfcad6f051c0a2aa7c"
+  integrity sha512-gATgwaAa+zYRHHe3+SxnQdmpMgw2DMHlYD2y9GjZLOMAJqmCjNUeV4dVk1jk/emSUZPnHFWbdS7z9XCpYmqF5g==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    "@polkadot/extrinsics" "^0.31.97"
-    "@polkadot/rpc-core" "^0.31.97"
-    "@polkadot/rpc-provider" "^0.31.97"
-    "@polkadot/storage" "^0.31.97"
+    "@polkadot/extrinsics" "^0.31.102"
+    "@polkadot/rpc-core" "^0.31.102"
+    "@polkadot/rpc-provider" "^0.31.102"
+    "@polkadot/storage" "^0.31.102"
     "@types/rx" "^4.1.1"
     rxjs "^6.3.3"
 
@@ -1433,18 +1433,18 @@
     typedoc-plugin-markdown "^1.1.17"
     typescript "^3.1.3"
 
-"@polkadot/extrinsics@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.31.97.tgz#44b7fcb42cab272f70b805fff1cf82fc8bd6214c"
-  integrity sha512-SxZDMUn6ArPSUyuX6OpWR5NT1S3YYKuj+e7knQ7/sy0oh/CAc5IE7PyCFd4yPxmoKDAdmKnVU42fbIhOJHEqRQ==
+"@polkadot/extrinsics@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.31.102.tgz#7198e0c4967ff88f4832e6b982bbeb68e1996efe"
+  integrity sha512-G6KBOWkTtFiLjP4Kg+yw9u+s585tDQyIPceXgo7P7AVEATkk50/nNqG0JrZWk23ETE9wlbJqohygX9M/PB1yfA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@polkadot/util" "^0.32.12"
 
-"@polkadot/jsonrpc@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.31.97.tgz#9f8bb6b8d54c3e4991f6eb605ee75b349a724ca3"
-  integrity sha512-wfzhxl7NuHEFtF16p+X92Jv1WUh3MTCQ0IBSIBXFEtIsJyaInEgrl3ozxbsbpKk8/fn3iEms9ILWT4PJu8aTOw==
+"@polkadot/jsonrpc@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.31.102.tgz#d76c92debbc8c15aabe199aab111a194326b1eb7"
+  integrity sha512-bUrIr7ZCR/JfE3mNgf9m6cBmj4AYTKHSuQX2KC+qmK6jrgV6fJCJsFnIRqFMYZCH50QYAYwFLxhtJZTREx4M5w==
   dependencies:
     babel-runtime "^6.26.0"
 
@@ -1459,24 +1459,24 @@
     "@types/bs58" "^3.0.30"
     bs58 "^4.0.1"
 
-"@polkadot/rpc-core@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.31.97.tgz#ab0eb62b9559afab51d33ed0b9344c74578a11b2"
-  integrity sha512-MiBptx5VMZ7eh2nvwx06E5FVIHJLLL/R1AG6iDHoMNOGY/H8SKtzx+6Ynhrd6bO3Y7XN5pRV1rjJCdQCnI0qfg==
+"@polkadot/rpc-core@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.31.102.tgz#55bdb1909793d5a394841875fb7778dcffaf7406"
+  integrity sha512-2PaVeWPWcFIY/fojGEkVen/CSbImFcZZYEnJ+BOb5obKWXxDc7L4HM0ZtctUG/xRTR0ReECHUTA6Ah7bo38CPQ==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    "@polkadot/jsonrpc" "^0.31.97"
-    "@polkadot/rpc-provider" "^0.31.97"
+    "@polkadot/jsonrpc" "^0.31.102"
+    "@polkadot/rpc-provider" "^0.31.102"
     "@polkadot/util" "^0.32.12"
 
-"@polkadot/rpc-provider@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.31.97.tgz#de3893e60a6ccdedb9a1d61c24b5049d640179d6"
-  integrity sha512-rLASzl5lAp49MsnB+tP4xvoq0ahWrab4enU6JN3yMKRK901zhfP8Q6M+pvETPimky4DGzAVi6ls5S6Qxw2PEDA==
+"@polkadot/rpc-provider@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.31.102.tgz#4a5ad81379a5e378a3d4e753cdd2c912b0c6baad"
+  integrity sha512-60mTGl0er080Y33KVSEnMymXRONnKL6j0ToVwEKOkmSlThdRvrXaluFQVZvJeY8PoRptSWEel96FWLPmWkgkrg==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@polkadot/keyring" "^0.32.12"
-    "@polkadot/storage" "^0.31.97"
+    "@polkadot/storage" "^0.31.102"
     "@polkadot/util" "^0.32.12"
     "@polkadot/util-crypto" "^0.32.12"
     "@types/nock" "^9.3.0"
@@ -1484,25 +1484,25 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.28"
 
-"@polkadot/rpc-rx@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.31.97.tgz#7f294b44c05aa1f816ab8ac25a7660ce48692d4f"
-  integrity sha512-VXOUAq0FKEbizW76+HbA9w9/3Mqu2rq61IcH0ypGK6L7VvQJDIYv+F4KLDaeYQkWYZjaGx1RilPdqfT3fWwe7A==
+"@polkadot/rpc-rx@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.31.102.tgz#84927e0e99613982fe3fc527233b58d04d0c529f"
+  integrity sha512-wbEfHfSUMxq/jfS7Af4FRXiGfOBKUVQdh5xcQ831uxVsLEZAqoOomyhYYIhYE6lrXe5naTCCdnYYIOsCChETjg==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    "@polkadot/rpc-core" "^0.31.97"
-    "@polkadot/rpc-provider" "^0.31.97"
+    "@polkadot/rpc-core" "^0.31.102"
+    "@polkadot/rpc-provider" "^0.31.102"
     "@types/rx" "^4.1.1"
     rxjs "^6.3.3"
 
-"@polkadot/storage@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.31.97.tgz#aaa1575d967014f026db0a1a8afff1f3fa41b9c0"
-  integrity sha512-umI/0w0HiAFeTgCP9DO8618f1NJU9O/okl7gFyAPyMQPpAjabajfnnwrvYc0swZAJTy+HPWLaS5QiMSKMhDI7A==
+"@polkadot/storage@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.31.102.tgz#ba8279263091b7e148784fbb5cc06bf62a1e5596"
+  integrity sha512-JtXwjNcT2P25q6uN4RpHIHtfYcWjrLE9PlSQrNCX3/dwpUmrNY+TINag7tadKnVAELOBW0vLGilmrBNi7VKNoA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@polkadot/keyring" "^0.32.12"
-    "@polkadot/types" "^0.31.97"
+    "@polkadot/types" "^0.31.102"
     "@polkadot/util" "^0.32.12"
     "@polkadot/util-crypto" "^0.32.12"
 
@@ -1513,10 +1513,10 @@
   dependencies:
     "@types/node" "^10.12.0"
 
-"@polkadot/types@^0.31.97":
-  version "0.31.97"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.31.97.tgz#8388393bfa713db6194a07bb962d5f1ab61e60fe"
-  integrity sha512-hPkqaY8dx4VAi/PcoGeev4HTqioHIOE0jl99wCqKC4cPZ7J4n0C11ZDatLJ+nMok7rruKeDvoLaKzBA/HueMqg==
+"@polkadot/types@^0.31.102":
+  version "0.31.102"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.31.102.tgz#bf1676480220fe28abb5d37f71672ecc528b63d5"
+  integrity sha512-Rf7dx/E6oxChliMl2kcZv03aHWIGwGy2P8fgXJFhT2edrU5KRwW8S5HzeoJcGnVjWvGjnD/lK90yKOwuisjJZw==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@polkadot/keyring" "^0.32.12"


### PR DESCRIPTION
<img width="1440" alt="polkadot apps portal 2018-11-07 21-19-38" src="https://user-images.githubusercontent.com/1424473/48158771-ab04de80-e2d3-11e8-8a38-f82855ac1ae2.png">

Needed for https://github.com/polkadot-js/apps/issues/381 (Contracts introduce their own storage keys, thse are not part of the runtime, so now known there or in metadata - it is specific on a per-contract basis)