### PR TITLE
Small fixes & tweaks

### DIFF
--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -139,8 +139,6 @@ class Transfer extends React.PureComponent<Props, State> {
         ? apiPromise.tx.balances.transfer(recipientId, amount)
         : null;
 
-      console.log('extrinsic', extrinsic);
-
       return {
         accountId,
         amount,

--- a/packages/ui-params/src/Param/findComponent.ts
+++ b/packages/ui-params/src/Param/findComponent.ts
@@ -25,7 +25,7 @@ import VoteThreshold from './VoteThreshold';
 
 const components: ComponentMap = {
   'AccountId': Account,
-  'AccountIndex': Account,
+  'AccountIndex': Amount,
   'Address': Account,
   'Balance': Balance,
   'BlockNumber': Amount,

--- a/packages/ui-params/src/initValue.ts
+++ b/packages/ui-params/src/initValue.ts
@@ -24,6 +24,7 @@ export default function getInitValue (def: TypeDef): RawParam$Value | Array<RawP
     : def.type;
 
   switch (type) {
+    case 'AccountIndex':
     case 'Balance':
     case 'BlockNumber':
     case 'Compact':
@@ -55,7 +56,6 @@ export default function getInitValue (def: TypeDef): RawParam$Value | Array<RawP
       return 0;
 
     case 'AccountId':
-    case 'AccountIndex':
     case 'Address':
     case 'Bytes':
     case 'Call':

--- a/packages/ui-signer/src/Modal.tsx
+++ b/packages/ui-signer/src/Modal.tsx
@@ -306,7 +306,11 @@ class Signer extends React.PureComponent<Props, State> {
     const { queueSetTxStatus } = this.props;
 
     try {
-      const subscription = await extrinsicCall.apply(extrinsic, [..._params, async (result: SubmittableSendResult) => {
+      const unsubscribe = await extrinsicCall.apply(extrinsic, [..._params, async (result: SubmittableSendResult) => {
+        if (!result || !result.type || !result.status) {
+          return;
+        }
+
         const status = result.type.toLowerCase() as QueueTx$Status;
 
         console.log('submitAndWatchExtrinsic: updated status ::', result);
@@ -314,11 +318,9 @@ class Signer extends React.PureComponent<Props, State> {
         queueSetTxStatus(id, status, result);
 
         if (status === 'finalised') {
-          const unsubscribe = await subscription;
-
           unsubscribe();
         }
-      }]) as PromiseSubscription;
+      }]);
     } catch (error) {
       console.error('error.message', error.message);
       queueSetTxStatus(id, 'error', {}, error);

--- a/packages/ui-signer/src/Modal.tsx
+++ b/packages/ui-signer/src/Modal.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { SubmittableSendResult } from '@polkadot/api/types';
-import { PromiseSubscription, SubmittableExtrinsic } from '@polkadot/api/promise/types';
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { ApiProps } from '@polkadot/ui-api/types';
 import { I18nProps, BareProps } from '@polkadot/ui-app/types';
 import { RpcMethod } from '@polkadot/jsonrpc/types';


### PR DESCRIPTION
- Trap invalid signAndSend results due to https://github.com/polkadot-js/api/issues/598
- Allow "look like hex" raw seeds < 32 in length (reported by @jiangfuyao)
- ui-params inputs AccountIndex as a number (should actually also allow ss58 - however the previous dropdown approach didn't work at all here)
- Remove unneeded debug log in transfer app