### PR TITLE
[next] Handle byte display consistently

### DIFF
--- a/packages/ui-app/src/Params/Param/BaseBytes.tsx
+++ b/packages/ui-app/src/Params/Param/BaseBytes.tsx
@@ -5,7 +5,7 @@
 import { Props as BaseProps, Size } from '../types';
 
 import React from 'react';
-import { U8a, Compact } from '@polkadot/types/codec';
+import { Compact } from '@polkadot/types/codec';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 
 import Input from '../../Input';
@@ -26,11 +26,7 @@ export default class BaseBytes extends React.PureComponent<Props> {
   render () {
     const { children, className, defaultValue: { value }, isDisabled, isError, label, size = 'full', style, withLabel } = this.props;
     const defaultValue = value
-      ? (
-        value instanceof U8a
-          ? value.toHex()
-          : u8aToHex(value as Uint8Array, isDisabled ? 256 : -1)
-      )
+      ? u8aToHex(value as Uint8Array, isDisabled ? 256 : -1)
       : undefined;
 
     return (
@@ -67,14 +63,12 @@ export default class BaseBytes extends React.PureComponent<Props> {
       value = new Uint8Array([]);
     }
 
-    let isValid = length !== -1
+    let isValid = validate(value) && length !== -1
       ? value.length === length
       : value.length !== 0;
 
     if (withLength && isValid) {
-      const [offset, readLength] = Compact.decodeU8a(value, 32);
-
-      isValid = readLength.eqn(value.length - offset) && validate(value);
+      value = Compact.addLengthPrefix(value);
     }
 
     onChange && onChange({

--- a/packages/ui-signer/src/Queue.tsx
+++ b/packages/ui-signer/src/Queue.tsx
@@ -59,10 +59,10 @@ export default class Queue extends React.Component<Props, State> {
   private isDuplicateNonce = (value: QueueTx$Extrinsic | QueueTx$Rpc | QueueTx): boolean => {
     const { queue } = this.state;
 
-    return queue.filter(item => {
-      return item.accountNonce && value.accountNonce
-               ? item.accountNonce.eq(value.accountNonce) && item.accountId === value.accountId
-               : null;
+    return queue.filter((item) => {
+      return !STATUS_COMPLETE.includes(item.status) && item.accountNonce && value.accountNonce
+        ? item.accountNonce.eq(value.accountNonce) && item.accountId === value.accountId
+        : null;
     }).length > 0;
   }
 


### PR DESCRIPTION
- Handle hex inputs as not having the hex prefix 
- Cancelled queue items (signer) should not block subsequent queing
- Part of https://github.com/polkadot-js/apps/issues/460.