### PR TITLE
Allow networkId from settings defaults (Alex & CC spec overrides)

### DIFF
--- a/packages/app-rpc/package.json
+++ b/packages/app-rpc/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-keyring": "^0.24.27",
+    "@polkadot/ui-keyring": "^0.24.29",
     "@polkadot/ui-signer": "^0.21.20"
   }
 }

--- a/packages/app-settings/package.json
+++ b/packages/app-settings/package.json
@@ -13,6 +13,6 @@
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.21.20",
     "@polkadot/ui-react-rx": "^0.21.20",
-    "@polkadot/ui-settings": "^0.24.27"
+    "@polkadot/ui-settings": "^0.24.29"
   }
 }

--- a/packages/app-staking/package.json
+++ b/packages/app-staking/package.json
@@ -15,7 +15,7 @@
     "@polkadot/keyring": "^0.33.30",
     "@polkadot/storage": "^0.38.1",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-keyring": "^0.24.27",
+    "@polkadot/ui-keyring": "^0.24.29",
     "@polkadot/ui-react-rx": "^0.21.20"
   }
 }

--- a/packages/app-toolbox/package.json
+++ b/packages/app-toolbox/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-keyring": "^0.24.27"
+    "@polkadot/ui-keyring": "^0.24.29"
   }
 }

--- a/packages/app-transfer/package.json
+++ b/packages/app-transfer/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-keyring": "^0.24.27",
+    "@polkadot/ui-keyring": "^0.24.29",
     "@polkadot/ui-react-rx": "^0.21.20"
   }
 }

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -26,7 +26,7 @@
     "@polkadot/app-transfer": "^0.21.20",
     "@polkadot/app-vanitygen": "^0.21.20",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-assets": "^0.24.27",
+    "@polkadot/ui-assets": "^0.24.29",
     "@polkadot/ui-signer": "^0.21.20"
   }
 }

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/types": "^0.38.1",
-    "@polkadot/ui-identicon": "^0.24.27",
-    "@polkadot/ui-keyring": "^0.24.27",
+    "@polkadot/ui-identicon": "^0.24.29",
+    "@polkadot/ui-keyring": "^0.24.29",
     "@polkadot/ui-react-rx": "^0.21.20",
-    "@polkadot/ui-settings": "^0.24.27",
+    "@polkadot/ui-settings": "^0.24.29",
     "@types/chart.js": "^2.7.42",
     "@types/i18next": "^12.1.0",
     "@types/i18next-browser-languagedetector": "^2.0.1",

--- a/packages/ui-react-rx/src/Api/index.tsx
+++ b/packages/ui-react-rx/src/Api/index.tsx
@@ -84,7 +84,8 @@ export default class ApiWrapper extends React.PureComponent<Props, State> {
       ? value.toString()
       : null;
     const found = settings.availableChains.find(({ name }) => name === chain) || {
-      networkId: 42,
+      // default should be 42 here, see setAdressPrefix below and change with below
+      networkId: undefined, // 42
       tokenDecimals: 0,
       tokenSymbol: undefined
     };
@@ -94,8 +95,9 @@ export default class ApiWrapper extends React.PureComponent<Props, State> {
     balanceFormat.setDefaultDecimals(properties.get('tokenDecimals') || found.tokenDecimals);
     InputNumber.setUnit(properties.get('tokenSymbol') || found.tokenSymbol);
 
-    // setup keyringonly after prefix has been set
-    keyring.setAddressPrefix(properties.get('networkId') || found.networkId as any);
+    // setup keyring only after prefix has been set. The networkId is handled slightly differently here
+    // to allow overrides by settings first - revert to normal above when we get rid of invalid specs
+    keyring.setAddressPrefix(found.networkId as any || properties.get('networkId') || 42);
     keyring.setDevMode(isTestChain(chain || ''));
     keyring.loadAll();
 

--- a/packages/ui-signer/package.json
+++ b/packages/ui-signer/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.21.20",
-    "@polkadot/ui-keyring": "^0.24.27"
+    "@polkadot/ui-keyring": "^0.24.29"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,31 +1549,31 @@
     "@polkadot/util" "^0.33.30"
     core-js "^2.6.1"
 
-"@polkadot/ui-assets@^0.24.27":
-  version "0.24.27"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.24.27.tgz#d896353169c7ee55facf32997414fcb47fbb30b1"
-  integrity sha512-LT6jK45f+u/djpH6TH4WuI1BZg/uFfjdbiOvYFQwEv71BOnKQnfSog5KBxDC9TRU29dorup7cwlzvwyf5c5/xA==
+"@polkadot/ui-assets@^0.24.29":
+  version "0.24.29"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.24.29.tgz#83eafa8876cc86a8d9831eabd12fb6fbd2e9f588"
+  integrity sha512-y05Ndwz+sQWn85X/+Fqcf+w1y+BfNtzHYB+GHl0LwDm3O1EnxrzUWGNLPxjYzdvGWdaJEe1mrkyZYRdVPfkiyw==
   dependencies:
     "@babel/runtime" "^7.2.0"
 
-"@polkadot/ui-identicon@^0.24.27":
-  version "0.24.27"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.24.27.tgz#6c9eaf78937bd7adac5e622333471550e0bc7a9b"
-  integrity sha512-bj9UA9G4x9Qlb5QC6ScpO3EsiCUoTFAze0jIrnOHdZYaDfZ3ZKAV5mNojDmRFNO8uRCCB0JH77TBW0Hk+xljdg==
+"@polkadot/ui-identicon@^0.24.29":
+  version "0.24.29"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.24.29.tgz#89e64b98923bed64631bf58567c9da6f6eff9ce4"
+  integrity sha512-4s6ONya1tg3cRXGXgamugq8aTukQCEK5ZwcXm4ZTKYo+RZAw1CfxOHyS7Qf408VeCRMMuLv2DSXwbDcj7GybjQ==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@polkadot/keyring" "^0.33.30"
-    "@polkadot/ui-settings" "^0.24.27"
+    "@polkadot/ui-settings" "^0.24.29"
     "@polkadot/util-crypto" "^0.33.30"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.0.0"
     react-copy-to-clipboard "^5.0.1"
 
-"@polkadot/ui-keyring@^0.24.27":
-  version "0.24.27"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.24.27.tgz#ceff451ee0c42bb35b75f73c08038844767eaf24"
-  integrity sha512-1h/qtJAm88ZngosXCxLrGLEGmMGULiy1dB10wTGZyCfkLklsloamMhNRb34LaQHV7ohnGDv9HAxV0qLGzdeOHw==
+"@polkadot/ui-keyring@^0.24.29":
+  version "0.24.29"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.24.29.tgz#933671a53f39f1b2b0810ead87fdbf23b184730e"
+  integrity sha512-ivMJP0Bj0KgDe4thtATmVYR4sDum6JKpaYxpv7xu9Ka8RMyrhN2GE9byXgpSL+NeeipuDloRCTFrFLOYBpH51A==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@polkadot/keyring" "^0.33.30"
@@ -1581,10 +1581,10 @@
     "@types/store" "^2.0.1"
     store "^2.0.12"
 
-"@polkadot/ui-settings@^0.24.27":
-  version "0.24.27"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.24.27.tgz#2f04a0b3bb328a8cc37d03ae4dc843d5760088eb"
-  integrity sha512-J1IZPsiN8jfvqhM7vSoUFdNrUsbGVcKD1xYabywH5HsEBq3UsvG3C081ncwiKoLZO5lYNEb+nWEbfm5TzhWdOw==
+"@polkadot/ui-settings@^0.24.29":
+  version "0.24.29"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.24.29.tgz#02cd5008cb95719cb7a7c16b5651146079cbe445"
+  integrity sha512-CsuaPV1c4HoWYiCfFIuzZQ5sfhZjQ6SG7fknRlh1EofI7S7t1MoWO61hY43HvhmWiBy3HeAtZOS6SqnZ8ffYWg==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@types/store" "^2.0.1"


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot/pull/68

Here we have a short-term override (from settings) to first use the networkId there - it will take some time for the updated chain specs to make the rounds.

Tested, 42 now shows for Alexander and Cherry -

<img width="1430" alt="polkadot apps portal 2019-01-09 00-06-17" src="https://user-images.githubusercontent.com/1424473/50864476-73cdaf00-13a2-11e9-8cc5-e91cc702a14d.png">
