### PR TITLE
Explorer flex for events, extrinsics (medium+)

### DIFF
--- a/packages/app-explorer/src/BlockByHash/Events.tsx
+++ b/packages/app-explorer/src/BlockByHash/Events.tsx
@@ -25,7 +25,7 @@ class Events extends React.PureComponent<Props> {
     return (
       <section>
         <h1>{t('events')}</h1>
-        <div className='explorer--BlockByHash-flexable'>
+        <div className='explorer--BlockByHash-flexable ui--flex-medium'>
           <EventsDisplay
             eventClassName='explorer--BlockByHash-block'
             value={value}

--- a/packages/app-explorer/src/BlockByHash/Extrinsics.tsx
+++ b/packages/app-explorer/src/BlockByHash/Extrinsics.tsx
@@ -40,7 +40,7 @@ class Extrinsics extends React.PureComponent<Props> {
     }
 
     return (
-      <div className='explorer--BlockByHash-flexable'>
+      <div className='explorer--BlockByHash-flexable ui--flex-medium'>
         {value.map(this.renderExtrinsic)}
       </div>
     );

--- a/packages/app-explorer/src/BlockByHash/Logs.tsx
+++ b/packages/app-explorer/src/BlockByHash/Logs.tsx
@@ -26,7 +26,7 @@ class Logs extends React.PureComponent<Props> {
     return (
       <section>
         <h1>{t('logs')}</h1>
-        <div className='explorer--BlockByHash-flexable'>
+        <div className='explorer--BlockByHash-flexable ui--flex-medium'>
           {value.map(this.renderItem)}
         </div>
       </section>

--- a/packages/app-explorer/src/index.css
+++ b/packages/app-explorer/src/index.css
@@ -31,7 +31,6 @@
 }
 
 .explorer--BlockByHash-flexable {
-  display: flex;
   flex-wrap: wrap;
   margin-top: -0.5rem;
 }
@@ -39,7 +38,6 @@
 .explorer--BlockByHash-block {
   flex: 0 0 50%;
   min-width: 0;
-  max-width: 50%;
 }
 
 .explorer--Container {


### PR DESCRIPTION
Just adding flex on medium+ displays (as per other areas where we have 2 column layouts) - wrapping is horrible on small screens.