### PR TITLE
Add resolution overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "packages/*"
   ],
   "resolutions": {
+    "@polkadot/api": "^0.46.5",
+    "@polkadot/keyring": "^0.35.4",
+    "@polkadot/types": "^0.46.5",
+    "@polkadot/util": "^0.35.4",
+    "@polkadot/util-crypto": "^0.35.4",
     "babel-core": "^7.0.0-bridge.0",
     "rxjs": "^6.4.0",
     "typescript": "^3.3.3333"
@@ -27,8 +32,8 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/runtime": "^7.3.4",
-    "@polkadot/dev-react": "^0.25.12",
-    "@polkadot/ts": "^0.1.55",
+    "@polkadot/dev-react": "^0.25.13",
+    "@polkadot/ts": "^0.1.56",
     "autoprefixer": "^9.4.9",
     "empty": "^0.10.1",
     "gh-pages": "^2.0.1",

--- a/packages/ui-api/package.json
+++ b/packages/ui-api/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-reactive#readme",
   "dependencies": {
     "@babel/runtime": "^7.3.4",
-    "@polkadot/api": "^0.46.4",
+    "@polkadot/api": "^0.46.5",
     "@polkadot/ui-util": "^0.28.8",
     "rxjs-compat": "^6.3.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,40 +1471,40 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@polkadot/api-derive@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.46.4.tgz#ac9e53a1d68edcc33ffaaf5485e97abf97154c7a"
-  integrity sha512-hyAKJiiEqSgtzE4nQRDuxqX8wHftOi+QihorvsRwXdiq0D7I17t7fmY9BaUBbX/9hrfQPoqLYnIatpQ16z3Iww==
+"@polkadot/api-derive@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.46.5.tgz#620466a17758fc39147c41082b528febe0ed39bb"
+  integrity sha512-5HmXIz/Sepyqo059n5tklUY2ANDJvl1IhpILy3G/koZvhrKgS0/MWDGemA2sGv6sMcpKcreClXP9nkDyGwxWMw==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/api" "^0.46.4"
-    "@polkadot/types" "^0.46.4"
+    "@polkadot/api" "^0.46.5"
+    "@polkadot/types" "^0.46.5"
     "@types/memoizee" "^0.4.2"
     memoizee "^0.4.14"
 
-"@polkadot/api@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.46.4.tgz#0d664522646577d1f4cb65ded9ef2f4680121b0a"
-  integrity sha512-HCLmKmOUt7QgB0UfLpOgVQ+boHXvqaYSU6LlZjkCiyjTD7zfTaQd48LlsKvWl30HTdzDTawKgITvL9IF8wAL3g==
+"@polkadot/api@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.46.5.tgz#f41ce15a31c3b65db7ad647d41734ca961cf4e8c"
+  integrity sha512-3Cm/NN4WDT43sSmh+rGbb95ku507+KVr6ucZXEv2ZbAK+5gvAm37mbzrrTKwaN1KL9CVwAO0oClt49Csbk5MMA==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/api-derive" "^0.46.4"
-    "@polkadot/extrinsics" "^0.46.4"
-    "@polkadot/rpc-provider" "^0.46.4"
-    "@polkadot/rpc-rx" "^0.46.4"
-    "@polkadot/storage" "^0.46.4"
-    "@polkadot/types" "^0.46.4"
-    "@polkadot/util-crypto" "^0.35.1"
+    "@polkadot/api-derive" "^0.46.5"
+    "@polkadot/extrinsics" "^0.46.5"
+    "@polkadot/rpc-provider" "^0.46.5"
+    "@polkadot/rpc-rx" "^0.46.5"
+    "@polkadot/storage" "^0.46.5"
+    "@polkadot/types" "^0.46.5"
+    "@polkadot/util-crypto" "^0.35.4"
 
-"@polkadot/dev-react@^0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev-react/-/dev-react-0.25.12.tgz#60d30dd493bebec97874c9484f1644b2e076154c"
-  integrity sha512-Sl0hth5aEgYnFuxNcsPinbZNbgV4A6w8P2iYZs7wjg5Y4sTi5iTYrHcNF6ZOJvvKFW+FJ5KT6Kam7ZzBW5qEYQ==
+"@polkadot/dev-react@^0.25.13":
+  version "0.25.13"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev-react/-/dev-react-0.25.13.tgz#703163b2485333a4ee9988cf24fc48983a02e8e0"
+  integrity sha512-wIU/VBqf5ZVdjKBn6fSryn/EklLmzNwh77jiv5JPT7E9oZ4OpKIioMI0mupPVO5oaIQWXKAh1bU1MIFUoCxgew==
   dependencies:
     "@babel/core" "^7.3.4"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
     "@babel/preset-react" "^7.0.0"
-    "@polkadot/dev" "^0.25.12"
+    "@polkadot/dev" "^0.25.13"
     "@types/react" "^16.8.5"
     "@types/react-dom" "^16.8.2"
     "@types/styled-components" "4.1.8"
@@ -1520,6 +1520,7 @@
     mini-css-extract-plugin "^0.5.0"
     react "^16.8.3"
     react-dom "^16.8.3"
+    react-hot-loader "^4.7.2"
     style-loader "^0.23.0"
     styled-components "^4.1.3"
     thread-loader "^2.1.2"
@@ -1531,10 +1532,10 @@
     webpack-plugin-serve "^0.7.2"
     worker-loader "^2.0.0"
 
-"@polkadot/dev@^0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.25.12.tgz#de440a96dba3c9b4a92e6be0f0276b8c1f4daf24"
-  integrity sha512-pISn6l4+brHCE04jjqSc7j7V63QmuhFykJFV2WejZHvUtKzBJa35C1ps+U9iKfa5Ma2gFyjyvlQOOvAKRwuKrA==
+"@polkadot/dev@^0.25.13":
+  version "0.25.13"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.25.13.tgz#2cb3888cba59409dc0e5f829b41c738e34e8fad7"
+  integrity sha512-uHizvsNzNodL+aL7B0z363l4/mAfguzdaP5xggUsI9z2iA3GPu80gmgmLgMq+0kbr/Ju0N3vWP5BgUI4OH5/Qw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.3.4"
@@ -1567,23 +1568,23 @@
     typescript "^3.3.3333"
     vuepress "^1.0.0-alpha.40"
 
-"@polkadot/extrinsics@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.46.4.tgz#e830150e28235ac581ac947915d6bad889e72ff8"
-  integrity sha512-pzSSNW9vp7qu1SU+0xScNwu9BOpMdg5J5io4ZSX3P5JvVKvjNSorRlxDYY+D6I45pbIhq7Y8dqj5ACcGrxtq3g==
+"@polkadot/extrinsics@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.46.5.tgz#49b796657bb7e92672ff7c144d59d9781fdfc7d5"
+  integrity sha512-lWj7s2xAHSxKLeC7pZ7seLyQ0bBXz4TezI+yLmM3CEQLEBuDW3zGGyMFbxSVZSJtgtd0ujbxuZX5mKn8kEOTTg==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/types" "^0.46.4"
-    "@polkadot/util" "^0.35.1"
+    "@polkadot/types" "^0.46.5"
+    "@polkadot/util" "^0.35.4"
 
-"@polkadot/jsonrpc@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.46.4.tgz#7cd4f12b415b158522e444f89efd795753968fae"
-  integrity sha512-9CmPJ2ckqgcf9b1OuOnEgnf111+rRpuC34CVY0ZnUeg7wyleYdND0HrQ4QC9EnNBOz3dz9y0ui9VmDKBL8uQsw==
+"@polkadot/jsonrpc@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.46.5.tgz#f687989cc0cb62292397dc2f23be043546950abf"
+  integrity sha512-ePzJaCZi/iITxPGLrIemZW5CVvtDy0Fr9XKhbsu87t+jcITzFz5EBDCzxaFdy7JQyr9AeZjxxPj0Md45Wbjw0Q==
   dependencies:
     "@babel/runtime" "^7.3.4"
 
-"@polkadot/keyring@^0.35.1":
+"@polkadot/keyring@^0.35.4":
   version "0.35.4"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.35.4.tgz#c7a6eca79a53c0468fa2a32b4647e5866460f9de"
   integrity sha512-muqVxGXigwW+ahQKBCDc0vdeOatP82vbcu4p7tz/LIzgfKmHX85JBWi63lcNTWljabJSRf9mqlf3jaU7L4OXlw==
@@ -1594,40 +1595,40 @@
     "@types/bs58" "^4.0.0"
     bs58 "^4.0.1"
 
-"@polkadot/rpc-core@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.46.4.tgz#3d30ba9b80aab15575dbeed86f94dcd11a6e2f09"
-  integrity sha512-7QE9L8/1Mns7GD5AFMyj2Md/iSqI3HpK6VcHn9/0Nqu0noAStzYlCeWBTegda3cBrhywp8kqd7PrkD9eo4gf/w==
+"@polkadot/rpc-core@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.46.5.tgz#914f4a90b98bd90f88b02a9e512efe160ae7a179"
+  integrity sha512-3/IdqjRt80lVF+CYzPYB9sbufWFpn3AqH++3zNeBb8GHzXfg/dcJnTQ8NYtSZEOkMTKSRr1ZnoBlStTKweRquA==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/jsonrpc" "^0.46.4"
-    "@polkadot/rpc-provider" "^0.46.4"
-    "@polkadot/types" "^0.46.4"
-    "@polkadot/util" "^0.35.1"
+    "@polkadot/jsonrpc" "^0.46.5"
+    "@polkadot/rpc-provider" "^0.46.5"
+    "@polkadot/types" "^0.46.5"
+    "@polkadot/util" "^0.35.4"
 
-"@polkadot/rpc-provider@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.46.4.tgz#b56ea7289c42d62086fbaf4241ee5a879991eb89"
-  integrity sha512-YydQoT4xw9KlQUEz7LGoUn+IgAyCcoPuRrJ7FpfUA+EMExEoYEfcaxjcwUUq04kB0jV5kvSPXkpxaa6Vd8zMQA==
+"@polkadot/rpc-provider@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.46.5.tgz#54f3254030fd29364e45ad6dce7febfbf6a28ea6"
+  integrity sha512-/OMLccZ/7iE4AztfXV0jEC9aj5Ykb697nnfvO7/jfA4s7feJ+PG4kUBcR8V7/o2TJfZO48SbHnkpsqww9yxqeg==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/keyring" "^0.35.1"
-    "@polkadot/storage" "^0.46.4"
-    "@polkadot/util" "^0.35.1"
-    "@polkadot/util-crypto" "^0.35.1"
+    "@polkadot/keyring" "^0.35.4"
+    "@polkadot/storage" "^0.46.5"
+    "@polkadot/util" "^0.35.4"
+    "@polkadot/util-crypto" "^0.35.4"
     "@types/nock" "^9.3.1"
     eventemitter3 "^3.1.0"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.28"
 
-"@polkadot/rpc-rx@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.46.4.tgz#dc66266271a17c399fc2ee1cdd1fa578e707ed66"
-  integrity sha512-tFo1wdRLkCeYpvrigT6WC0GT3XkRZsB2xX28LXlN7+y0tkKvLNgz8Af8YeCJrQo8R/IUmT6Q5RgV702HsIjipw==
+"@polkadot/rpc-rx@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.46.5.tgz#b5a8dc4d565cf3ed3ccbee99db6542c78eeb2c88"
+  integrity sha512-zwA9FTRkriL900onT4tyZBWiHdtPSyaIUY8DjpucAOG7BZ+Ya+GENIcPjnmrADb89wpu/Rcn8ZqtNnzzoQp7Mg==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/rpc-core" "^0.46.4"
-    "@polkadot/rpc-provider" "^0.46.4"
+    "@polkadot/rpc-core" "^0.46.5"
+    "@polkadot/rpc-provider" "^0.46.5"
     "@types/memoizee" "^0.4.2"
     "@types/rx" "^4.1.1"
     memoizee "^0.4.14"
@@ -1638,30 +1639,30 @@
   resolved "https://registry.yarnpkg.com/@polkadot/schnorrkel-js/-/schnorrkel-js-0.1.2-3.tgz#9117ac5126b465a1cf53c2b6bb68a17efc7e0390"
   integrity sha512-1LgF4wtER3q5uqY67CdOsQQ/SBqT6v0ZKQIS3cOTVByF16WtApD6U324uCJyMdie+GZFv0xr/40I4Ni2It+8jw==
 
-"@polkadot/storage@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.46.4.tgz#018ccd3efc3601ab930bdb29d3934f92ec6ef089"
-  integrity sha512-M3yu0PeC5px9UxqUXeBj5nOsywsJYhqFUn020exdIMG4Yx5mSPWn2KKGimy3JZkDWcfhy1WPCyeC2pPHecyy2A==
+"@polkadot/storage@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.46.5.tgz#0b40d8caf6e0df01aeec1b29f1e596f0359cae82"
+  integrity sha512-dLAWIlplQIHL9Sd4KBQM+kypv7fAoxxvVwrWgstFkmzsCQlnSSM+s2j+iuCbelrkmr0nbRCRyE/W0FOh2ZHA/A==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/keyring" "^0.35.1"
-    "@polkadot/types" "^0.46.4"
-    "@polkadot/util" "^0.35.1"
-    "@polkadot/util-crypto" "^0.35.1"
+    "@polkadot/keyring" "^0.35.4"
+    "@polkadot/types" "^0.46.5"
+    "@polkadot/util" "^0.35.4"
+    "@polkadot/util-crypto" "^0.35.4"
 
-"@polkadot/ts@^0.1.55":
+"@polkadot/ts@^0.1.56":
   version "0.1.56"
   resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.56.tgz#ffd6e9c95704a7fb90b918193b9dc5c440114b27"
   integrity sha512-wnt4zXxZXyz6WaubTO/I+nUElwV2DogFzdl6CrKfVn2PTWp8uHN06W9s40FH57ORtmQfDr9rLRP8Nq+oIyElbg==
 
-"@polkadot/types@^0.46.4":
-  version "0.46.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.46.4.tgz#fd775de672d43cc3c15624ce67d976024b4a8d58"
-  integrity sha512-8O2bYLV4Ig1g7rsc+QN2t8LRvrKkUeRlApE6+Gsdmi6kxnpy55EB1znrrsYZtpT/Iz/r/b2g66yiyjhA8GsPiw==
+"@polkadot/types@^0.46.5":
+  version "0.46.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.46.5.tgz#bfcd42dc2307ba5f83bbbdaf8cb93ae8f13aabef"
+  integrity sha512-sh0BUvzZdoVdQipMt7aSOBL2d4lcLn4X9Cs7S8a5td5/O3fEPcgxPP9xtTAqbA4sSOhUeZ4UepBxOSaPJo1Yqw==
   dependencies:
     "@babel/runtime" "^7.3.4"
-    "@polkadot/keyring" "^0.35.1"
-    "@polkadot/util" "^0.35.1"
+    "@polkadot/keyring" "^0.35.4"
+    "@polkadot/util" "^0.35.4"
     core-js "^2.6.5"
 
 "@polkadot/ui-assets@^0.28.8":
@@ -1710,7 +1711,7 @@
   dependencies:
     "@babel/runtime" "^7.3.4"
 
-"@polkadot/util-crypto@^0.35.1", "@polkadot/util-crypto@^0.35.4":
+"@polkadot/util-crypto@^0.35.4":
   version "0.35.4"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.35.4.tgz#f63d9a0fb1527b506e391ec77e51edcbfb5597f5"
   integrity sha512-CsdP2u+OEzk7zIuptHY6OEJpCvamgb2p+n80qO3g+VCF9144ArB/UzOE1Zw0ixNHOs6Dj6M2qYUMZf8hUrIvAg==
@@ -1730,7 +1731,7 @@
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^0.35.1", "@polkadot/util@^0.35.4":
+"@polkadot/util@^0.35.4":
   version "0.35.4"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.35.4.tgz#1e84ca76c08768b8ac7d73c84308c1d7d1077295"
   integrity sha512-JhhfqDBcxHud3dlBt6xqDvnCS52mz7RN1QJOZMiOTrf12vyq3GN6NrEUcTOgiTGy3mUyB2t+5zx24VX8HrTeKA==


### PR DESCRIPTION
Add addition resolution overrides, for instance in the case of edgeware (https://github.com/hicommonwealth/apps/commit/28c6b911505e53afeabeb58409f0c429ecc1191b) types are being registered, however the base has an older version of the API (although compatible) and it creates havoc with the resolutions.

 Force these for apps to always use the specified version as defined by apps.

cc @drewstone