### PR TITLE
display params when querying chain storage

### DIFF
--- a/packages/app-storage/src/Query.css
+++ b/packages/app-storage/src/Query.css
@@ -1,0 +1,8 @@
+.query-input {
+    width:100%;
+    word-wrap:break-word;
+    text-align:left;
+    border:1px gray dotted;
+    margin:.25rem;
+    padding:.75rem 1rem;
+}

--- a/packages/app-storage/src/Query.css
+++ b/packages/app-storage/src/Query.css
@@ -1,4 +1,4 @@
-.query-input {
+.query-input .ui--Param-text {
     width:100%;
     word-wrap:break-word;
     text-align:left;

--- a/packages/app-storage/src/Query.tsx
+++ b/packages/app-storage/src/Query.tsx
@@ -135,14 +135,6 @@ class Query extends React.PureComponent<Props, State> {
     );
   }
 
-  private typeIsTuple (type: string): boolean {
-    return type.charAt(0) === '(' && type.charAt(type.length - 1) === ')';
-  }
-
-  private breakDownTuple (type: string): Array<any> {
-    return type.substring(1, type.length - 1).split(',');
-  }
-
   private renderInputs () {
     const value = this.props.value;
     const { key } = value;
@@ -157,20 +149,6 @@ class Query extends React.PureComponent<Props, State> {
           {
             params.map((obj) => {
               // check if the type name references a tuple, e.g. "(Hash, AccountId)"
-              if (this.typeIsTuple(type)) {
-                let types = this.breakDownTuple(type);
-                // if so run valueToText on each element of the tuple
-                let output = [];
-                for (let i = 0; i < types.length; i++) {
-                  output[i] = (
-                    <div className='query-input'>
-                      {valueToText(types[i], (obj.value as Array<any>)[i])}
-                    </div>
-                  );
-                }
-                return output;
-              }
-
               return (
                 <div className='query-input'>
                 {

--- a/packages/ui-params/src/Params.css
+++ b/packages/ui-params/src/Params.css
@@ -29,6 +29,10 @@
   vertical-align: middle;
 }
 
+.ui--Param-text.breakword {
+  word-wrap: break-word;
+}
+
 .ui--Param-text.nowrap {
   white-space: nowrap;
 }

--- a/packages/ui-params/src/valueToText.tsx
+++ b/packages/ui-params/src/valueToText.tsx
@@ -29,7 +29,7 @@ type DivProps = {
 function div ({ key, className }: DivProps, ...values: Array<React.ReactNode>): React.ReactNode {
   return (
     <div
-      className={classes('ui--Param-text.breakword', className)}
+      className={classes('ui--Param-text breakword', className)}
       key={key}
     >
       {values}
@@ -108,6 +108,14 @@ function div ({ key, className }: DivProps, ...values: Array<React.ReactNode>): 
 //   );
 // }
 
+function typeIsTuple (type: string): boolean {
+  return type.charAt(0) === '(' && type.charAt(type.length - 1) === ')';
+}
+
+function breakDownTuple (type: string): Array<any> {
+  return type.substring(1, type.length - 1).split(',');
+}
+
 function valueToText (type: string, value: any, swallowError: boolean = true, contentShorten: boolean = true): React.ReactNode {
   // try {
   //   if (type === 'bool') {
@@ -150,6 +158,18 @@ function valueToText (type: string, value: any, swallowError: boolean = true, co
   //     console.log('valueToText', type, value, error);
   //   }
   // }
+
+  if (typeIsTuple(type)) {
+    let types = breakDownTuple(type);
+    // if so run valueToText on each element of the tuple
+    let output = [];
+    for (let i = 0; i < types.length; i++) {
+      output[i] = (
+        valueToText(types[i], (value as Array<any>)[i])
+      );
+    }
+    return output;
+  }
 
   // When displaying parameters of type Hash, these will sometimes come in the
   // form of a Uint8Array and not print properly unless converted to a Hash

--- a/packages/ui-params/src/valueToText.tsx
+++ b/packages/ui-params/src/valueToText.tsx
@@ -7,6 +7,8 @@ import './Params.css';
 import React from 'react';
 import { classes } from '@polkadot/ui-app/util';
 import { isNull, isUndefined, u8aToHex } from '@polkadot/util';
+import { Hash } from '@polkadot/types';
+import { disconnect } from 'cluster';
 
 // import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
 // import formatNumber from '@polkadot/ui-app/util/formatNumber';
@@ -28,7 +30,7 @@ type DivProps = {
 function div ({ key, className }: DivProps, ...values: Array<React.ReactNode>): React.ReactNode {
   return (
     <div
-      className={classes('ui--Param-text', className)}
+      className={classes('ui--Param-text.breakword', className)}
       key={key}
     >
       {values}
@@ -149,6 +151,12 @@ function valueToText (type: string, value: any, swallowError: boolean = true, co
   //     console.log('valueToText', type, value, error);
   //   }
   // }
+
+  // When displaying parameters of type Hash, these will sometimes come in the
+  // form of a Uint8Array and not print properly unless converted to a Hash
+  if (type === 'Hash') {
+    return div({},(new Hash(value)).toString());
+  }
 
   return isNull(value) || isUndefined(value)
     ? unknown

--- a/packages/ui-params/src/valueToText.tsx
+++ b/packages/ui-params/src/valueToText.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import { classes } from '@polkadot/ui-app/util';
 import { isNull, isUndefined, u8aToHex } from '@polkadot/util';
 import { Hash } from '@polkadot/types';
-import { disconnect } from 'cluster';
 
 // import IdentityIcon from '@polkadot/ui-react/IdentityIcon';
 // import formatNumber from '@polkadot/ui-app/util/formatNumber';


### PR DESCRIPTION
issue #417

Right now I only have tested this with the types that are currently used as parameters for the various functions available, I can't guarantee that it will work for any conceivable type that may one day be used as a parameter to a function - should ensuring that be within the scope of this issue? If so I can make this more robust. 

I also made some calls on graphic design that included re-arranging some of the existing output so that the placement of the input parameters would make visual sense. Obviously this is up to taste so let me know if this is to your liking or not. 