### PR TITLE
[next] Proper license naming for identicon

### DIFF
--- a/packages/ui-identicon/package.json
+++ b/packages/ui-identicon/package.json
@@ -12,7 +12,7 @@
   "maintainers": [
     "Jaco Greeff <jacogr@gmail.com>"
   ],
-  "license": "APL2",
+  "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "@polkadot/keyring": "^0.33.7",

--- a/packages/ui-identicon/src/Demo.tsx
+++ b/packages/ui-identicon/src/Demo.tsx
@@ -1,6 +1,6 @@
 // Copyright 2017-2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 import React from 'react';
 import { encodeAddress } from '@polkadot/keyring';

--- a/packages/ui-identicon/src/Empty.tsx
+++ b/packages/ui-identicon/src/Empty.tsx
@@ -1,6 +1,6 @@
 // Copyright 2017-2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Props } from './types';
 

--- a/packages/ui-identicon/src/IdentityIcon.css
+++ b/packages/ui-identicon/src/IdentityIcon.css
@@ -1,6 +1,6 @@
 /* Copyright 2017-2018 @polkadot/ui-identicon authors & contributors
 /* This software may be modified and distributed under the terms
-/* of the APL2 license. See the LICENSE file for details. */
+/* of the Apache-2.0 license. See the LICENSE file for details. */
 
 .ui--IdentityIcon {
   cursor: copy;

--- a/packages/ui-identicon/src/Polkadot.tsx
+++ b/packages/ui-identicon/src/Polkadot.tsx
@@ -1,7 +1,7 @@
 // Copyright 2018 Paritytech via paritytech/oo7/polkadot-identicon
 // Copyright 2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 // This has been converted from the original version that can be found at
 //

--- a/packages/ui-identicon/src/Substrate.tsx
+++ b/packages/ui-identicon/src/Substrate.tsx
@@ -1,6 +1,6 @@
 // Copyright 2017-2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Props } from './types';
 

--- a/packages/ui-identicon/src/index.tsx
+++ b/packages/ui-identicon/src/index.tsx
@@ -1,6 +1,6 @@
 // Copyright 2017-2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Prefix } from '@polkadot/keyring/address/types';
 import { IdentityProps as Props } from './types';

--- a/packages/ui-identicon/src/types.ts
+++ b/packages/ui-identicon/src/types.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 @polkadot/ui-identicon authors & contributors
 // This software may be modified and distributed under the terms
-// of the APL2 license. See the LICENSE file for details.
+// of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Prefix } from '@polkadot/keyring/address/types';
 


### PR DESCRIPTION
APL2 -> Apache-2.0