### PR TITLE
delete react-hot-loader devDependency

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -18,8 +18,5 @@
     "@polkadot/ui-signer": "^0.24.29",
     "@types/react-tooltip": "^3.9.1",
     "react-tooltip": "^3.9.2"
-  },
-  "devDependencies": {
-    "react-hot-loader": "^4.7.2"
   }
 }


### PR DESCRIPTION
Related to https://github.com/polkadot-js/dev/pull/191 which needs to be merged before this one.
Additionally a new version of the `dev` packages needs to be published before this PR can me merged..