### PR TITLE
Full width storage--actionrow

### DIFF
--- a/packages/app-explorer/src/BlockQuery/Query.tsx
+++ b/packages/app-explorer/src/BlockQuery/Query.tsx
@@ -36,8 +36,7 @@ class Query extends React.PureComponent<Props, State> {
     return (
       <summary>
         <div className='ui--row'>
-          <div className='small' />
-          <div className='storage--actionrow medium'>
+          <div className='storage--actionrow head'>
             <Input
               className='storage--actionrow-value'
               defaultValue={this.props.value}

--- a/packages/app-storage/src/index.css
+++ b/packages/app-storage/src/index.css
@@ -23,6 +23,12 @@
   .button {
     margin: 0.25rem;
   }
+
+  &.head {
+    flex: 1 1 100%;
+    margin: 0 auto;
+    max-width: 700px;
+  }
 }
 
 .storage--actionrow-value {

--- a/packages/app-storage/src/index.css
+++ b/packages/app-storage/src/index.css
@@ -27,7 +27,7 @@
   &.head {
     flex: 1 1 100%;
     margin: 0 auto;
-    max-width: 700px;
+    max-width: 620px;
   }
 }
 


### PR DESCRIPTION
Fix for #823.

Only query I'd have here is with `max-width`. Perhaps adhere to a value that other elements will stretch to also. 620px being a visually appealing amount and suitable for displaying an entire hash.
