### PR TITLE
Remove password rows on modals

### DIFF
--- a/packages/app-accounts/src/Backup.tsx
+++ b/packages/app-accounts/src/Backup.tsx
@@ -79,15 +79,13 @@ class Backup extends React.PureComponent<Props, State> {
         </Modal.Header>
         <Modal.Content className='app--account-Backup-content'>
           <AddressSummary value={pair.address()} />
-          <div className='ui--row'>
-            <Password
-              isError={!isPassValid}
-              label={t('unlock account using the password')}
-              onChange={this.onChangePass}
-              tabIndex={0}
-              value={password}
-            />
-          </div>
+          <Password
+            isError={!isPassValid}
+            label={t('unlock account using the password')}
+            onChange={this.onChangePass}
+            tabIndex={0}
+            value={password}
+          />
         </Modal.Content>
       </>
     );

--- a/packages/app-accounts/src/ChangePass.tsx
+++ b/packages/app-accounts/src/ChangePass.tsx
@@ -82,23 +82,21 @@ class ChangePass extends React.PureComponent<Props, State> {
         </Modal.Header>
         <Modal.Content>
           <AddressSummary value={account.address()} />
-          <div className='ui--row'>
-            <Password
-              autoFocus
-              isError={!isOldValid}
-              label={t('old password')}
-              onChange={this.onChangeOld}
-              tabIndex={1}
-              value={oldPass}
-            />
-            <Password
-              isError={!isNewValid}
-              label={t('new password')}
-              onChange={this.onChangeNew}
-              tabIndex={2}
-              value={newPass}
-            />
-          </div>
+          <Password
+            autoFocus
+            isError={!isOldValid}
+            label={t('old password')}
+            onChange={this.onChangeOld}
+            tabIndex={1}
+            value={oldPass}
+          />
+          <Password
+            isError={!isNewValid}
+            label={t('new password')}
+            onChange={this.onChangeNew}
+            tabIndex={2}
+            value={newPass}
+          />
         </Modal.Content>
       </>
     );


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/696
- Caused by new label placement

<img width="553" alt="polkadot apps portal 2019-02-11 23-08-57" src="https://user-images.githubusercontent.com/1424473/52597038-1241aa00-2e52-11e9-928d-2d936dd74cfd.png">

<img width="558" alt="polkadot apps portal 2019-02-11 23-09-11" src="https://user-images.githubusercontent.com/1424473/52597044-166dc780-2e52-11e9-866c-d3e3687f40f3.png">

Modals seriously need a rework all-around...