### PR TITLE
Allow to run on Node.js 11.x and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "0.23.8",
   "private": true,
   "engines": {
-    "node": "^10.13.0",
+    "node": ">=10.13.0",
     "yarn": "^1.10.1"
   },
   "homepage": ".",


### PR DESCRIPTION
Current requirement in package.json doesn't allow to run Polkadot Apps on Node.js 11.x