### PR TITLE
Styled Theming + media template introduction

### DIFF
--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -34,7 +34,7 @@ const media = Object
    .keys(ScreenSizes)
    .reduce((acc, label) => {
       acc[label] = (...args) => css`
-       @media (max-width: ${ScreenSizes[label] / 16}em) {
+       @media (min-width: ${ScreenSizes[label] / 16}em) {
         ${css(...args)}
        }
       `
@@ -48,10 +48,10 @@ const Wrapper = styled.div`
   min-height: 100vh;
 
   header {
-    margin-bottom: 1.1rem;
+    margin-bottom: 0.8rem;
     text-align: center;
     ${media.TABLET`
-      margin-bottom: 0.8rem;
+      margin-bottom: 1.1rem;
    `}
   }
 `;

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -7,7 +7,7 @@ import { SideBarTransition, SIDEBAR_TRANSITION_DURATION, SIDEBAR_MENU_THRESHOLD 
 
 import React from 'react';
 import store from 'store';
-import styled, {ThemeProvider} from 'styled-components';
+import styled, { css, ThemeProvider } from 'styled-components';
 import { classes } from '@polkadot/ui-app/util';
 import Signer from '@polkadot/ui-signer';
 import settings from '@polkadot/ui-settings';
@@ -19,7 +19,7 @@ import Content from './Content';
 import SideBar from './SideBar';
 
 import theme from 'styled-theming';
-import ScreenSizes from '@polkadot/ui-app/constants';
+import { ScreenSizes } from '@polkadot/ui-app/constants';
 
 type Props = BareProps & {};
 
@@ -30,12 +30,30 @@ type State = {
   transition: SideBarTransition
 };
 
+const media = Object
+   .keys(ScreenSizes)
+   .reduce((acc, label) => {
+      acc[label] = (...args) => css`
+       @media (max-width: ${ScreenSizes[label] / 16}em) {
+        ${css(...args)}
+       }
+      `
+return acc
+}, {});
+
 const Wrapper = styled.div`
   align-items: stretch;
   box-sizing: border-box;
   display: flex;
-  height: 100%;
   min-height: 100vh;
+
+  header {
+    margin-bottom: 1.1rem;
+    text-align: center;
+    ${media.TABLET`
+      margin-bottom: 0.8rem;
+   `}
+  }
 `;
 
 class Apps extends React.Component<Props, State> {
@@ -69,7 +87,10 @@ class Apps extends React.Component<Props, State> {
 
     const { isCollapsed, isMenu, menuOpen } = this.state;
     return (
-      <ThemeProvider theme={{ theme: settings.uiTheme }}>
+      <ThemeProvider theme={{
+        theme: settings.uiTheme,
+        media: media,
+      }}>
         <Wrapper
           className={
             classes('apps-Wrapper',

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -7,7 +7,7 @@ import { SideBarTransition, SIDEBAR_TRANSITION_DURATION, SIDEBAR_MENU_THRESHOLD 
 
 import React from 'react';
 import store from 'store';
-import styled from 'styled-components';
+import styled, {ThemeProvider} from 'styled-components';
 import { classes } from '@polkadot/ui-app/util';
 import Signer from '@polkadot/ui-signer';
 import settings from '@polkadot/ui-settings';
@@ -17,6 +17,9 @@ import { hot } from 'react-hot-loader/root';
 import Connecting from './Connecting';
 import Content from './Content';
 import SideBar from './SideBar';
+
+import theme from 'styled-theming';
+import ScreenSizes from '@polkadot/ui-app/constants';
 
 type Props = BareProps & {};
 
@@ -66,28 +69,30 @@ class Apps extends React.Component<Props, State> {
 
     const { isCollapsed, isMenu, menuOpen } = this.state;
     return (
-      <Wrapper
-        className={
-          classes('apps-Wrapper',
-                   !isCollapsed ? 'expanded' : 'collapsed',
-                   isMenu ? 'fixed' : '',
-                   menuOpen ? 'menu-open' : '',
-                   `theme--${settings.uiTheme}`)
-        }
-      >
-        {this.renderMenuBg()}
-        <SideBar
-          collapse={this.collapse}
-          handleResize={this.handleResize}
-          menuOpen={menuOpen}
-          isCollapsed={isCollapsed}
-          toggleMenu={this.toggleMenu}
-        />
-        <Signer>
-          <Content />
-        </Signer>
-        <Connecting />
-      </Wrapper>
+      <ThemeProvider theme={{ theme: settings.uiTheme }}>
+        <Wrapper
+          className={
+            classes('apps-Wrapper',
+                     !isCollapsed ? 'expanded' : 'collapsed',
+                     isMenu ? 'fixed' : '',
+                     menuOpen ? 'menu-open' : '',
+                     `theme--${settings.uiTheme}`)
+          }
+        >
+          {this.renderMenuBg()}
+          <SideBar
+            collapse={this.collapse}
+            handleResize={this.handleResize}
+            menuOpen={menuOpen}
+            isCollapsed={isCollapsed}
+            toggleMenu={this.toggleMenu}
+          />
+          <Signer>
+            <Content />
+          </Signer>
+          <Connecting />
+        </Wrapper>
+      </ThemeProvider>
     );
   }
 

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -76,10 +76,12 @@ class Apps extends React.Component<Props, State> {
 
     const { isCollapsed, isMenu, menuOpen } = this.state;
     return (
-      <ThemeProvider theme={{
-        theme: settings.uiTheme,
-        media: media,
-      }}>
+      <ThemeProvider
+        theme={{
+          theme: settings.uiTheme,
+          media: media
+        }}
+      >
         <Wrapper
           className={
             classes('apps-Wrapper',

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -18,7 +18,6 @@ import Content from './Content';
 import SideBar from './SideBar';
 
 import styled, { ThemeProvider } from 'styled-components';
-import theme from 'styled-theming';
 import { media } from '@polkadot/ui-app/media';
 
 type Props = BareProps & {};

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -77,10 +77,7 @@ class Apps extends React.Component<Props, State> {
     const { isCollapsed, isMenu, menuOpen } = this.state;
     return (
       <ThemeProvider
-        theme={{
-          theme: settings.uiTheme,
-          media: media
-        }}
+        theme={{ theme: settings.uiTheme }}
       >
         <Wrapper
           className={

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -7,7 +7,6 @@ import { SideBarTransition, SIDEBAR_TRANSITION_DURATION, SIDEBAR_MENU_THRESHOLD 
 
 import React from 'react';
 import store from 'store';
-import styled, { css, ThemeProvider } from 'styled-components';
 import { classes } from '@polkadot/ui-app/util';
 import Signer from '@polkadot/ui-signer';
 import settings from '@polkadot/ui-settings';
@@ -18,8 +17,9 @@ import Connecting from './Connecting';
 import Content from './Content';
 import SideBar from './SideBar';
 
+import styled, { ThemeProvider } from 'styled-components';
 import theme from 'styled-theming';
-import { ScreenSizes } from '@polkadot/ui-app/constants';
+import { media } from '@polkadot/ui-app/media';
 
 type Props = BareProps & {};
 
@@ -29,17 +29,6 @@ type State = {
   menuOpen: boolean,
   transition: SideBarTransition
 };
-
-const media = Object
-   .keys(ScreenSizes)
-   .reduce((acc, label) => {
-      acc[label] = (...args) => css`
-       @media (min-width: ${ScreenSizes[label] / 16}em) {
-        ${css(...args)}
-       }
-      `
-return acc
-}, {});
 
 const Wrapper = styled.div`
   align-items: stretch;

--- a/packages/apps/src/SideBar/SideBar.css
+++ b/packages/apps/src/SideBar/SideBar.css
@@ -24,7 +24,7 @@
       opacity: 0;
       width: 0;
     }
-    
+
     &.open {
       opacity: 1;
     }
@@ -43,27 +43,6 @@
     &.expanded {
       width: 12rem;
     }
-
-    > img {
-      background: #333;
-      border-radius: 50%;
-      cursor: pointer;
-      left: 0.9rem;
-      opacity: 0;
-      padding: 4px;
-      position: absolute;
-      transition: opacity 0.2s ease-in, top 0.2s ease-in;
-      top: -2.9rem;
-      width: 2.6rem;
-     
-      &.delayed {
-        transition-delay: 0.4s;
-      }
-      &.open {
-        opacity: 1;
-        top: 0.9rem;
-      }
-    }
   }
 
   .apps--SideBar {
@@ -75,7 +54,7 @@
     left: 0;
     transition: left 0.3s linear;
     width: 100%;
-    
+
     .ui.vertical.menu {
       display: flex;
       height: 100vh;

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -48,6 +48,7 @@ const Toggle = styled.img`
   left: 0.9rem;
   opacity: 0;
   position: absolute;
+  top: 0px;
   transition: opacity 0.2s ease-in, top 0.2s ease-in;
   width: 2.6rem;
 

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 import { media } from '@polkadot/ui-app/media';
 import { Responsive } from 'semantic-ui-react';
 import theme from 'styled-theming';
+import { primaryColor } from '@polkadot/ui-app/styles/theme';
 
 type Props = I18nProps & {
   collapse: () => void,
@@ -32,7 +33,7 @@ type Props = I18nProps & {
 
 const Toggle = styled.img`
   background: ${theme('theme', {
-    substrate: '#333',
+    substrate: primaryColor,
     polkadot: 'none'
   })};
   padding: ${theme('theme', {

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -30,19 +30,15 @@ type Props = I18nProps & {
   toggleMenu: () => void
 };
 
-const toggleTheme = theme('theme', {
-  substrate: '#333',
-  polkadot: 'none'
-});
-
-const togglePadding = theme('theme', {
-  substrate: '4px',
-  polkadot: 'none'
-});
-
 const Toggle = styled.img`
-  background: ${toggleTheme};
-  padding: ${togglePadding};
+  background: ${theme('theme', {
+    substrate: '#333',
+    polkadot: 'none'
+  })};
+  padding: ${theme('theme', {
+    substrate: '4px',
+    polkadot: 'none'
+  })};
   border-radius: 50%;
   cursor: pointer;
   left: 0.9rem;

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -17,7 +17,10 @@ import Item from './Item';
 import NodeInfo from './NodeInfo';
 import getLogo from './logos';
 
+import styled, { css } from 'styled-components';
+import { media } from '@polkadot/ui-app/media';
 import { Responsive } from 'semantic-ui-react';
+import theme from 'styled-theming';
 
 type Props = I18nProps & {
   collapse: () => void,
@@ -27,6 +30,41 @@ type Props = I18nProps & {
   toggleMenu: () => void
 };
 
+const toggleTheme = theme('theme', {
+  substrate: '#333',
+  polkadot: 'none'
+});
+
+const togglePadding = theme('theme', {
+  substrate: '4px',
+  polkadot: 'none'
+});
+
+const Toggle = styled.img`
+  background: ${toggleTheme};
+  padding: ${togglePadding};
+  border-radius: 50%;
+  cursor: pointer;
+  left: 0.9rem;
+  opacity: 0;
+  position: absolute;
+  transition: opacity 0.2s ease-in, top 0.2s ease-in;
+  width: 2.6rem;
+
+  &.delayed {
+    transition-delay: 0.4s;
+  }
+  &.open {
+    opacity: 1;
+    top: 0.9rem;
+  }
+
+  ${media.TABLET`
+    opacity: 0 !important;
+    top: -2.9rem !important;
+  `}
+`;
+
 class SideBar extends React.PureComponent<Props> {
   render () {
     const { isCollapsed } = this.props;
@@ -35,8 +73,10 @@ class SideBar extends React.PureComponent<Props> {
       <Responsive
         onUpdate={this.props.handleResize}
         className={
-          classes('apps-SideBar-Wrapper',
-                  isCollapsed ? 'collapsed' : 'expanded')
+          classes(
+            'apps-SideBar-Wrapper',
+              isCollapsed ? 'collapsed' : 'expanded',
+            )
         }
       >
         {this.renderMenuToggle()}
@@ -152,7 +192,7 @@ class SideBar extends React.PureComponent<Props> {
     const { toggleMenu, menuOpen } = this.props;
 
     return (
-      <img
+      <Toggle
         alt='logo'
         className={menuOpen ? 'closed' : 'open delayed'}
         onClick={toggleMenu}

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -17,7 +17,7 @@ import Item from './Item';
 import NodeInfo from './NodeInfo';
 import getLogo from './logos';
 
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { media } from '@polkadot/ui-app/media';
 import { Responsive } from 'semantic-ui-react';
 import theme from 'styled-theming';
@@ -72,7 +72,7 @@ class SideBar extends React.PureComponent<Props> {
         className={
           classes(
             'apps-SideBar-Wrapper',
-              isCollapsed ? 'collapsed' : 'expanded',
+              isCollapsed ? 'collapsed' : 'expanded'
             )
         }
       >

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^5.0.0",
     "semantic-ui-css": "^2.3.1",
     "semantic-ui-react": "^0.86.0",
-    "store": "^2.0.12"
+    "store": "^2.0.12",
+    "styled-theming": "^2.2.0"
   }
 }

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -22,6 +22,7 @@
     "@types/react-copy-to-clipboard": "^4.2.6",
     "@types/react-dropzone": "^4.2.2",
     "@types/react-router-dom": "^4.3.0q",
+    "@types/styled-theming": "^2.2.0",
     "chart.js": "^2.7.2",
     "codeflask": "^1.4.0",
     "i18next": "^15.0.9",

--- a/packages/ui-app/src/constants.ts
+++ b/packages/ui-app/src/constants.ts
@@ -8,7 +8,7 @@ export enum BitLengthOption {
 };
 
 export enum ScreenSizes {
-  DESKTOP = 991,
-  TABLET = 767,
-  PHONE = 575
+  DESKTOP = 992,
+  TABLET = 768,
+  PHONE = 576
 };

--- a/packages/ui-app/src/constants.ts
+++ b/packages/ui-app/src/constants.ts
@@ -5,4 +5,10 @@
 export enum BitLengthOption {
   CHAIN_SPEC = 128,
   NORMAL_NUMBERS = 32
-}
+};
+
+export enum ScreenSizes {
+  DESKTOP = 992,
+  TABLET = 768,
+  PHONE = 576
+};

--- a/packages/ui-app/src/constants.ts
+++ b/packages/ui-app/src/constants.ts
@@ -5,10 +5,10 @@
 export enum BitLengthOption {
   CHAIN_SPEC = 128,
   NORMAL_NUMBERS = 32
-};
+}
 
 export enum ScreenSizes {
   DESKTOP = 992,
   TABLET = 768,
   PHONE = 576
-};
+}

--- a/packages/ui-app/src/constants.ts
+++ b/packages/ui-app/src/constants.ts
@@ -8,7 +8,7 @@ export enum BitLengthOption {
 };
 
 export enum ScreenSizes {
-  DESKTOP = 992,
-  TABLET = 768,
-  PHONE = 576
+  DESKTOP = 991,
+  TABLET = 767,
+  PHONE = 575
 };

--- a/packages/ui-app/src/media.ts
+++ b/packages/ui-app/src/media.ts
@@ -5,13 +5,15 @@
 import { css } from 'styled-components';
 import { ScreenSizes } from './constants';
 
-export const media = Object
+export const media: any = Object
  .keys(ScreenSizes)
- .reduce((acc, label) => {
-   acc[label] = (...args) => css`
-     @media (min-width: ${ScreenSizes[label] / 16}em) {
-      ${css(...args)}
+ .reduce((acc: any, label: any) => {
+   let size: any = ScreenSizes[label];
+   acc[label] = (...args: any) => (
+    css`
+     @media ( min-width: ${size / 16}em) {
+      ${css`${{ ...args }}`}
      }
-      `;
+    `);
    return acc;
  }, {});

--- a/packages/ui-app/src/media.ts
+++ b/packages/ui-app/src/media.ts
@@ -1,0 +1,17 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { css } from 'styled-components';
+import { ScreenSizes } from './constants';
+
+export const media = Object
+ .keys(ScreenSizes)
+ .reduce((acc, label) => {
+    acc[label] = (...args) => css`
+     @media (min-width: ${ScreenSizes[label] / 16}em) {
+      ${css(...args)}
+     }
+      `
+return acc
+}, {});

--- a/packages/ui-app/src/media.ts
+++ b/packages/ui-app/src/media.ts
@@ -8,10 +8,10 @@ import { ScreenSizes } from './constants';
 export const media = Object
  .keys(ScreenSizes)
  .reduce((acc, label) => {
-    acc[label] = (...args) => css`
+   acc[label] = (...args) => css`
      @media (min-width: ${ScreenSizes[label] / 16}em) {
       ${css(...args)}
      }
-      `
-return acc
-}, {});
+      `;
+   return acc;
+ }, {});

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -95,12 +95,3 @@ article {
     padding: 0;
   }
 }
-
-header {
-  margin-bottom: 1.1rem;
-  text-align: center;
-
-  @media(max-width: 767px) {
-    margin-bottom: 0.8rem;
-  }
-}

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -70,7 +70,7 @@ th.ui--media-small {
     height: auto;
     visibility: visible;
     width: auto;
-    
+
   }
 
   td.ui--media-small,
@@ -83,15 +83,5 @@ th.ui--media-small {
 @media (max-width: 767px) {
   .ui.menu.tabular {
     padding-left: 5.2rem !important;
-  }
-}
-
-/* sidebar */
-@media (min-width: 768px) {
-  .apps-SideBar-Wrapper {
-    > img {
-      opacity: 0 !important;
-      top: -2.9rem !important;
-    }
   }
 }

--- a/packages/ui-app/src/styles/theme.ts
+++ b/packages/ui-app/src/styles/theme.ts
@@ -1,0 +1,11 @@
+/* Copyright 2017-2019 @polkadot/ui-app authors & contributors
+/* This software may be modified and distributed under the terms
+/* of the Apache-2.0 license. See the LICENSE file for details. */
+
+import styled from 'styled-components';
+import theme from 'styled-theming';
+
+export const primaryColor = theme('theme', {
+  substrate: '#333',
+  polkadot: '#E6007A'
+});

--- a/packages/ui-app/src/styles/theme.ts
+++ b/packages/ui-app/src/styles/theme.ts
@@ -2,7 +2,6 @@
 /* This software may be modified and distributed under the terms
 /* of the Apache-2.0 license. See the LICENSE file for details. */
 
-import styled from 'styled-components';
 import theme from 'styled-theming';
 
 export const primaryColor = theme('theme', {

--- a/packages/ui-app/src/styles/theme/polkadot.css
+++ b/packages/ui-app/src/styles/theme/polkadot.css
@@ -92,13 +92,6 @@
     background-color: $red;
   }
 
-  .apps-SideBar-Wrapper {
-    > img {
-      background: none !important;
-      padding: 0 !important;
-    }
-  }
-
   a.apps--SideBar-Item-NavLink:hover {
     color: $nav-link;
     transition: 0.15s;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13489,12 +13489,7 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@^3.4.1:
+typescript@3.2.x, typescript@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13484,12 +13484,7 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@^3.4.1:
+typescript@3.2.x, typescript@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,6 +2496,11 @@
     "@types/react" "*"
     csstype "^2.2.0"
 
+"@types/styled-theming@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/styled-theming/-/styled-theming-2.2.0.tgz#0c4971dae7d36e1553779864caf27cc02bb3e8e2"
+  integrity sha512-IwS8K1jvn1yw3A6oSuA9zXjWW5zOQhM/psUSfehR1k0r60WWlLa1/S7El40loOMSy8blusgn7r5y/dhyEd0kKw==
+
 "@types/tapable@*":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
@@ -13484,7 +13489,12 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x, typescript@^3.4.1:
+typescript@3.2.x:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+
+typescript@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12919,6 +12919,11 @@ styled-components@^4.2.0:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
+styled-theming@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/styled-theming/-/styled-theming-2.2.0.tgz#3084e43d40eaab4bc11ebafd3de04e3622fee37e"
+  integrity sha1-MITkPUDqq0vBHrr9PeBONiL+434=
+
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
@@ -13479,7 +13484,12 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x, typescript@^3.4.1:
+typescript@3.2.x:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+
+typescript@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==


### PR DESCRIPTION
* Introduces `styled-theming`, installed in `ui-app`. `substrate` and `polkadot` themes as per `settings.uiTheme`
* `<ThemeProvider />` wraps everything in `Apps.tsx`
* media templates for `MOBILE`, `TABLET` and `DESKTOP` imported from `ui-app/src/media.ts` Media templates are "mobile first" adopting a `min-width` approach to screen sizing, following the conventions used in `media.css`.
* Converted the menu toggle media queries to styled theming

Following @jacogr guidelines to introduce `styled`  as and when files are touched.

Demonstration of embedded theme config:
```
const Toggle = styled.img`
  background: ${theme('theme', {
    substrate: '#333',
    polkadot: 'none'
  })};
  padding: ${theme('theme', {
    substrate: '4px',
    polkadot: 'none'
  })};
...
```

Demonstation of media template usage:
```
const Toggle = styled.img`
   ...
  ${media.TABLET`
    opacity: 0 !important;
    top: -2.9rem !important;
  `}
`;

```
