### PR TITLE
Fix app-accounts Restore feature

### DIFF
--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -98,7 +98,8 @@ class Restore extends React.PureComponent<Props, State> {
       const isFileValid = keyring.decodeAddress(json.address).length === 32 &&
         isHex(json.encoded) &&
         isObject(json.meta) &&
-        json.encoding.content === 'pkcs8';
+        json.encoding.content[0] === 'pkcs8' &&
+        json.encoding.content[1] === 'ed25519';
 
       this.setState({
         isFileValid,


### PR DESCRIPTION
Fixes file validity check, solving #760

The encoding.content value is not just the string 'pkcs8' but an array `['pkcs8', 'ed25519']`

https://github.com/polkadot-js/common/blob/503dc99815700c79d01c09dc337c5bc8bebd38cc/packages/keyring/src/pair/toJson.ts#L20