### PR TITLE
Add recently offline warning badge for validators

### DIFF
--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -4,15 +4,15 @@
 
 import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
-import { Nominators } from '../types';
 
 import React from 'react';
-import { AccountId, Balance } from '@polkadot/types';
-import { withMulti } from '@polkadot/ui-api/with';
+import { AccountId, Balance, Option } from '@polkadot/types';
+import { withCall, withMulti } from '@polkadot/ui-api/with';
 import { AddressMini, AddressRow } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
 
 import translate from '../translate';
+import { Nominators, RecentlyOfflineMap } from '../types';
 
 type Props = I18nProps & {
   address: string,
@@ -21,11 +21,21 @@ type Props = I18nProps & {
   defaultName: string,
   isAuthor: boolean,
   lastBlock: string,
-  nominators: Nominators
+  nominators: Nominators,
+  recentlyOffline: RecentlyOfflineMap,
+  staking_bonded?: Option<AccountId>
 };
 
-class Address extends React.PureComponent<Props> {
-  private getDisplayName () {
+type State = {
+  badgeExpanded: boolean;
+};
+
+class Address extends React.PureComponent<Props, State> {
+  state: State = {
+    badgeExpanded: false
+  };
+
+  private getDisplayName = (): string | undefined => {
     const { address, defaultName } = this.props;
 
     const pair = keyring.getAccount(address).isValid()
@@ -37,29 +47,70 @@ class Address extends React.PureComponent<Props> {
       : defaultName;
   }
 
+  private onClickBadge = (): void => {
+    const { badgeExpanded } = this.state;
+    this.setState({ badgeExpanded: !badgeExpanded });
+  }
+
   render () {
-    const { address, balanceArray, isAuthor, lastBlock, nominators, t } = this.props;
+    const { address, balanceArray, isAuthor, lastBlock, nominators, recentlyOffline, staking_bonded, t } = this.props;
+    const { badgeExpanded } = this.state;
     const myNominators = Object.keys(nominators).filter((nominator) =>
       nominators[nominator].indexOf(address) !== -1
     );
-    const children = myNominators.length
-      ? (
-      <details className='staking--Account-detail'>
-        <summary>{t('Nominators ({{count}})', {
-          replace: {
-            count: myNominators.length
-          }
-        })}</summary>
-        {myNominators.map((accountId) =>
-          <AddressMini
-            key={accountId.toString()}
-            value={accountId}
-            withBalance
-          />
+    const bondedId: string | null = staking_bonded && staking_bonded.isSome
+      ? staking_bonded.unwrap().toString()
+      : null;
+
+    const hasNominators = !!myNominators.length;
+    const isRecentlyOffline = bondedId && recentlyOffline[bondedId];
+
+    const children = (hasNominators || isRecentlyOffline) ? (
+      <>
+        <details className='staking--Account-detail'>
+          {myNominators.length && (
+          <>
+            <summary>
+              {t('Nominators ({{count}})', {
+                replace: {
+                  count: myNominators.length
+                }
+              })}
+            </summary>
+            {myNominators.map((accountId) =>
+              <AddressMini
+                key={accountId.toString()}
+                value={accountId}
+                withBalance
+              />
+            )}
+          </>
         )}
-      </details>
-    )
-    : undefined;
+        </details>
+        {(bondedId && recentlyOffline[bondedId]) && (() => {
+          const { blockNumber, instances } = recentlyOffline[bondedId];
+
+          return (
+            <div
+              onClick={this.onClickBadge}
+              className={['recentlyOffline', badgeExpanded ? 'expand' : ''].join(' ')}
+            >
+              <div className='badge'>
+                {instances.toString()}
+              </div>
+              <div className='detail'>
+                {t('Reported offline {{instances}} times since block #{{blockNumber}}', {
+                  replace: {
+                    instances: instances.toString(),
+                    blockNumber
+                  }
+                })}
+              </div>
+            </div>
+          );
+        })()}
+      </>
+    ) : undefined;
 
     return (
       <article key={address}>
@@ -85,5 +136,6 @@ class Address extends React.PureComponent<Props> {
 
 export default withMulti(
   Address,
-  translate
+  translate,
+  withCall('query.staking.bonded', { paramName: 'address' })
 );

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -4,7 +4,7 @@
 
 import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
-import { Nominators } from '../types';
+import { Nominators, RecentlyOffline, RecentlyOfflineMap } from '../types';
 
 import React from 'react';
 import { AccountId, Balance, HeaderExtended } from '@polkadot/types';
@@ -20,7 +20,8 @@ type Props = I18nProps & {
   chain_subscribeNewHead?: HeaderExtended,
   current: Array<string>,
   next: Array<string>,
-  nominators: Nominators
+  nominators: Nominators,
+  staking_recentlyOffline?: RecentlyOffline
 };
 
 class CurrentList extends React.PureComponent<Props> {
@@ -66,7 +67,7 @@ class CurrentList extends React.PureComponent<Props> {
   }
 
   private renderColumn (addresses: Array<string>, defaultName: string) {
-    const { balances, balanceArray, chain_subscribeNewHead, nominators, t } = this.props;
+    const { balances, balanceArray, chain_subscribeNewHead, nominators, staking_recentlyOffline, t } = this.props;
 
     if (addresses.length === 0) {
       return (
@@ -82,6 +83,17 @@ class CurrentList extends React.PureComponent<Props> {
       lastAuthor = (chain_subscribeNewHead.author || '').toString();
     }
 
+    const recentlyOffline: RecentlyOfflineMap = (staking_recentlyOffline || []).reduce(
+      (result, [accountId, blockNumber, instances]) => ({
+        ...result,
+        [accountId.toString()]: {
+          blockNumber,
+          instances
+        }
+      }),
+      {}
+    );
+
     return (
       <div>
         {addresses.map((address) => (
@@ -94,6 +106,7 @@ class CurrentList extends React.PureComponent<Props> {
             key={address}
             lastBlock={lastBlock}
             nominators={nominators}
+            recentlyOffline={recentlyOffline}
           />
         ))}
       </div>
@@ -105,6 +118,7 @@ export default withMulti(
   CurrentList,
   translate,
   withCalls<Props>(
-    'derive.chain.subscribeNewHead'
+    'derive.chain.subscribeNewHead',
+    'query.staking.recentlyOffline'
   )
 );

--- a/packages/app-staking/src/Overview/index.css
+++ b/packages/app-staking/src/Overview/index.css
@@ -54,6 +54,11 @@
     position: relative;
 
     details {
+      summary {
+        cursor: pointer;
+        outline: none;
+      }
+
       summary + div {
         margin-top: 0;
       }
@@ -76,6 +81,51 @@
         height: auto;
         opacity: 1;
         transform: scale(1);
+      }
+    }
+
+    .recentlyOffline {
+      position: absolute;
+      font-size: 12px;
+      cursor: help;
+      display: flex;
+      justify-content: center;
+      right: 12px;
+      top: 88px;
+      width: 22px;
+      height: 22px;
+      padding: 0;
+      background: red;
+      color: #eee;
+      border-radius: 16px;
+      box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+      transition: all ease .2s;
+
+      & > * {
+        line-height: 22px;
+        overflow: hidden;
+        transition: all ease 0.25;
+      }
+
+      .badge {
+        font-weight: bold;
+        width: auto;
+      }
+
+      .detail {
+        width: 0;
+      }
+
+      &.expand {
+        width: 300px;
+
+        .badge {
+          width: 0;
+        }
+
+        .detail {
+          width: auto;
+        }
       }
     }
   }

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -1,9 +1,9 @@
 // Copyright 2017-2019 @polkadot/app-staking authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
-
+import BN from 'bn.js';
 import { DerivedBalancesMap } from '@polkadot/api-derive/types';
-import { AccountId, Balance } from '@polkadot/types';
+import { AccountId, Balance, BlockNumber } from '@polkadot/types';
 
 export type Nominators = {
   // stash account and who is being nominated
@@ -17,3 +17,14 @@ export type ComponentProps = {
   nominators: Nominators,
   validators: Array<string>
 };
+
+export type RecentlyOffline = Array<[AccountId, BlockNumber, BN]>;
+
+export type RecentlyOfflineMap = {
+  [s: string]: OfflineStatus
+};
+
+export interface OfflineStatus {
+  blockNumber: BlockNumber;
+  instances: BN;
+}


### PR DESCRIPTION
Adds a lower-right badge for staking validators showing number of offline instances, which expands to message with instances and first block number. It was originally to open on hover but this seems more mobile friendly. I have combined the nominators summary and badge into a new combined child node.

Please double check that I have the mapping from recentlyOffline() through bonded() correct! At the moment there are two validators with the badge visible. Also any corrections for css/js project standards I'm not aware of :)