### PR TITLE
Refined InputNumber

### DIFF
--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -31,6 +31,8 @@ type Props = BareProps & {
   onBlur?: (event: React.KeyboardEvent<Element>) => void,
   onKeyDown?: (event: React.KeyboardEvent<Element>) => void,
   onKeyUp?: (event: React.KeyboardEvent<Element>) => void,
+  onKeyPress?: (event: React.KeyboardEvent<Element>) => void,
+  onPaste?: (event: React.ClipboardEvent<Element>) => void,
   placeholder?: string,
   tabIndex?: number,
   type?: Input$Type,
@@ -41,6 +43,12 @@ type Props = BareProps & {
 type State = {
   name: string;
 };
+
+// Find decimal separator used in current locale
+const getDecimalSeparator = (): string => Intl.NumberFormat()
+    .formatToParts(1.1)
+    .find(part => part.type === 'decimal')!
+    .value;
 
 // note: KeyboardEvent.keyCode and KeyboardEvent.which are deprecated
 const KEYS = {
@@ -57,7 +65,8 @@ const KEYS = {
   TAB: 'Tab',
   V: 'v',
   X: 'x',
-  ZERO: '0'
+  ZERO: '0',
+  DECIMAL: getDecimalSeparator()
 };
 
 const KEYS_PRE: Array<any> = [KEYS.ALT, KEYS.CMD, KEYS.CTRL];
@@ -132,6 +141,7 @@ export default class Input extends React.PureComponent<Props, State> {
                 ? 'new-password'
                 : 'off'
             }
+            onPaste={this.onPaste}
           />
           {
             isEditable
@@ -165,6 +175,14 @@ export default class Input extends React.PureComponent<Props, State> {
 
     if (onKeyUp) {
       onKeyUp(event);
+    }
+  }
+
+  private onPaste = (event: React.ClipboardEvent<Element>): void => {
+    const { onPaste } = this.props;
+
+    if (onPaste) {
+      onPaste(event);
     }
   }
 }

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -142,7 +142,6 @@ class InputNumber extends React.PureComponent<Props, State> {
   }
 
   private onChange = (value: string): void => {
-    console.log('onChange');
     const { bitLength, onChange } = this.props;
     const { siUnit } = this.state;
 

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -248,7 +248,7 @@ class InputNumber extends React.PureComponent<Props, State> {
   private bnToInputValue = (bn: BN, siUnit: string): string => {
     const decimals = formatBalance.getDefaults().decimals;
     const siPower = formatBalance.findSi(siUnit).power;
-    const base = new BN(10).pow(new BN(decimals + siPower))
+    const base = new BN(10).pow(new BN(decimals + siPower));
 
     const zero = new BN(0);
     const div = bn.div(base);
@@ -256,14 +256,18 @@ class InputNumber extends React.PureComponent<Props, State> {
 
     return `${
       div.gt(zero) ? div.toString() : '0'
-    }${(() => {
-      const padding = Math.max(
-        mod.toString().length,
-        base.toString().length - div.toString().length,
-        bn.toString().length - div.toString().length,
-      );
-      return mod.gt(zero) ? `.${mod.toString(10, padding).replace(/0*$/, '')}` : ''
-    })()}`
+    }${
+      mod.gt(zero) ?
+        (() => {
+          const padding = Math.max(
+            mod.toString().length,
+            base.toString().length - div.toString().length,
+            bn.toString().length - div.toString().length
+          );
+          return `.${mod.toString(10, padding).replace(/0*$/, '')}`;
+        })() :
+        ''
+    }`;
   }
 }
 

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -84,7 +84,6 @@ class InputNumber extends React.PureComponent<Props, State> {
   }
 
   render () {
-    console.log('render');
     const { bitLength = DEFAULT_BITLENGTH, className, isSi, isDisabled, maxLength, style, t } = this.props;
     const { isValid, value } = this.state;
     const maxValueLength = this.maxValue(bitLength).toString().length - 1;
@@ -262,7 +261,6 @@ class InputNumber extends React.PureComponent<Props, State> {
         base.toString().length - div.toString().length,
         bn.toString().length - div.toString().length,
       );
-      console.log(padding);
       return mod.gt(zero) ? `.${mod.toString(10, padding).replace(/0*$/, '')}` : ''
     })()}`
   }

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -261,7 +261,6 @@ class InputNumber extends React.PureComponent<Props, State> {
 
     const base = new BN(10).pow(new BN(basePower + siPower));
     const zero = new BN(0);
-    
     const div = bn.div(base);
     const mod = bn.mod(base);
 


### PR DESCRIPTION
Closes #886 

- Change InputNumber to default to whole unit (DOT)
- Update input value to reflect new unit when selected from dropdown
- Regex-based key/paste interception and sanitizing
- Prevent edge cases (too small or too big for max bit length)
- Distinguishes between , and . for decimal character (needs EU tester)

Originally was going to use a number input but there was some trouble with allowing region-specific decimal separators