### PR TITLE
Summary expansion concept - bar with Carousel 

### DIFF
--- a/packages/app-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/app-explorer/src/NodeInfo/Summary.tsx
@@ -44,7 +44,7 @@ class Summary extends React.PureComponent<Props, State> {
     const { peerBest } = this.state;
 
     return (
-      <summary>
+      <summary className='summary--fullWidth'>
         <section className='ui--media-medium'>
           <CardSummary label={t('refresh in')}>
             <Elapsed value={nextRefresh} />

--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -11,10 +11,8 @@ import { BestFinalised, BestNumber, TimeNow, TimePeriod } from '@polkadot/ui-rea
 import SummarySession from './SummarySession';
 import translate from './translate';
 
-import { CarouselProvider, Slider, Slide, ButtonBack, ButtonNext, DotGroup } from 'pure-react-carousel';
+import { CarouselProvider, Slider, Slide, DotGroup } from 'pure-react-carousel';
 import 'pure-react-carousel/dist/react-carousel.es.css';
-
-import componentQueries from 'react-component-queries'
 
 type Props = I18nProps & {};
 

--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -11,37 +11,67 @@ import { BestFinalised, BestNumber, TimeNow, TimePeriod } from '@polkadot/ui-rea
 import SummarySession from './SummarySession';
 import translate from './translate';
 
+import { CarouselProvider, Slider, Slide, ButtonBack, ButtonNext, DotGroup } from 'pure-react-carousel';
+import 'pure-react-carousel/dist/react-carousel.es.css';
+
+import componentQueries from 'react-component-queries'
+
 type Props = I18nProps & {};
 
 class Summary extends React.PureComponent<Props> {
+
   render () {
     const { className, style, t } = this.props;
 
     return (
-      <summary
-        className={className}
-        style={style}
-      >
-        <section className='ui--media-small'>
-          <CardSummary label={t('target')}>
-            <TimePeriod />
-          </CardSummary>
-          <CardSummary label={t('last block')}>
-            <TimeNow />
-          </CardSummary>
-        </section>
-        <section className='ui--media-large'>
-          <SummarySession />
-        </section>
-        <section>
-          <CardSummary label={t('finalised')}>
-            <BestFinalised />
-          </CardSummary>
-          <CardSummary label={t('best')}>
-            <BestNumber />
-          </CardSummary>
-        </section>
-      </summary>
+        <div
+          className={`summary summary--fullWidth isSummary  ${className}`}
+          style={style}
+        >
+          <CarouselProvider
+            naturalSlideWidth={100}
+            naturalSlideHeight={1}
+            totalSlides={2}
+            className='summary--Carousel'
+          >
+            <Slider>
+              <Slide className='summary--Carousel-slide' index={0}>
+                <div className='isSummary'>
+                  <section>
+                    <CardSummary label={t('target')}>
+                      <TimePeriod />
+                    </CardSummary>
+                    <CardSummary label={t('last block')}>
+                      <TimeNow />
+                    </CardSummary>
+                  </section>
+                  <section>
+                    <SummarySession />
+                  </section>
+                  <section>
+                    <CardSummary label={t('finalised')}>
+                      <BestFinalised />
+                    </CardSummary>
+                    <CardSummary label={t('best')}>
+                      <BestNumber />
+                    </CardSummary>
+                  </section>
+                </div>
+              </Slide>
+              <Slide className='summary--Carousel-slide' index={1}>
+                <div className='isSummary'>
+                  <section>
+                    <article>
+                      More Stats Here
+                    </article>
+                  </section>
+                </div>
+              </Slide>
+
+            </Slider>
+            <DotGroup />
+          </CarouselProvider>
+        </div>
     );
   }
 }

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -15,6 +15,7 @@
     "@babel/runtime": "^7.3.4",
     "@polkadot/ui-app": "^0.24.24",
     "@polkadot/ui-assets": "^0.28.6",
-    "@polkadot/ui-signer": "^0.24.24"
+    "@polkadot/ui-signer": "^0.24.24",
+    "pure-react-carousel": "^1.18.0"
   }
 }

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -180,7 +180,7 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
     plugins: plugins.concat([
       isProd
         ? null
-        : new WebpackPluginServe({
+        : new git({
           port: 3000,
           static: path.join(process.cwd(), '/build')
         }),

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -36,7 +36,7 @@ label {
   color: #4e4e4e;
   display: block;
   font-family: sans-serif;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 100;
   margin: 0.25rem;
   opacity: 0.75;
@@ -121,21 +121,75 @@ summary {
   text-align: center;
 }
 
-summary {
+summary,
+
+.isSummary {
   align-items: stretch;
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
 }
 
-summary article {
-  color: rgba(0, 0, 0, 0.6);
-  flex: 0 1 auto;
-  text-align: left;
+.summary--fullWidth {
+  background: #fff;
+  box-shadow: rgba(0, 0, 0, 0.0980392) 0px 10px 40px 0px;
+  border-radius: 5px;
+
+  article {
+    box-shadow: none;
+  }
 }
 
-summary > section {
-  display: flex;
-  flex: 0 1 auto;
-  text-align: left;
+.summary, 
+.container,
+summary {
+  margin: 2.4em 0 3em 0;
+  padding: 0.2em 0.5em;
+
+  section {
+    display: flex;
+    flex: 0 1 auto;
+    text-align: left;
+  }
+
+  article {
+    color: rgba(0, 0, 0, 0.6);
+    flex: 0 1 auto;
+    text-align: left;
+  }
+
+  .summary--Carousel {
+    width: 100%;
+    height: 84px;
+    position: relative;
+
+    .summary--Carousel-slide {
+      position: relative;
+      width: 100%;
+      height: 100px;
+
+      .container {
+        width: 100%;
+        box-shadow: none;
+      }
+    }
+
+    .carousel__dot-group {
+      position: absolute;
+      top: -1.9em;
+      right: 0px;
+
+      .carousel__dot {
+        width: 20px;
+        height: 20px;
+        background: #888;
+        border-radius: 50%;
+        transform: scale(0.4);
+
+        &:disabled {
+          background: #ddd;
+        }
+      }
+    }
+  }  
 }

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -205,9 +205,9 @@ header .ui--Button-Group {
 }
 
 .ui--CardSummary-large {
-  font-size: 2.25rem;
+  font-size: 1.9rem;
   font-weight: 100;
-  line-height: 2.25rem;
+  line-height: 2.3rem;
   text-align: right;
 }
 

--- a/packages/ui-app/src/styles/semantic.css
+++ b/packages/ui-app/src/styles/semantic.css
@@ -169,3 +169,7 @@
     background: #fafafa /* #fff */;
   }
 }
+
+.ui.tiny.progress .bar {
+  height: 0.35em;
+}

--- a/packages/ui-app/src/styles/semantic.css
+++ b/packages/ui-app/src/styles/semantic.css
@@ -171,5 +171,5 @@
 }
 
 .ui.tiny.progress .bar {
-  height: 0.35em;
+  height: 0.3em;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4847,6 +4847,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deep-freeze@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+  integrity sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -4861,6 +4866,11 @@ deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
+
+deepmerge@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-gateway@^4.0.1:
   version "4.1.2"
@@ -5348,6 +5358,13 @@ enzyme@^3.9.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.1.2"
+
+equals@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/equals/-/equals-1.0.5.tgz#212062dde5e1a510d955f13598efcc6a621b6ace"
+  integrity sha1-ISBi3eXhpRDZVfE1mO/MamIbas4=
+  dependencies:
+    jkroso-type "1"
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -7856,6 +7873,11 @@ jest@^24.1.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.1.0"
+
+jkroso-type@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jkroso-type/-/jkroso-type-1.1.1.tgz#bc4ced6d6c45fe0745282bafc86a9f8c4fc9ce61"
+  integrity sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE=
 
 joi@^14.3.0:
   version "14.3.1"
@@ -10981,6 +11003,16 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+pure-react-carousel@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/pure-react-carousel/-/pure-react-carousel-1.18.0.tgz#bd03b3ccd9e17da5c96b9d07785674003daadbca"
+  integrity sha512-tIHdLs2aWyDwVBQC6TOkFmlPA44NidqOA2RwMVc5sNKrS1rnfbLiTNNBAoPOiSm/eb/ULsG9WN6QfoqV7MkDAg==
+  dependencies:
+    deep-freeze "0.0.1"
+    deepmerge "^2.2.1"
+    equals "^1.0.5"
+    prop-types "^15.6.2"
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
This PR demonstrates an enhanced summary section in the form of a unified panel, with an optional carousel built in allowing us to show stats that are currently hidden on smaller screens. 

I feel this is the direction the summaries should be going in whereby no stats are sacrificed on smaller devices.

Some UI has been slightly decreased in size for a more balanced font sizing.

Note:  Unfinished - concept only 

![summarybar](https://user-images.githubusercontent.com/13929023/53722960-a3300200-3ea1-11e9-91ca-dfdd012b0f62.gif)

If positive feedback is received I would then like to explore dynamic slides depending on window width.

Carousel used: 
[Pure React Carousel](https://www.npmjs.com/package/pure-react-carousel). Keeping components lightweight with great customisability.