### PR TITLE
Expose types on JS console

### DIFF
--- a/packages/app-js/src/Playground.tsx
+++ b/packages/app-js/src/Playground.tsx
@@ -15,6 +15,7 @@ import snappy from 'snappyjs';
 import { withApi, withMulti } from '@polkadot/ui-api';
 import { Button, Dropdown, Editor } from '@polkadot/ui-app';
 import uiKeyring from '@polkadot/ui-keyring';
+import * as types from '@polkadot/types';
 import * as util from '@polkadot/util';
 import * as hashing from '@polkadot/util-crypto';
 
@@ -36,6 +37,7 @@ type Injected = {
   global: null,
   hashing: typeof hashing,
   keyring: KeyringInstance | null,
+  types: typeof types,
   util: typeof util,
   window: null
 };
@@ -177,6 +179,7 @@ class Playground extends React.PureComponent<Props, State> {
       keyring: isDevelopment
         ? uiKeyring.keyring
         : null,
+      types,
       util,
       window: null
     };

--- a/packages/app-js/src/snippets/wrapping.ts
+++ b/packages/app-js/src/snippets/wrapping.ts
@@ -3,7 +3,7 @@
  // of the Apache-2.0 license. See the LICENSE file for details.
 
 export default function makeWrapper (isDevelopment: boolean): string {
-  const args = `api, hashing, ${isDevelopment ? 'keyring, ' : ''}util`;
+  const args = `api, hashing, ${isDevelopment ? 'keyring, ' : ''}types, util`;
 
   return `// All code is wrapped within an async closure,
 // allowing access to ${args}.


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/831

e.g.

```js
const { Balance } = types;
const { u8aToHex } = util;

console.log(u8aToHex(new Balance(12345).toU8a()))
```

(Sadly the `toU8a()` returns a pure `Unint8Array` hence the `u8aToHex` helper above - maybe at some point we can convert all `toU8a()` on the types in `@polkadot/types` to return a `U8a`, which would allow something like

```js
const { Balance } = types;

console.log(new Balance(12345).toU8a().toHex())
```