### PR TITLE
recentlyOffline returns multiple entries per account

### DIFF
--- a/packages/app-staking/src/Account/SessionKey.tsx
+++ b/packages/app-staking/src/Account/SessionKey.tsx
@@ -68,7 +68,7 @@ class Key extends React.PureComponent<Props, State> {
         <Modal.Content className='ui--signer-Signer-Content'>
           <InputAddress
             className='medium'
-            help={t('Changing the key only takes effect at the start of the next session.')}
+            help={t('Changing the key only takes effect at the start of the next session. If validating, you should (currently) use an ed25519 key.')}
             isDisabled
             label={t('session key')}
             value={accountId}

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -8,7 +8,7 @@ import { Nominators, RecentlyOfflineMap } from '../types';
 
 import BN from 'bn.js';
 import React from 'react';
-import { AccountId, Balance, Option } from '@polkadot/types';
+import { AccountId, Balance, Option, StakingLedger } from '@polkadot/types';
 import { withCall, withMulti } from '@polkadot/ui-api/with';
 import { AddressMini, AddressRow } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
@@ -25,7 +25,7 @@ type Props = I18nProps & {
   lastBlock: string,
   nominators: Nominators,
   recentlyOffline: RecentlyOfflineMap,
-  staking_bonded?: Option<AccountId>
+  staking_ledger?: Option<StakingLedger>
 };
 
 type State = {
@@ -111,17 +111,17 @@ class Address extends React.PureComponent<Props, State> {
   }
 
   private renderOffline () {
-    const { recentlyOffline, staking_bonded, t } = this.props;
+    const { recentlyOffline, staking_ledger, t } = this.props;
     const { badgeExpanded } = this.state;
-    const bondedId: string | null = staking_bonded && staking_bonded.isSome
-      ? staking_bonded.unwrap().toString()
+    const stashId: string | null = staking_ledger && staking_ledger.isSome
+      ? staking_ledger.unwrap().stash.toString()
       : null;
 
-    if (!bondedId || !recentlyOffline[bondedId]) {
+    if (!stashId || !recentlyOffline[stashId]) {
       return null;
     }
 
-    const offline = recentlyOffline[bondedId];
+    const offline = recentlyOffline[stashId];
     const count = offline.reduce((total, { count }) => total.add(count), new BN(0));
     const blockNumbers = offline.map(({ blockNumber }) => `#${formatNumber(blockNumber)}`);
 
@@ -134,7 +134,7 @@ class Address extends React.PureComponent<Props, State> {
           {count.toString()}
         </div>
         <div className='detail'>
-          {t('Reported offline {{count}} times, at blocks {{blockNumbers}}', {
+          {t('Reported offline {{count}} times, at {{blockNumbers}}', {
             replace: {
               count: count.toString(),
               blockNumbers: blockNumbers.join(', ')
@@ -149,5 +149,5 @@ class Address extends React.PureComponent<Props, State> {
 export default withMulti(
   Address,
   translate,
-  withCall('query.staking.bonded', { paramName: 'address' })
+  withCall('query.staking.ledger', { paramName: 'address' })
 );

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -24,7 +24,33 @@ type Props = I18nProps & {
   staking_recentlyOffline?: RecentlyOffline
 };
 
-class CurrentList extends React.PureComponent<Props> {
+type State = {
+  recentlyOffline: RecentlyOfflineMap
+};
+
+class CurrentList extends React.PureComponent<Props, State> {
+  state: State = { recentlyOffline: {} };
+
+  static getDerivedStateFromProps ({ staking_recentlyOffline = [] }: Props): State {
+    return {
+      recentlyOffline: staking_recentlyOffline.reduce(
+        (result, [accountId, blockNumber, count]) => {
+          const account = accountId.toString();
+
+          if (!result[account]) {
+            result[account] = [];
+          }
+
+          result[account].push({
+            blockNumber,
+            count
+          });
+
+          return result;
+        }, {} as RecentlyOfflineMap)
+    };
+  }
+
   render () {
     return (
       <div className='validator--ValidatorsList ui--flex-medium'>
@@ -67,7 +93,8 @@ class CurrentList extends React.PureComponent<Props> {
   }
 
   private renderColumn (addresses: Array<string>, defaultName: string) {
-    const { balances, balanceArray, chain_subscribeNewHead, nominators, staking_recentlyOffline, t } = this.props;
+    const { balances, balanceArray, chain_subscribeNewHead, nominators, t } = this.props;
+    const { recentlyOffline } = this.state;
 
     if (addresses.length === 0) {
       return (
@@ -82,17 +109,6 @@ class CurrentList extends React.PureComponent<Props> {
       lastBlock = `#${formatNumber(chain_subscribeNewHead.blockNumber)}`;
       lastAuthor = (chain_subscribeNewHead.author || '').toString();
     }
-
-    const recentlyOffline: RecentlyOfflineMap = (staking_recentlyOffline || []).reduce(
-      (result, [accountId, blockNumber, instances]) => ({
-        ...result,
-        [accountId.toString()]: {
-          blockNumber,
-          instances
-        }
-      }),
-      {}
-    );
 
     return (
       <div>

--- a/packages/app-staking/src/Overview/index.css
+++ b/packages/app-staking/src/Overview/index.css
@@ -86,12 +86,12 @@
 
     .recentlyOffline {
       position: absolute;
+      bottom: 0.75rem;
       font-size: 12px;
       cursor: help;
       display: flex;
       justify-content: center;
-      right: 12px;
-      top: 88px;
+      right: 0.75rem;
       width: 22px;
       height: 22px;
       padding: 0;

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -62,6 +62,8 @@ class App extends React.PureComponent<Props, State> {
   }
 
   static getDerivedStateFromProps ({ staking_controllers = [[], []], session_validators = [], staking_nominators = [[], []] }: Props): State {
+    console.error(staking_controllers[0].map((id) => id.toString()));
+
     return {
       intentions: staking_controllers[1].filter((optId) => optId.isSome).map((accountId) =>
         accountId.unwrap().toString()

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -22,10 +22,10 @@ export type ComponentProps = {
 export type RecentlyOffline = Array<[AccountId, BlockNumber, BN]>;
 
 export type RecentlyOfflineMap = {
-  [s: string]: OfflineStatus
+  [s: string]: Array<OfflineStatus>
 };
 
 export interface OfflineStatus {
   blockNumber: BlockNumber;
-  instances: BN;
+  count: BN;
 }


### PR DESCRIPTION
- Change the recentOffline map to have an array of values per account (see attached screenshot)
- Generate recentOffline with `getDerivedStateFromProps`
- Split nominators & offline rendering into own functions

<img width="1206" alt="Polkadot:Substrate Portal 2019-04-05 14-01-58" src="https://user-images.githubusercontent.com/1424473/55626313-79714000-57ab-11e9-98cc-c010d2e63691.png">

<img width="615" alt="Polkadot:Substrate Portal 2019-04-05 14-58-55" src="https://user-images.githubusercontent.com/1424473/55629399-66fb0480-57b3-11e9-855f-50683e2288f4.png">
