### PR TITLE
Logs render Tuples as Params

### DIFF
--- a/packages/app-explorer/src/BlockByHash/Logs.tsx
+++ b/packages/app-explorer/src/BlockByHash/Logs.tsx
@@ -5,7 +5,7 @@
 import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
-import { Struct, Vector, getTypeDef } from '@polkadot/types/codec';
+import { Struct, Tuple, Vector, getTypeDef } from '@polkadot/types/codec';
 import { DigestItem } from '@polkadot/types/Digest';
 import { Params } from '@polkadot/ui-app/index';
 
@@ -39,28 +39,11 @@ class Logs extends React.PureComponent<Props> {
     let content: React.ReactNode;
 
     if (item.value instanceof Struct) {
-      const types: { [index: string]: string } = item.value.Type;
-
-      const params = Object.keys(types).map((name) => ({
-        name,
-        type: getTypeDef(types[name])
-      }));
-      const values = item.value.toArray().map((value) => ({
-        isValid: true,
-        value
-      }));
-
-      content = (
-        <Params
-          isDisabled
-          params={params}
-          values={values}
-        />
-      );
+      content = this.formatStruct(item.value);
+    } else if (item.value instanceof Tuple) {
+      content = this.formatTuple(item.value);
     } else if (item.value instanceof Vector) {
-      content = item.value.map((entry, index) => (
-        <span key={index}>{entry.toString()}</span>
-      ));
+      content = this.formatVector(item.value);
     } else {
       content = item.value.toString().split(',').join(', ');
     }
@@ -82,6 +65,65 @@ class Logs extends React.PureComponent<Props> {
           </div>
         </article>
       </div>
+    );
+  }
+
+  private formatStruct (struct: Struct) {
+    const types: { [index: string]: string } = struct.Type;
+    const params = Object.keys(types).map((name) => ({
+      name,
+      type: getTypeDef(types[name])
+    }));
+    const values = struct.toArray().map((value) => ({
+      isValid: true,
+      value
+    }));
+
+    return (
+      <Params
+        isDisabled
+        params={params}
+        values={values}
+      />
+    );
+  }
+
+  private formatTuple (tuple: Tuple) {
+    const types = tuple.Types;
+    const params = types.map((type) => ({
+      type: getTypeDef(type)
+    }));
+    const values = tuple.toArray().map((value) => ({
+      isValid: true,
+      value
+    }));
+
+    return (
+      <Params
+        isDisabled
+        params={params}
+        values={values}
+      />
+    );
+  }
+
+  private formatVector (vector: Vector<any>) {
+    const type = getTypeDef(vector.Type);
+    const values = vector.toArray().map((value) => ({
+      isValid: true,
+      value
+    }));
+    const params = values.map((_, index) => ({
+      name: `${index}`,
+      type
+    }));
+
+    return (
+      <Params
+        isDisabled
+        params={params}
+        values={values}
+      />
     );
   }
 }

--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -96,8 +96,8 @@ export default class Input extends React.PureComponent<Props, State> {
           autoFocus={autoFocus}
           className={
             isEditable
-              ? 'edit icon'
-              : ''
+              ? 'ui--Input edit icon'
+              : 'ui--Input'
           }
           defaultValue={
             isUndefined(value)

--- a/packages/ui-app/src/Params/Param/Unknown.tsx
+++ b/packages/ui-app/src/Params/Param/Unknown.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import Static from '../../Static';
 import translate from '../../translate';
+import Bare from './Bare';
 import BaseBytes from './BaseBytes';
 
 type Props = BareProps & WithNamespaces & {
@@ -24,12 +25,18 @@ class Unknown extends React.PureComponent<Props> {
       const value = defaultValue && defaultValue.value && defaultValue.value.toString();
 
       return (
-        <Static
-          label={label}
-          value={value || t('unknown.empty', {
-            defaultValue: 'empty'
-          })}
-        />
+        <Bare
+          className={className}
+          style={style}
+        >
+          <Static
+            className='full'
+            label={label}
+            value={value || t('unknown.empty', {
+              defaultValue: 'empty'
+            })}
+          />
+        </Bare>
       );
     }
 

--- a/packages/ui-app/src/Params/Param/findComponent.ts
+++ b/packages/ui-app/src/Params/Param/findComponent.ts
@@ -74,5 +74,7 @@ export default function findComponent (def: TypeDef, overrides: ComponentMap = {
     }
   })(def);
 
+  console.error('type', type);
+
   return overrides[type] || components[type] || Unknown;
 }

--- a/packages/ui-app/src/Params/Param/index.tsx
+++ b/packages/ui-app/src/Params/Param/index.tsx
@@ -43,6 +43,8 @@ class ParamComponent extends React.PureComponent<Props, State> {
 
     const { className, defaultValue, isDisabled, name, onChange, style, type } = this.props;
 
+    console.error('type', type, Component.name);
+
     return (
       <Component
         className={classes('ui--Param', className)}

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -184,6 +184,18 @@ header .ui--Button-Group {
   margin-left: 0.25rem !important;
 }
 
+.ui--Input {
+  &.disabled {
+    overflow: hidden;
+
+    input {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
 .ui--InputFile {
   align-items: center;
   background: #fff;


### PR DESCRIPTION
Part of #548 

<img width="450" alt="polkadot apps portal 2018-12-31 14-59-30" src="https://user-images.githubusercontent.com/1424473/50561625-b4775980-0d0c-11e9-979d-86b7b2048a9c.png">
