### PR TITLE
Tabs Simplify and Summary Tidy-up

### DIFF
--- a/packages/app-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/app-explorer/src/NodeInfo/Summary.tsx
@@ -45,18 +45,18 @@ class Summary extends React.PureComponent<Props, State> {
 
     return (
       <SummaryBox>
-        <section className='ui--media-medium'>
+        <section>
           <CardSummary label={t('refresh in')}>
             <Elapsed value={nextRefresh} />
           </CardSummary>
-          <CardSummary label={t('total peers')}>
+          <CardSummary label={t('total peers')} className='ui--media-medium'>
             {
               info.health
                 ? `${info.health.peers.toNumber()}`
                 : '-'
             }
           </CardSummary>
-          <CardSummary label={t('syncing')}>
+          <CardSummary label={t('syncing')} className='ui--media-medium'>
             {
               info.health
                 ? (

--- a/packages/app-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/app-explorer/src/NodeInfo/Summary.tsx
@@ -49,14 +49,14 @@ class Summary extends React.PureComponent<Props, State> {
           <CardSummary label={t('refresh in')}>
             <Elapsed value={nextRefresh} />
           </CardSummary>
-          <CardSummary label={t('total peers')} className='ui--media-medium'>
+          <CardSummary label={t('total peers')} className='ui--media-small'>
             {
               info.health
                 ? `${info.health.peers.toNumber()}`
                 : '-'
             }
           </CardSummary>
-          <CardSummary label={t('syncing')} className='ui--media-medium'>
+          <CardSummary label={t('syncing')} className='ui--media-small'>
             {
               info.health
                 ? (

--- a/packages/app-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/app-explorer/src/NodeInfo/Summary.tsx
@@ -49,14 +49,20 @@ class Summary extends React.PureComponent<Props, State> {
           <CardSummary label={t('refresh in')}>
             <Elapsed value={nextRefresh} />
           </CardSummary>
-          <CardSummary label={t('total peers')} className='ui--media-small'>
+          <CardSummary
+            className='ui--media-small'
+            label={t('total peers')}
+          >
             {
               info.health
                 ? `${info.health.peers.toNumber()}`
                 : '-'
             }
           </CardSummary>
-          <CardSummary label={t('syncing')} className='ui--media-small'>
+          <CardSummary 
+            className='ui--media-small'
+            label={t('syncing')}
+          >
             {
               info.health
                 ? (

--- a/packages/app-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/app-explorer/src/NodeInfo/Summary.tsx
@@ -59,7 +59,7 @@ class Summary extends React.PureComponent<Props, State> {
                 : '-'
             }
           </CardSummary>
-          <CardSummary 
+          <CardSummary
             className='ui--media-small'
             label={t('syncing')}
           >

--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -19,8 +19,8 @@ class Summary extends React.PureComponent<Props> {
 
     return (
       <SummaryBox>
-        <section className='ui--media-small'>
-          <CardSummary label={t('target')}>
+        <section>
+          <CardSummary label={t('target')} className='ui--media-small'>
             <TimePeriod />
           </CardSummary>
           <CardSummary label={t('last block')}>

--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -20,7 +20,10 @@ class Summary extends React.PureComponent<Props> {
     return (
       <SummaryBox>
         <section>
-          <CardSummary label={t('target')} className='ui--media-small'>
+          <CardSummary
+            className='ui--media-small'
+            label={t('target')}
+          >
             <TimePeriod />
           </CardSummary>
           <CardSummary label={t('last block')}>

--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -32,6 +32,10 @@ const Wrapper = styled.div`
   overflow-y: auto;
   width: 100%;
   padding: 0 2em;
+
+  @media(max-width: 768px) {
+    padding: 0 1.5em;
+  }
 `;
 
 const unknown = {

--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled.div`
   padding: 0 2em;
 
   @media(max-width: 768px) {
-    padding: 0 1.5em;
+    padding: 0 0.5em;
   }
 `;
 

--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -31,11 +31,15 @@ const Wrapper = styled.div`
   overflow-x: hidden;
   overflow-y: auto;
   width: 100%;
-  padding: 0 2em;
+  padding: 0 2rem;
 
   @media(max-width: 768px) {
-    padding: 0 0.5em;
+    padding: 0 0.5rem;
   }
+`;
+
+const Connecting = styled.div`
+  padding: 1rem 0;
 `;
 
 const unknown = {
@@ -57,7 +61,7 @@ class Content extends React.Component<Props> {
     if (needsApi && (!isApiReady || !isApiConnected)) {
       return (
         <Wrapper>
-          <main>{t('Waiting for API to be connected and ready.')}</main>
+          <Connecting>{t('Waiting for API to be connected and ready.')}</Connecting>
         </Wrapper>
       );
     }

--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -31,6 +31,7 @@ const Wrapper = styled.div`
   overflow-x: hidden;
   overflow-y: auto;
   width: 100%;
+  padding: 0 2em;
 `;
 
 const unknown = {

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -28,11 +28,18 @@ const Card = styled.article`
   > div {
     font-size: 2.1rem;
     font-weight: 100;
-    line-height: 2.25rem;
     text-align: right;
 
     > * {
-      margin: 0.4rem 0;
+      margin: 0.8rem 0;
+
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     > label {
@@ -41,7 +48,7 @@ const Card = styled.article`
     }
 
     .progress {
-      margin: 0.25rem 0 -0.5rem !important;
+      margin: 0.5rem 0 -0.5rem !important;
       background: rgba(0,0,0,0.05);
     }
   }

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -20,15 +20,14 @@ const Card = styled.article`
   background: none;
   color: rgba(0, 0, 0, 0.6);
   display: flex;
-  flex: 0 1 auto;
+  flex: 0 1 auto%;
   flex-flow: row wrap;
   justify-content: flex-end;
   min-height: 5.7rem;
   padding: 0.5rem 1.5rem;
-  text-align: left;
 
   > div {
-    font-size: 2.2rem;
+    font-size: 2.1rem;
     font-weight: 100;
     line-height: 2.25rem;
     text-align: right;
@@ -39,13 +38,20 @@ const Card = styled.article`
 
     > label {
       line-height: 1rem;
-      min-width: 7rem !important;
       font-size: 0.95rem;
     }
 
     .progress {
       margin: 0.25rem 0 -0.5rem !important;
       background: rgba(0,0,0,0.05);
+    }
+  }
+
+  @media(max-width: 768px) {
+    padding: 0.5 0.75em;
+
+    > div {
+      font-size: 1.8rem;
     }
   }
 `;

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -54,7 +54,7 @@ const Card = styled.article`
     }
   }
 
-  @media(max-width: 768px) {
+  @media(max-width: 767px) {
     min-height: 4.8rem;
     padding: 0.25 0.4em;
 

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -40,7 +40,7 @@ const Card = styled.article`
     > label {
       line-height: 1rem;
       min-width: 7rem !important;
-      font-size: 0.9rem;
+      font-size: 0.95rem;
     }
 
     .progress {

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -81,7 +81,7 @@ type Props = BareProps & {
 
 export default class CardSummary extends React.PureComponent<Props> {
   render () {
-    const { children, progress, label, className } = this.props;
+    const { children, className, label, progress, style } = this.props;
     const value = progress && progress.value;
     const total = progress && progress.total;
     const left = progress && !isUndefined(value) && !isUndefined(total) && value.gten(0) && total.gtn(0)
@@ -105,7 +105,10 @@ export default class CardSummary extends React.PureComponent<Props> {
     }
 
     return (
-      <Card className={className}>
+      <Card 
+        className={className}
+        style={style}
+      >
         <Labelled
           isSmall
           label={label}

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -28,10 +28,11 @@ const Card = styled.article`
   > div {
     font-size: 2.1rem;
     font-weight: 100;
+    line-height: 2.1rem;
     text-align: right;
 
     > * {
-      margin: 0.8rem 0;
+      margin: 0.6rem 0;
 
       &:first-child {
         margin-top: 0;
@@ -48,7 +49,7 @@ const Card = styled.article`
     }
 
     .progress {
-      margin: 0.5rem 0 -0.5rem !important;
+      margin: 0.2rem 0 -0.5rem !important;
       background: rgba(0,0,0,0.05);
     }
   }
@@ -59,6 +60,7 @@ const Card = styled.article`
 
     > div {
       font-size: 1.4rem;
+      line-height: 1.4rem;
     }
   }
 `;

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -17,10 +17,9 @@ import styled from 'styled-components';
 const Card = styled.article`
   align-items: center;
   box-shadow: none;
-  background: none;
   color: rgba(0, 0, 0, 0.6);
   display: flex;
-  flex: 0 1 auto%;
+  flex: 0 1 auto;
   flex-flow: row wrap;
   justify-content: flex-end;
   min-height: 5.7rem;
@@ -48,10 +47,11 @@ const Card = styled.article`
   }
 
   @media(max-width: 768px) {
-    padding: 0.5 0.75em;
+    min-height: 4.8rem;
+    padding: 0.25 0.75em;
 
     > div {
-      font-size: 1.8rem;
+      font-size: 1.7rem;
     }
   }
 `;
@@ -72,7 +72,7 @@ type Props = BareProps & {
 
 export default class CardSummary extends React.PureComponent<Props> {
   render () {
-    const { children, progress, label } = this.props;
+    const { children, progress, label, className } = this.props;
     const value = progress && progress.value;
     const total = progress && progress.total;
     const left = progress && !isUndefined(value) && !isUndefined(total) && value.gten(0) && total.gtn(0)
@@ -96,7 +96,7 @@ export default class CardSummary extends React.PureComponent<Props> {
     }
 
     return (
-      <Card>
+      <Card className={className}>
         <Labelled
           isSmall
           label={label}

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -55,10 +55,10 @@ const Card = styled.article`
 
   @media(max-width: 768px) {
     min-height: 4.8rem;
-    padding: 0.25 0.75em;
+    padding: 0.25 0.4em;
 
     > div {
-      font-size: 1.7rem;
+      font-size: 1.4rem;
     }
   }
 `;

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -105,7 +105,7 @@ export default class CardSummary extends React.PureComponent<Props> {
     }
 
     return (
-      <Card 
+      <Card
         className={className}
         style={style}
       >

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -41,7 +41,7 @@ const StyledSummary = styled.div`
 		}
 	}
 
-  @media(max-width: 768px) {
+  @media(max-width: 767px) {
     padding: 0;
 
     .ui--media-small {

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -20,20 +20,7 @@ const StyledSummary = styled.div`
   flex-wrap: no-wrap;
   justify-content: space-between;
   margin-bottom: 2.5em;
-  overflow-x: scroll;
   padding-right: 1rem;
-
-  &::-webkit-scrollbar {
-    height: 2px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: #e1e1e1;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: none;
-  }
 
   > section {
 		display: flex;

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -43,7 +43,7 @@ const StyledSummary = styled.div`
 
   @media(max-width: 768px) {
     padding: 0;
-    
+
     .ui--media-small {
       display: none !important;
     }

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -42,6 +42,8 @@ const StyledSummary = styled.div`
 	}
 
   @media(max-width: 768px) {
+    padding: 0;
+    
     .ui--media-small {
       display: none !important;
     }

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -13,7 +13,6 @@ type Props = BareProps & {
 
 const StyledSummary = styled.div`
   align-items: stretch;
-  background: rgba(255,255,255,0.65);
   border-radius: 4px;
   box-shadow: 0 10px 40px rgba(0,0,0,.1);
   display: flex;
@@ -27,10 +26,6 @@ const StyledSummary = styled.div`
 		flex: 0 1 auto;
 		text-align: left;
 	}
-
-  > section:first-child > article:first-child .label-small > label {
-    min-width: 4rem !important;
-  }
 
 	details & {
 		display: block;

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -14,12 +14,10 @@ type Props = BareProps & {
 const StyledSummary = styled.div`
   align-items: stretch;
   border-radius: 4px;
-  box-shadow: 0 10px 40px rgba(0,0,0,.1);
   display: flex;
   flex-wrap: no-wrap;
   justify-content: space-between;
   margin-bottom: 2.5em;
-  padding-right: 1rem;
 
   > section {
 		display: flex;
@@ -42,6 +40,12 @@ const StyledSummary = styled.div`
 			margin-top: 0.75rem;
 		}
 	}
+
+  @media(max-width: 768px) {
+    .ui--media-small {
+      display: none !important;
+    }
+  }
 
   .ui.label {
     padding-left: 0;

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -97,7 +97,7 @@ article {
 }
 
 header {
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.1rem;
   text-align: center;
 
   @media(max-width: 767px) {

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -97,6 +97,6 @@ article {
 }
 
 header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.2rem;
   text-align: center;
 }

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -53,7 +53,6 @@ br {
 }
 
 main {
-  padding: 1em 2em;
   min-height: 100vh;
 }
 
@@ -98,6 +97,6 @@ article {
 }
 
 header {
-  margin-bottom: 2em;
+  margin-bottom: 1.5rem;
   text-align: center;
 }

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -100,7 +100,7 @@ header {
   margin-bottom: 1.2rem;
   text-align: center;
 
-  @media(max-width: 768px) {
+  @media(max-width: 767px) {
     margin-bottom: 0.8rem;
   }
 }

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -99,4 +99,8 @@ article {
 header {
   margin-bottom: 1.2rem;
   text-align: center;
+
+  @media(max-width: 768px) {
+    margin-bottom: 0.8rem;
+  }
 }

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -13,6 +13,7 @@
 .ui--media-large,
 .ui--media-medium,
 .ui--media-small {
+  display: none;
   height: 0;
   visibility: hidden;
   width: 0;
@@ -70,6 +71,7 @@ th.ui--media-small {
     height: auto;
     visibility: visible;
     width: auto;
+    
   }
 
   td.ui--media-small,

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -83,7 +83,7 @@ th.ui--media-small {
 /* tabs */
 @media (max-width: 767px) {
   .ui.menu.tabular {
-    padding-left: 4.2rem !important;
+    padding-left: 5.2rem !important;
   }
 }
 

--- a/packages/ui-app/src/styles/semantic.css
+++ b/packages/ui-app/src/styles/semantic.css
@@ -160,14 +160,27 @@
 }
 
 .ui.menu.tabular {
-  background: #f2f2f2;
+  border-color: #e6e6e6;
   /* break out of the wrapping main padding */
   margin: -1em -2em 0;
-  padding: 1em 2em 0;
+  overflow-x: scroll;
+  padding: 2em 2em 0 2em;
   transition: padding-left 0.2s linear 0.4s;
 
-  .item.active {
-    background: #fafafa /* #fff */;
+  &::-webkit-scrollbar {
+    display: none;
+    width: 0px;
+  }
+
+  .item {
+    border-bottom: 2px solid rgba(0, 0, 0, 0);
+    top: -1px;
+
+    &.active {
+      background: none; /* #fafafa */;
+      border: none;
+      border-bottom: 2px solid #3f3f3f;
+    }
   }
 }
 

--- a/packages/ui-app/src/styles/theme/polkadot.css
+++ b/packages/ui-app/src/styles/theme/polkadot.css
@@ -114,4 +114,8 @@
       color: $nav-link;
     }
   }
+
+  .ui.menu.tabular .item.active {
+    border-bottom: 2px solid rgba(215, 94, 161, 1);
+  }
 }


### PR DESCRIPTION
Tabs:
- minimises Tabs UI 
- adds scrolling functionality to Tabs bar

Summary:
- removes scrolling functionality from summary bar
- Smaller stats on small screens
- 3 stats on small screens: room for 2 pertinent and 1 ticker

Padding:
- minimises `<Content />` padding on small screens 
- removes padding from `<main>`, with the thought of having more flexibility further down the hierarchy
    - would be nice to have a full width summary bar
    - would be nice to have more granular control of content padding

<img width="1260" alt="Screenshot 2019-04-03 at 09 20 34" src="https://user-images.githubusercontent.com/13929023/55446330-c27d9480-55f1-11e9-893c-fe15f31ed58a.png">

Before and after (so far):

<img width="940" alt="Screenshot 2019-04-03 at 14 20 41" src="https://user-images.githubusercontent.com/13929023/55457179-c1615d00-561b-11e9-942c-014b6d8c68f5.png">