### PR TITLE
Smaller quick-fixes for app-js 

### DIFF
--- a/packages/app-js/src/Playground.tsx
+++ b/packages/app-js/src/Playground.tsx
@@ -315,7 +315,11 @@ class Playground extends React.PureComponent<Props, State> {
       history.push(path);
     }
 
-    this.copyToClipboard(`${window.location.origin}/#${path}`);
+    const basePath = window.location.pathname.replace('/', '').length > 0
+      ? `${window.location.origin}/${window.location.pathname.replace('/', '')}`
+      : `${window.location.origin}`;
+
+    this.copyToClipboard(`${basePath}/#${path}`);
   }
 
   private copyToClipboard = (link: string): void => {

--- a/packages/app-js/src/index.css
+++ b/packages/app-js/src/index.css
@@ -64,7 +64,6 @@
 
   .codeflask--has-line-numbers .codeflask__flatten {
     font-size: 12px;
-    height: 99.99%;
     line-height: 18px;
     min-width: calc(100% - 40px);
     width: auto;

--- a/packages/app-js/src/index.tsx
+++ b/packages/app-js/src/index.tsx
@@ -17,12 +17,10 @@ class AppJs extends React.PureComponent<Props> {
     const { basePath } = this.props;
 
     return (
-      <main className='js--App'>
-        <Switch>
-          <Route path={`${basePath}/share/:base64`} component={Playground} />
-          <Route component={Playground} />
-        </Switch>
-      </main>
+      <Switch>
+        <Route path={`${basePath}/share/:base64`} component={Playground} />
+        <Route component={Playground} />
+      </Switch>
     );
   }
 }


### PR DESCRIPTION
- [x] Fixed copyToClipboard link
- [x] Fixed duplicate wrapper leading to component height > 100%
- [x] Fixed overflow for longer coder examples in editor