### PR TITLE
Display session key with stashes

### DIFF
--- a/packages/app-staking/src/Account/SessionKey.tsx
+++ b/packages/app-staking/src/Account/SessionKey.tsx
@@ -16,11 +16,19 @@ type Props = I18nProps & {
 };
 
 type State = {
-  sessionId?: string
+  sessionId: string
 };
 
 class Key extends React.PureComponent<Props, State> {
-  state: State = {};
+  state: State;
+
+  constructor (props: Props) {
+    super(props);
+
+    this.state = {
+      sessionId: props.accountId
+    };
+  }
 
   render () {
     const { accountId, isOpen, onClose, t } = this.props;
@@ -62,15 +70,21 @@ class Key extends React.PureComponent<Props, State> {
   }
 
   private renderContent () {
-    const { t } = this.props;
+    const { accountId, t } = this.props;
     const { sessionId } = this.state;
 
     return (
       <>
         <Modal.Header>
-          {t('Key Preferences')}
+          {t('Session Key')}
         </Modal.Header>
         <Modal.Content className='ui--signer-Signer-Content'>
+          <InputAddress
+            className='medium'
+            defaultValue={accountId}
+            isDisabled
+            label={t('controller account')}
+          />
           <InputAddress
             className='medium'
             help={t('Changing the key only takes effect at the start of the next session. If validating, you should (currently) use an ed25519 key.')}

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -173,6 +173,7 @@ class Account extends React.PureComponent<Props, State> {
   }
 
   private renderNominee () {
+    const { t } = this.props;
     const nominees = this.getNominees();
 
     if (!nominees || !nominees.length) {
@@ -181,7 +182,7 @@ class Account extends React.PureComponent<Props, State> {
 
     return (
       <div className='staking--Account-detail'>
-        <label className='staking--label'>nominating</label>
+        <label className='staking--label'>{t('nominating')}</label>
         {
           nominees.map((nomineeId, index) => (
             <AddressMini
@@ -220,6 +221,7 @@ class Account extends React.PureComponent<Props, State> {
   }
 
   private renderBondedId () {
+    const { t } = this.props;
     const { bondedId } = this.state;
 
     if (!bondedId) {
@@ -228,16 +230,14 @@ class Account extends React.PureComponent<Props, State> {
 
     return (
       <div className='staking--Account-detail'>
-        <label className='staking--label'>controller account</label>
-        <AddressMini
-          value={bondedId}
-          withBalance
-        />
+        <label className='staking--label'>{t('controller')}</label>
+        <AddressMini value={bondedId} />
       </div>
     );
   }
 
   private renderSessionId () {
+    const { t } = this.props;
     const { sessionId } = this.state;
 
     if (!sessionId) {
@@ -246,16 +246,14 @@ class Account extends React.PureComponent<Props, State> {
 
     return (
       <div className='staking--Account-detail'>
-        <label className='staking--label'>session account</label>
-        <AddressMini
-          value={sessionId}
-          withBalance
-        />
+        <label className='staking--label'>{t('session')}</label>
+        <AddressMini value={sessionId} />
       </div>
     );
   }
 
   private renderStashId () {
+    const { t } = this.props;
     const { stashId } = this.state;
 
     if (!stashId) {
@@ -264,11 +262,8 @@ class Account extends React.PureComponent<Props, State> {
 
     return (
       <div className='staking--Account-detail'>
-        <label className='staking--label'>stash account</label>
-        <AddressMini
-          value={stashId}
-          withBalance
-        />
+        <label className='staking--label'>{t('stash')}</label>
+        <AddressMini value={stashId} />
       </div>
     );
   }
@@ -305,7 +300,7 @@ class Account extends React.PureComponent<Props, State> {
             isPrimary
             key='bond'
             onClick={this.toggleBonding}
-            label={t('Bond')}
+            label={t('Bond Funds')}
           />
         );
       } else {
@@ -316,16 +311,7 @@ class Account extends React.PureComponent<Props, State> {
       const isNominating = nominees && nominees.length;
       const isValidating = intentions.indexOf(accountId) !== -1;
 
-      if (!sessionId) {
-        buttons.push(
-          <Button
-            isPrimary
-            key='session'
-            onClick={this.toggleSessionKey}
-            label={t('Set Session Key')}
-          />
-        );
-      } else if (isValidating || isNominating) {
+      if (isValidating || isNominating) {
         buttons.push(
           <TxButton
             accountId={accountId}
@@ -336,14 +322,25 @@ class Account extends React.PureComponent<Props, State> {
           />
         );
       } else {
-        buttons.push(
-          <Button
-            isPrimary
-            key='validate'
-            onClick={this.toggleValidating}
-            label={t('Validate')}
-          />
-        );
+        if (!sessionId) {
+          buttons.push(
+            <Button
+              isPrimary
+              key='session'
+              onClick={this.toggleSessionKey}
+              label={t('Set Session Key')}
+            />
+          );
+        } else {
+          buttons.push(
+            <Button
+              isPrimary
+              key='validate'
+              onClick={this.toggleValidating}
+              label={t('Validate')}
+            />
+          );
+        }
         buttons.push(<Button.Or key='nominate.or' />);
         buttons.push(
           <Button

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -91,8 +91,8 @@ class Account extends React.PureComponent<Props, State> {
           <div className='staking--Account-expand'>
             {this.renderButtons()}
             {this.renderBondedId()}
-            {this.renderSessionId()}
             {this.renderStashId()}
+            {this.renderSessionId()}
             {this.renderNominee()}
             {this.renderNominators()}
           </div>

--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -99,11 +99,11 @@
   margin-top: 0.75rem;
 
   .staking--label {
-    margin-bottom: -0.25rem;
+    margin-bottom: -0.5rem;
   }
 }
 
-.staking--controller-info {
+.staking--accounts-info {
   position: absolute;
   top: 0.25rem;
   right: 1rem;
@@ -111,6 +111,6 @@
   text-align: right;
 
   .staking--label {
-    margin-bottom: -0.25rem;
+    margin-bottom: -0.5rem;
   }
 }

--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -97,9 +97,10 @@ export default withMulti(
   // These API queries are used in a number of places, warm them up
   // to avoid constant un-/re-subscribe on these
   withCalls<Props>(
-    'query.session.validators',
     'derive.accounts.indexes',
     'derive.balances.fees',
-    'derive.staking.controllers'
+    'derive.staking.controllers',
+    'query.staking.nominators',
+    'query.session.validators'
   )
 );

--- a/packages/apps/src/SideBar/NodeInfo.tsx
+++ b/packages/apps/src/SideBar/NodeInfo.tsx
@@ -36,28 +36,31 @@ const Wrapper = styled.div`
   }
 `;
 
-const HEALTH_POLL = 22500;
 const pkgJson = require('../../package.json');
 
 class NodeInfo extends React.PureComponent<Props> {
-  componentDidMount () {
-    const { api } = this.props;
-
-    window.setInterval(() => {
-      api.rpc.system
-        .health()
-        .catch(() => {
-          // ignore
-        });
-    }, HEALTH_POLL);
-  }
-
   render () {
     const { api } = this.props;
     const uiInfo = `apps v${pkgJson.version}`;
 
     return (
       <Wrapper>
+        {this.renderNode()}
+        <div>{api.libraryInfo.replace('@polkadot/', '')}</div>
+        <div>{uiInfo}</div>
+      </Wrapper>
+    );
+  }
+
+  private renderNode () {
+    const { isApiReady } = this.props;
+
+    if (!isApiReady) {
+      return null;
+    }
+
+    return (
+      <>
         <div>
           <Chain />&nbsp;
           <BestNumber label='#' />
@@ -67,9 +70,7 @@ class NodeInfo extends React.PureComponent<Props> {
           <NodeVersion label='v' />
         </div>
         <div className='spacer' />
-        <div>{api.libraryInfo.replace('@polkadot/', '')}</div>
-        <div>{uiInfo}</div>
-      </Wrapper>
+      </>
     );
   }
 }


### PR DESCRIPTION
- Display session keys on overview, Closes https://github.com/polkadot-js/apps/issues/910
- Don't force session key for nominating, Closes https://github.com/polkadot-js/apps/issues/908
- As a bonus, remove the display of node name & version when not connected