### PR TITLE
#459 Add spread and copy buttons for substrate.code query

### DIFF
--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -26,8 +26,7 @@ type ComponentProps = {};
 
 type State = {
   inputs: Array<any>, // node?
-  Component: React.ComponentType<ComponentProps>,
-  showFullResultContent?: boolean
+  Component: React.ComponentType<ComponentProps>
 };
 
 type CacheInstance = {

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -14,7 +14,7 @@ import { withObservableDiv } from '@polkadot/ui-react-rx/with/index';
 import { isU8a, u8aToHex, u8aToString } from '@polkadot/util';
 
 import translate from './translate';
-import { Bytes } from '@polkadot/types';
+import { ReactNodeArray } from 'prop-types';
 
 type Props = I18nProps & {
   onRemove: (id: number) => void,
@@ -102,9 +102,9 @@ class Query extends React.PureComponent<Props, State> {
   }
 
   private renderButtons () {
-
-    const specificFunctionalButtons = [];
-    const defaultButton =
+    const { key } = this.props.value as StorageModuleQuery;
+    const buttons = [] as ReactNodeArray;
+    const closeButton =
       <Button
         icon='close'
         isNegative
@@ -122,11 +122,11 @@ class Query extends React.PureComponent<Props, State> {
         text='copy'
       />;
 
-    if (this.props.value.key.meta.type.raw == 'Bytes') {
-      specificFunctionalButtons.push(spreadButton, copyButton);
+    if (key.meta.type.toString() === 'Bytes') {
+      buttons.push(spreadButton, copyButton);
     }
-    // array spread not usable ?
-    return [].concat(specificFunctionalButtons, defaultButton);
+
+    return buttons.concat([ closeButton ]);
   }
 
   private renderInputs () {
@@ -137,7 +137,7 @@ class Query extends React.PureComponent<Props, State> {
         <div className='ui--Param-text name'>:</div>
       );
     }
-
+    console.log(inputs);
     return [
       <div key='open' className='ui--Param-text name'>(</div>,
       inputs,

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -100,8 +100,8 @@ class Query extends React.PureComponent<Props, State> {
     );
   }
 
-  private renderButtons() {
-    const { value: { key: {method, section} } } = this.props;
+  private renderButtons () {
+    const { value: { key: { method, section } } } = this.props;
 
     const specificFunctionalButtons = [];
     const defaultButton =
@@ -109,20 +109,20 @@ class Query extends React.PureComponent<Props, State> {
         icon='close'
         isNegative
         onClick={this.onRemove}
-      />
+      />;
     const spreadButton =
       /* needs an spread content action (wasm byte code)*/
       <Button
-        text="spread"
-      />
+        text='spread'
+      />;
 
     const copyButton =
       /* needs an copy content action (wasm byte code) */
       <Button
-        text="copy"
-      />
+        text='copy'
+      />;
 
-    if (section === "substrate" && method === "code") {
+    if (section === 'substrate' && method === 'code') {
       specificFunctionalButtons.push(spreadButton, copyButton);
     }
     // array spread not usable ?

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -14,7 +14,6 @@ import { withObservableDiv } from '@polkadot/ui-react-rx/with/index';
 import { isU8a, u8aToHex, u8aToString } from '@polkadot/util';
 
 import translate from './translate';
-import { ReactNodeArray } from 'prop-types';
 import { RenderFn, DefaultProps, ComponentRenderer } from '@polkadot/ui-react-rx/with/types';
 
 type Props = I18nProps & {
@@ -30,7 +29,7 @@ type State = {
 };
 
 type CacheInstance = {
-  component: React.ComponentType<any>,
+  Component: React.ComponentType<any>,
   render: RenderFn,
   refresh: (swallowErrors: boolean, contentShorten: boolean) => React.ComponentType<any>
 };
@@ -67,7 +66,7 @@ class Query extends React.PureComponent<Props, State> {
 
   static createComponentCacheInstance (type: string, pluggedComponent: React.ComponentType<any>, defaultProps: DefaultProps<any>, fetchAndRenderHelper: ComponentRenderer<any>) {
     return {
-      component: pluggedComponent,
+      Component: pluggedComponent,
       // In order to replace the default component during runtime we can provide a RenderFn to create a new 'plugged' component
       render: (createComponent: RenderFn) => {
         return fetchAndRenderHelper(
@@ -86,7 +85,7 @@ class Query extends React.PureComponent<Props, State> {
   }
 
   static getDerivedStateFromProps ({ value }: Props, prevState: State): State | null {
-    const Component = Query.getCachedComponent(value).component;
+    const Component = Query.getCachedComponent(value).Component;
     const inputs = isU8a(value.key)
       ? []
       // FIXME We need to render the actual key params
@@ -137,7 +136,7 @@ class Query extends React.PureComponent<Props, State> {
   private renderButtons () {
     const { id, key } = this.props.value as StorageModuleQuery;
 
-    const buttons = [] as ReactNodeArray;
+    const buttons = [] as Array<React.ReactNode>;
     const closeButton =
       <Button
         icon='close'
@@ -194,10 +193,10 @@ class Query extends React.PureComponent<Props, State> {
   }
 
   private refreshCachedComponent (id: number, swallowErrors: boolean, contentShorten: boolean) {
-    cache[id].component = cache[id].refresh(swallowErrors, contentShorten);
+    cache[id].Component = cache[id].refresh(swallowErrors, contentShorten);
     this.setState({
       ...this.state,
-      Component: cache[id].component
+      Component: cache[id].Component
     });
   }
 

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -93,15 +93,40 @@ class Query extends React.PureComponent<Props, State> {
         >
           <Component />
         </Labelled>
-        <Labelled className='storage--actionrow-button'>
-          <Button
-            icon='close'
-            isNegative
-            onClick={this.onRemove}
-          />
+        <Labelled className='.storage--queryrow-button'>
+          {this.renderButtons()}
         </Labelled>
       </div>
     );
+  }
+
+  private renderButtons() {
+    const { value: { key: {method, section} } } = this.props;
+
+    const specificFunctionalButtons = [];
+    const defaultButton =
+      <Button
+        icon='close'
+        isNegative
+        onClick={this.onRemove}
+      />
+    const spreadButton =
+      /* needs an spread content action (wasm byte code)*/
+      <Button
+        text="spread"
+      />
+
+    const copyButton =
+      /* needs an copy content action (wasm byte code) */
+      <Button
+        text="copy"
+      />
+
+    if (section === "substrate" && method === "code") {
+      specificFunctionalButtons.push(spreadButton, copyButton);
+    }
+    // array spread not usable ?
+    return [].concat(specificFunctionalButtons, defaultButton);
   }
 
   private renderInputs () {

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -50,11 +50,11 @@ class Query extends React.PureComponent<Props, State> {
         : 'Data';
       const defaultProps = { className: 'ui--output' };
 
-      /* render function to create an element for the query results which is plugged to the api */
+      // render function to create an element for the query results which is plugged to the api
       const fetchAndRenderHelper = withObservableDiv('rawStorage', { params: [key, ...values] });
       const pluggedComponent = fetchAndRenderHelper(
         (value: any) => {
-          /* By default we render a simple div node component with the query results in it */
+          // By default we render a simple div node component with the query results in it
           return valueToText(type, value, true, true);
         },
         defaultProps
@@ -68,14 +68,14 @@ class Query extends React.PureComponent<Props, State> {
   static createComponentCacheInstance (type: string, pluggedComponent: React.ComponentType<any>, defaultProps: DefaultProps<any>, fetchAndRenderHelper: ComponentRenderer<any>) {
     return {
       component: pluggedComponent,
-      /* In order to replace the default component during runtime we can provide a RenderFn to create a new 'plugged' component */
+      // In order to replace the default component during runtime we can provide a RenderFn to create a new 'plugged' component
       render: (createComponent: RenderFn) => {
         return fetchAndRenderHelper(
           createComponent,
           defaultProps
         );
       },
-      /* In order to modify the parameters which are used to render the default component, we can use this method */
+      // In order to modify the parameters which are used to render the default component, we can use this method
       refresh: (swallowErrors: boolean, contentShorten: boolean) => {
         return fetchAndRenderHelper(
           (value: any) => valueToText(type, value, swallowErrors, contentShorten),
@@ -127,7 +127,7 @@ class Query extends React.PureComponent<Props, State> {
         >
           <Component />
         </Labelled>
-        <Labelled className='.storage--queryrow-button'>
+        <Labelled>
           {this.renderButtons()}
         </Labelled>
       </div>

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -14,6 +14,7 @@ import { withObservableDiv } from '@polkadot/ui-react-rx/with/index';
 import { isU8a, u8aToHex, u8aToString } from '@polkadot/util';
 
 import translate from './translate';
+import { Bytes } from '@polkadot/types';
 
 type Props = I18nProps & {
   onRemove: (id: number) => void,
@@ -101,7 +102,6 @@ class Query extends React.PureComponent<Props, State> {
   }
 
   private renderButtons () {
-    const { value: { key: { method, section } } } = this.props;
 
     const specificFunctionalButtons = [];
     const defaultButton =
@@ -122,7 +122,7 @@ class Query extends React.PureComponent<Props, State> {
         text='copy'
       />;
 
-    if (section === 'substrate' && method === 'code') {
+    if (this.props.value.key.meta.type.raw == 'Bytes') {
       specificFunctionalButtons.push(spreadButton, copyButton);
     }
     // array spread not usable ?

--- a/packages/app-storage/src/index.css
+++ b/packages/app-storage/src/index.css
@@ -34,6 +34,10 @@
   min-width: 0;
 }
 
+.storage--actionrow-value .ui--output {
+  word-break: break-all;
+}
+
 .storage--actionrow-button {
   flex: 0;
   padding: 0 0.25rem;

--- a/packages/app-storage/src/index.css
+++ b/packages/app-storage/src/index.css
@@ -39,11 +39,6 @@
   padding: 0 0.25rem;
 }
 
-.storage--queryrow-button {
-  flex: 1;
-  padding: 0 0.25rem;
-}
-
 .storage--Queries .storage--actionrow-button .ui.label {
   font-size: 1rem;
   line-height: 1.714rem;

--- a/packages/app-storage/src/index.css
+++ b/packages/app-storage/src/index.css
@@ -39,6 +39,11 @@
   padding: 0 0.25rem;
 }
 
+.storage--queryrow-button {
+  flex: 1;
+  padding: 0 0.25rem;
+}
+
 .storage--Queries .storage--actionrow-button .ui.label {
   font-size: 1rem;
   line-height: 1.714rem;

--- a/packages/ui-app/src/Params/valueToText.tsx
+++ b/packages/ui-app/src/Params/valueToText.tsx
@@ -154,9 +154,9 @@ function valueToText (type: string, value: any, swallowError: boolean = true, co
     : div(
       {},
       ['Bytes', 'Data'].includes(type)
-        ? u8aToHex(value.toU8a(true), contentShorten ? 512 : value.length)
+        ? u8aToHex(value.toU8a(true), contentShorten ? 512 : -1)
         : value.toString()
-    );
+    )
 }
 
 export default valueToText;

--- a/packages/ui-app/src/Params/valueToText.tsx
+++ b/packages/ui-app/src/Params/valueToText.tsx
@@ -156,7 +156,7 @@ function valueToText (type: string, value: any, swallowError: boolean = true, co
       ['Bytes', 'Data'].includes(type)
         ? u8aToHex(value.toU8a(true), contentShorten ? 512 : -1)
         : value.toString()
-    )
+    );
 }
 
 export default valueToText;

--- a/packages/ui-app/src/Params/valueToText.tsx
+++ b/packages/ui-app/src/Params/valueToText.tsx
@@ -106,7 +106,7 @@ function div ({ key, className }: DivProps, ...values: Array<React.ReactNode>): 
 //   );
 // }
 
-function valueToText (type: string, value: any, swallowError: boolean = true): React.ReactNode {
+function valueToText (type: string, value: any, swallowError: boolean = true, contentShorten: boolean = true): React.ReactNode {
   // try {
   //   if (type === 'bool') {
   //     return div({}, value ? 'Yes' : 'No');
@@ -154,7 +154,7 @@ function valueToText (type: string, value: any, swallowError: boolean = true): R
     : div(
       {},
       ['Bytes', 'Data'].includes(type)
-        ? u8aToHex(value.toU8a(true), 512)
+        ? u8aToHex(value.toU8a(true), contentShorten ? 512 : value.length)
         : value.toString()
     );
 }


### PR DESCRIPTION
Hey there,

I implemented the spread and copy buttons for the substrate.code query..
The buttons have yet no functionality because I don't understand how the queries functionality is wired. I saw some code and modules which handle this functionality and ended there: https://github.com/polkadot-js/api/blob/master/packages/type-storage/src/substrate.ts

So yes, this would be my 'first revision' approach to this issue.

Greetings,

Robin

@tomusdrw  