### PR TITLE
Forward-port low-hanging breaks

### DIFF
--- a/packages/app-democracy/src/Summary.tsx
+++ b/packages/app-democracy/src/Summary.tsx
@@ -39,7 +39,7 @@ class Summary extends React.PureComponent<Props> {
             {formatNumber(democracy_referendumCount.sub(democracy_nextTally))}
           </CardSummary>
         </section>
-        <section>
+        <section className='ui--media-medium'>
           <CardSummary
             label={t('voting period')}
             progress={{

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -40,7 +40,7 @@ export default class BlockHeader extends React.PureComponent<Props> {
               : textNumber
             }&nbsp;</div>
             <div className='hash'>{hashHex}</div>
-            <div className='author'>{
+            <div className='author ui--media-medium'>{
               author
                 ? <AddressMini value={author} />
                 : undefined

--- a/packages/app-explorer/src/BlockHeader/index.tsx
+++ b/packages/app-explorer/src/BlockHeader/index.tsx
@@ -40,7 +40,7 @@ export default class BlockHeader extends React.PureComponent<Props> {
               : textNumber
             }&nbsp;</div>
             <div className='hash'>{hashHex}</div>
-            <div className='author ui--media-medium'>{
+            <div className='author ui--media-small'>{
               author
                 ? <AddressMini value={author} />
                 : undefined

--- a/packages/app-explorer/src/Main.tsx
+++ b/packages/app-explorer/src/Main.tsx
@@ -22,7 +22,7 @@ class Main extends React.PureComponent<Props> {
       <>
         <Summary />
         <Query />
-        <div className='explorer--Overview'>
+        <div className='explorer--Overview ui--flex-medium'>
           <div className='column'>
             <h1>{t('recent blocks')}</h1>
             <BlockHeaders />

--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -22,7 +22,7 @@ class Summary extends React.PureComponent<Props> {
         className={className}
         style={style}
       >
-        <section>
+        <section className='ui--media-small'>
           <CardSummary label={t('target')}>
             <TimePeriod />
           </CardSummary>
@@ -30,7 +30,7 @@ class Summary extends React.PureComponent<Props> {
             <TimeNow />
           </CardSummary>
         </section>
-        <section>
+        <section className='ui--media-large'>
           <SummarySession />
         </section>
         <section>

--- a/packages/app-explorer/src/index.css
+++ b/packages/app-explorer/src/index.css
@@ -89,12 +89,9 @@
 }
 
 .explorer--Overview {
-  display: flex;
-
   .column {
     flex: 0 0 50%;
     min-width: 0;
-    max-width: 50%;
     padding: 0 1em 1em;
   }
 }

--- a/packages/app-nodeinfo/src/Summary.tsx
+++ b/packages/app-nodeinfo/src/Summary.tsx
@@ -45,7 +45,7 @@ class Summary extends React.PureComponent<Props, State> {
 
     return (
       <summary>
-        <section>
+        <section className='ui--media-medium'>
           <CardSummary label={t('refresh in')}>
             <Elapsed value={nextRefresh} />
           </CardSummary>
@@ -68,7 +68,7 @@ class Summary extends React.PureComponent<Props, State> {
             }
           </CardSummary>
         </section>
-        <section>
+        <section className='ui--media-large'>
           <CardSummary label={t('queued tx')}>
             {
               info.extrinsics

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -26,7 +26,7 @@ type Props = I18nProps & {
 class CurrentList extends React.PureComponent<Props> {
   render () {
     return (
-      <div className='validator--ValidatorsList'>
+      <div className='validator--ValidatorsList ui--flex-medium'>
         <div className='validator--current'>
           {this.renderCurrent()}
         </div>

--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -39,10 +39,10 @@ class Summary extends React.PureComponent<Props> {
             {intentions.length}
           </CardSummary>
         </section>
-        <section>
+        <section className='ui--media-medium'>
           <SummarySession withBroken={false} />
         </section>
-        <section>
+        <section className='ui--media-large'>
           <CardSummary label={t('balances')}>
             {this.renderBalances()}
           </CardSummary>

--- a/packages/app-staking/src/Overview/index.css
+++ b/packages/app-staking/src/Overview/index.css
@@ -49,10 +49,7 @@
   text-align: right;
 }
 
-.validator--IntensionsList,
 .validator--ValidatorsList {
-  display: flex;
-
   article {
     position: relative;
 

--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -46,7 +46,7 @@ class Transfer extends React.PureComponent<Props, State> {
     return (
       <div className='transfer--Transfer'>
         <div className='transfer--Transfer-info'>
-          {this.renderAddress(accountId)}
+          {this.renderAddress(accountId, 'medium')}
           <div className='transfer--Transfer-data'>
             <InputAddress
               label={t('from my source account')}
@@ -80,13 +80,13 @@ class Transfer extends React.PureComponent<Props, State> {
               )}
             </QueueConsumer>
           </div>
-          {this.renderAddress(recipientId)}
+          {this.renderAddress(recipientId, 'large')}
         </div>
       </div>
     );
   }
 
-  private renderAddress (accountId: string | null) {
+  private renderAddress (accountId: string | null, media: 'large' | 'medium') {
     if (!accountId) {
       return null;
     }
@@ -98,7 +98,7 @@ class Transfer extends React.PureComponent<Props, State> {
     }
 
     return (
-      <div className='transfer--Transfer-address'>
+      <div className={`transfer--Transfer-address ui--media-${media}`}>
         <AddressSummary
           value={accountId}
           withCopy={false}

--- a/packages/ui-app/src/styles.ts
+++ b/packages/ui-app/src/styles.ts
@@ -10,5 +10,6 @@ import './styles/theme/substrate.css';
 
 import './styles/app.css';
 import './styles/form.css';
+import './styles/media.css';
 import './styles/rx.css';
 import './styles/components.css';

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -220,8 +220,14 @@ header .ui--Button-Group {
   margin-left: 0.25rem !important;
 }
 
-.ui--DropdownLinked-Items {
-  padding-left: 0.5rem;
+.ui--DropdownLinked.ui--row {
+  .small .ui.selection.dropdown {
+    min-width: 5rem;
+  }
+
+  .ui--DropdownLinked-Items {
+    padding-left: 0.5rem;
+  }
 }
 
 .ui--Input {

--- a/packages/ui-app/src/styles/form.css
+++ b/packages/ui-app/src/styles/form.css
@@ -11,7 +11,7 @@
 .ui--row {
   align-items: stretch;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   flex-direction: row;
   justify-content: flex-start;
   text-align: left;

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -2,41 +2,53 @@
 /* This software may be modified and distributed under the terms
 /* of the Apache-2.0 license. See the LICENSE file for details. */
 
+/* block by default, flex as per media queries below */
+.ui--flex-large,
+.ui--flex-medium,
+.ui--flex-small {
+  display: block;
+}
+
+/* hide all by default, add as per media queries below */
 .ui--media-large,
 .ui--media-medium,
 .ui--media-small {
+  height: 0;
   visibility: hidden;
   width: 0;
 }
 
-/*
-  ##Device = Desktops
-  ##Screen = 1281px to higher resolution desktops
-*/
 @media (min-width: 1281px) {
+  .ui--flex-large {
+    display: flex;
+  }
+
   .ui--media-large {
+    height: auto;
     visibility: visible;
     width: auto;
   }
 }
 
-/*
-  ##Device = Laptops, Desktops
-  ##Screen = B/w 1025px to 1280px
-*/
 @media (min-width: 1025px) {
+  .ui--flex-medium {
+    display: flex;
+  }
+
   .ui--media-medium {
+    height: auto;
     visibility: visible;
     width: auto;
   }
 }
 
-/*
-  ##Device = Tablets, Ipads (portrait)
-  ##Screen = B/w 768px to 1024px
-*/
 @media (min-width: 768px) {
+  .ui--flex-small {
+    display: flex;
+  }
+
   .ui--media-small {
+    height: auto;
     visibility: visible;
     width: auto;
   }

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -1,0 +1,43 @@
+/* Copyright 2017-2019 @polkadot/ui-app authors & contributors
+/* This software may be modified and distributed under the terms
+/* of the Apache-2.0 license. See the LICENSE file for details. */
+
+.ui--media-large,
+.ui--media-medium,
+.ui--media-small {
+  visibility: hidden;
+  width: 0;
+}
+
+/*
+  ##Device = Desktops
+  ##Screen = 1281px to higher resolution desktops
+*/
+@media (min-width: 1281px) {
+  .ui--media-large {
+    visibility: visible;
+    width: auto;
+  }
+}
+
+/*
+  ##Device = Laptops, Desktops
+  ##Screen = B/w 1025px to 1280px
+*/
+@media (min-width: 1025px) {
+  .ui--media-medium {
+    visibility: visible;
+    width: auto;
+  }
+}
+
+/*
+  ##Device = Tablets, Ipads (portrait)
+  ##Screen = B/w 768px to 1024px
+*/
+@media (min-width: 768px) {
+  .ui--media-small {
+    visibility: visible;
+    width: auto;
+  }
+}


### PR DESCRIPTION
(From the still WIP `jg-ui-break` branch)

- `ui--grid` and `ui--row` now defaults to `nowrap` (this solves breaks in eg. Accounts, Closes #671)
- Hide some stuff in apps based on media-query size (ui-app/styles/media.css)
  - explorer - summary items + author for a block (this solves my specific phone-view use-case)
  - transfer - hide recipient on medium, sender on small - the inputs are ok-ish
  - 2-column apps - on small screens lose 2-column layout (media flex)
- Half-ports, i.e. not close to 100%, but better than current master -
  - linked dropdowns (e.g. chain state section  + method), has smaller sizing allowance for first item, allowing for better with overlaps on small screens, but nowhere close to perfect

Nowhere near comprehensive, these are just the forward-ported items (really quick basics) that more-or-less aligns with the "show when available" approach taken with apps. Going through app by-app atm as a first step.

What is not covered, but hopefully will be when the rest is available (after a short break) -

- linked dropdown proper solution (probably want 33/67% here in smaller cases)
- overlaps in medium + medium items, i.e. something like the account info on extrinsics page
- active proposals and referendums are still on default layout only
- modals not adjusted