### PR TITLE
Remove InputNumber shift check

### DIFF
--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -154,11 +154,6 @@ class InputNumber extends React.PureComponent<Props, State> {
       return false;
     }
 
-    // prevent use of shift key
-    if (event.shiftKey) {
-      return false;
-    }
-
     // allow cut/copy/paste combinations but not non-numeric letters (i.e. a, c, x, v) individually
     if (
       (isSelectAll(event.key, isPreKeyDown)) ||


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/806 (tested on Chrome, things like Shift-2 (`@`) is still not entered.