### PR TITLE
Minimised Input textbox labelling

### DIFF
--- a/packages/ui-app/src/Editor/style.css
+++ b/packages/ui-app/src/Editor/style.css
@@ -7,7 +7,7 @@
   &.invalid {
     .codeflask {
       background-color: #fff6f6;
-      border-color: #e0b4b4;
+      border-color: #bb5f5f;
     }
   }
 }

--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -40,7 +40,7 @@ type Props = BareProps & {
 
 type State = {
   name: string;
-  hasValue: boolean;
+  minLabel: boolean;
 };
 
 // note: KeyboardEvent.keyCode and KeyboardEvent.which are deprecated
@@ -85,24 +85,29 @@ export default class Input extends React.PureComponent<Props, State> {
 
   constructor (props) {
     super(props);
+    props.label === undefined
+      ? this.state.minLabel = true
 
-    (this.props.defaultValue || this.props.value)
-      ? this.state.hasValue = true
-      : this.state.hasValue = false;
+      : (this.props.defaultValue || this.props.value)
+        ? this.state.minLabel = true
+        : this.state.minLabel = false;
   }
 
   render () {
 
     const { autoFocus = false, children, className, defaultValue, icon, isEditable = false, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, maxLength, min, name, placeholder, style, tabIndex, type = 'text', value, withLabel } = this.props;
 
+    const { minLabel } = this.state;
+
     return (
       <Labelled
         className={className}
         hasInput={true}
-        hasValue={this.state.hasValue}
+        minLabel={minLabel}
         label={label}
         style={style}
         withLabel={withLabel}
+        onFocus={this.onFocus}
       >
         <SUIInput
           action={isAction}
@@ -133,7 +138,9 @@ export default class Input extends React.PureComponent<Props, State> {
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           onKeyUp={this.onKeyUp}
-          placeholder={placeholder}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          placeholder={ minLabel ? placeholder : '' }
           tabIndex={tabIndex}
           type={type}
           value={value}
@@ -157,12 +164,22 @@ export default class Input extends React.PureComponent<Props, State> {
     );
   }
 
+  private onBlur = (event: React.KeyboardEvent<Element>): void => {
+    this.props.label !== undefined
+      && this.setState({ minLabel: event.target.value ? true : false });
+  }
+
   private onChange = (event: React.SyntheticEvent<Element>): void => {
     const { onChange } = this.props;
     const { value } = event.target as HTMLInputElement;
 
-    this.setState({ hasValue: value.length ? true : false });
+    this.setState({ minLabel: (this.props.label === undefined || value.length) ? true : false });
     onChange && onChange(value);
+  }
+
+  private onFocus = (event: React.KeyboardEvent<Element>): void => {
+    this.props.label !== undefined
+      && this.setState({ minLabel: true });
   }
 
   private onKeyDown = (event: React.KeyboardEvent<Element>): void => {

--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -80,10 +80,11 @@ let counter = 0;
 
 export default class Input extends React.PureComponent<Props, State> {
   state: State = {
-    name: `in_${counter++}_at_${Date.now()}`
+    name: `in_${counter++}_at_${Date.now()}`,
+    minLabel: false
   };
 
-  constructor (props) {
+  constructor (props: Props) {
     super(props);
     props.label === undefined
       ? this.state.minLabel = true
@@ -107,7 +108,6 @@ export default class Input extends React.PureComponent<Props, State> {
         label={label}
         style={style}
         withLabel={withLabel}
-        onFocus={this.onFocus}
       >
         <SUIInput
           action={isAction}
@@ -166,7 +166,7 @@ export default class Input extends React.PureComponent<Props, State> {
 
   private onBlur = (event: React.KeyboardEvent<Element>): void => {
     this.props.label !== undefined
-      && this.setState({ minLabel: event.target.value ? true : false });
+      && this.setState({ minLabel: event.target ? true : false });
   }
 
   private onChange = (event: React.SyntheticEvent<Element>): void => {

--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -40,6 +40,7 @@ type Props = BareProps & {
 
 type State = {
   name: string;
+  hasValue: boolean;
 };
 
 // note: KeyboardEvent.keyCode and KeyboardEvent.which are deprecated
@@ -82,12 +83,23 @@ export default class Input extends React.PureComponent<Props, State> {
     name: `in_${counter++}_at_${Date.now()}`
   };
 
+  constructor (props) {
+    super(props);
+
+    (this.props.defaultValue || this.props.value)
+      ? this.state.hasValue = true
+      : this.state.hasValue = false;
+  }
+
   render () {
+
     const { autoFocus = false, children, className, defaultValue, icon, isEditable = false, isAction = false, isDisabled = false, isError = false, isHidden = false, label, max, maxLength, min, name, placeholder, style, tabIndex, type = 'text', value, withLabel } = this.props;
 
     return (
       <Labelled
         className={className}
+        hasInput={true}
+        hasValue={this.state.hasValue}
         label={label}
         style={style}
         withLabel={withLabel}
@@ -149,6 +161,7 @@ export default class Input extends React.PureComponent<Props, State> {
     const { onChange } = this.props;
     const { value } = event.target as HTMLInputElement;
 
+    this.setState({ hasValue: value.length ? true : false });
     onChange && onChange(value);
   }
 

--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -175,8 +175,12 @@ export default class Input extends React.PureComponent<Props, State> {
   }
 
   private onBlur = (event: React.KeyboardEvent<Element>): void => {
-    this.props.label !== undefined
-      && this.setState({ minLabel: event.target ? true : false });
+    if (this.props.label === undefined) {
+      return;
+    }
+
+    const { value } = event.target as HTMLInputElement;
+    this.setState({ minLabel: value ? true : false });
   }
 
   private onChange = (event: React.SyntheticEvent<Element>): void => {

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -9,7 +9,6 @@ import styled from 'styled-components';
 
 import Icon from './Icon';
 import { classes } from './util';
-import styled from 'styled-components';
 
 type Props = BareProps & {
   children: React.ReactNode,
@@ -30,13 +29,60 @@ const StyledLabelled = styled.div`
   text-align: left;
 
   &.has-input {
-    padding: 1.6rem 0;
+    padding: 1.6rem 0 0.8rem;
 
     > div {
       z-index: 2;
       input {
         background: none !important;
       }
+    }
+  }
+
+  &.label-small {
+    display: block;
+
+    > label {
+      margin: 0;
+      min-width: 0;
+      padding-right: 0;
+    }
+  }
+
+  > .ui--Labelled-content {
+    box-sizing: border-box;
+    flex: 1 1;
+    min-width: 0;
+  }
+
+  > label {
+    flex: 0 0 15rem;
+    min-width: 15rem;
+    padding-right: 0.5rem;
+    position: relative;
+    text-align: left;
+    z-index: 1;
+
+    .help-hover {
+      background: #4e4e4e;
+      border-radius: 0.25rem;
+      color: #eee;
+      display: none;
+      padding: 0.5rem 1rem;
+      position: absolute;
+      text-align: left;
+      top: 0.5rem;
+      left: 2.5rem;
+      right: -5rem;
+      z-index: 10;
+    }
+
+    .icon.help {
+      margin-right: 0;
+    }
+
+    &.with-help:hover .help-hover {
+      display: block;
     }
   }
 `;
@@ -79,60 +125,6 @@ const defaultLabel: any = (// node?
   <div>&nbsp;</div>
 );
 
-const Wrapper = styled.div`
-  align-items: center;
-  display: flex;
-  flex: 1 1;
-  text-align: left;
-
-  &.label-small {
-    display: block;
-
-    > label {
-      margin: 0;
-      min-width: 0;
-      padding-right: 0;
-    }
-  }
-
-  > .ui--Labelled-content {
-    box-sizing: border-box;
-    flex: 1 1;
-    min-width: 0;
-  }
-
-  > label {
-    flex: 0 0 15rem;
-    min-width: 15rem;
-    padding-right: 0.5rem;
-    position: relative;
-    text-align: right;
-    z-index: 1;
-
-    .help-hover {
-      background: #4e4e4e;
-      border-radius: 0.25rem;
-      color: #eee;
-      display: none;
-      padding: 0.5rem 1rem;
-      position: absolute;
-      text-align: left;
-      top: 0.5rem;
-      left: 2.5rem;
-      right: -5rem;
-      z-index: 10;
-    }
-
-    .icon.help {
-      margin-right: 0;
-    }
-
-    &.with-help:hover .help-hover {
-      display: block;
-    }
-  }
-`;
-
 export default class Labelled extends React.PureComponent<Props> {
   render () {
     const { className, children, help, minLabel, hasInput = false, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
@@ -144,10 +136,6 @@ export default class Labelled extends React.PureComponent<Props> {
         <div className={className}>{children}</div>
       );
     }
-
-    const labelNode = help
-      ? <label className='with-help'>{label} <Icon name='help circle' /><div className='help-hover'>{help}</div></label>
-      : <label>{label}</label>;
 
     return (
       <StyledLabelled
@@ -164,10 +152,12 @@ export default class Labelled extends React.PureComponent<Props> {
           className={
             classes(
               hasInput ? 'has-input' : '',
-              (minLabel && hasInput) ? 'min-label' : ''
+              (minLabel && hasInput) ? 'min-label' : '',
+              help ? 'with-help' : ''
             )
           }
         >
+          {help && <><Icon name='help circle' /><div className='help-hover'>{help}</div></>}
           {label}
         </Label>
         {hasInput && <InputBackground />}

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -10,10 +10,12 @@ import { classes } from './util';
 import styled from 'styled-components';
 
 type Props = BareProps & {
+  children: React.ReactNode,
   isHidden?: boolean,
   isSmall?: boolean,
   label?: React.ReactNode,
-  children: React.ReactNode,
+  hasInput?: boolean,
+  minLabel?: boolean,
   withLabel?: boolean
 };
 

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -7,6 +7,7 @@ import { BareProps } from './types';
 import React from 'react';
 
 import { classes } from './util';
+import styled from 'styled-components';
 
 type Props = BareProps & {
   isHidden?: boolean,
@@ -16,13 +17,57 @@ type Props = BareProps & {
   withLabel?: boolean
 };
 
+const StyledLabelled = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1;
+  position: relative;
+  text-align: left;
+
+  &.has-input {
+    padding: 1.6rem 0;
+
+    > div {
+      z-index: 2;
+      input {
+        background: none !important;
+      }
+    }
+  }
+`;
+
+const Label = styled.label`
+  &.default {
+    flex: 0 0 15rem;
+    min-width: 15rem;
+    padding-right: 0.5rem;
+    text-align: right;
+  }
+  &.has-input {
+    left: 0.8em;
+    position: absolute;
+    top: 2.3em;
+    transition: top 0.2s cubic-bezier(0.215, 0.61, 0.355, 1), left 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
+    width: 100%;
+    z-index: 1;
+    opacity: 0.75;
+  }
+
+  &.has-value {
+    left: 0;
+    top: 0;
+    font-size: 0.9em;
+    opacity: 1;
+  }
+`;
+
 const defaultLabel: any = (// node?
   <div>&nbsp;</div>
 );
 
 export default class Labelled extends React.PureComponent<Props> {
   render () {
-    const { className, children, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
+    const { className, children, hasValue, hasInput = false, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
 
     if (isHidden) {
       return null;
@@ -33,15 +78,30 @@ export default class Labelled extends React.PureComponent<Props> {
     }
 
     return (
-      <div
-        className={classes('ui--Labelled', isSmall ? 'label-small' : '', className)}
+      <StyledLabelled
+        className={
+          classes(
+            'ui--Labelled',
+            isSmall ? 'label-small' : '', className,
+            hasInput ? 'has-input' : ''
+          )
+        }
         style={style}
       >
-        <label>{label}</label>
+        <Label
+          className={
+            classes(
+              hasInput ? 'has-input' : '',
+              (hasValue && hasInput) ? 'has-value' : ''
+            )
+          }
+        >
+          {label}
+        </Label>
         <div className='ui--Labelled-content'>
           {children}
         </div>
-      </div>
+      </StyledLabelled>
     );
   }
 }

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -53,9 +53,9 @@ const Label = styled.label`
     opacity: 0.75;
   }
 
-  &.has-value {
+  &.min-label {
     left: 0;
-    top: 0;
+    top: 0em;
     font-size: 0.9em;
     opacity: 1;
   }
@@ -67,7 +67,7 @@ const defaultLabel: any = (// node?
 
 export default class Labelled extends React.PureComponent<Props> {
   render () {
-    const { className, children, hasValue, hasInput = false, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
+    const { className, children, minLabel, hasInput = false, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
 
     if (isHidden) {
       return null;
@@ -92,7 +92,7 @@ export default class Labelled extends React.PureComponent<Props> {
           className={
             classes(
               hasInput ? 'has-input' : '',
-              (hasValue && hasInput) ? 'has-value' : ''
+              (minLabel && hasInput) ? 'min-label' : ''
             )
           }
         >

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -61,6 +61,15 @@ const Label = styled.label`
   }
 `;
 
+const InputBackground = styled.span`
+  background: #fff;
+  height: 2.6em;
+  position: absolute;
+  top: 1.8em;
+  width: 100%;
+  z-index: 0;
+`;
+
 const defaultLabel: any = (// node?
   <div>&nbsp;</div>
 );
@@ -98,6 +107,7 @@ export default class Labelled extends React.PureComponent<Props> {
         >
           {label}
         </Label>
+        {hasInput && <InputBackground />}
         <div className='ui--Labelled-content'>
           {children}
         </div>

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -29,7 +29,7 @@ const StyledLabelled = styled.div`
   text-align: left;
 
   &.has-input {
-    padding: 1.6rem 0 0.8rem;
+    padding: 1.6rem 0 0.5rem;
 
     > div {
       z-index: 2;

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -81,7 +81,7 @@ article {
 
   &.error {
     background: #fff6f6;
-    border-color: #e0b4b4;
+    border-color: #bb5f5f;
     color: #9f3a38;
   }
 

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -24,7 +24,7 @@
 
 .ui--output.error {
   background: #fff6f6;
-  border-color: #e0b4b4;
+  border-color: #bb5f5f;
 }
 
 .ui--Button-Group .button {
@@ -239,7 +239,7 @@ header .ui--Button-Group {
 
   &.error {
     background: #fff6f6;
-    border-color: #e0b4b4;
+    border-color: #bb5f5f;
   }
 
   &:hover {
@@ -254,11 +254,6 @@ header .ui--Button-Group {
 }
 
 .ui--Labelled {
-  align-items: center;
-  display: flex;
-  flex: 1 1;
-  text-align: left;
-
   &.label-small {
     display: block;
 
@@ -273,13 +268,6 @@ header .ui--Button-Group {
     box-sizing: border-box;
     flex: 1 1;
     min-width: 0;
-  }
-
-  > label {
-    flex: 0 0 15rem;
-    min-width: 15rem;
-    padding-right: 0.5rem;
-    text-align: right;
   }
 }
 


### PR DESCRIPTION
Aiming to solve the following issues in regards to text input with this PR:

* Alignment: Text input labels have arbitrary widths and do not align in most cases
* Mobile friendly: Smaller screens do not display labels beside a textbox well
* Space: Normalises spacing, more coherent when multiple inputs are grouped in rows

--
Embedded in `<Labelled />`  is an added functionality to embed a textbox label inside the field, and to minimise it outwards when the field has a value or is focussed:

![textbox1](https://user-images.githubusercontent.com/13929023/55686358-d67b1a80-5992-11e9-91f1-014333fba144.gif)

The textbox is smart enough not to do this when there is no label:

<img width="632" alt="Screenshot 2019-04-08 at 00 10 39" src="https://user-images.githubusercontent.com/13929023/55686361-e1ce4600-5992-11e9-97e6-4b55b6ec5bf3.png">

Labels are minimised by default if a `defaultValue` is provided:

<img width="598" alt="Screenshot 2019-04-08 at 00 12 35" src="https://user-images.githubusercontent.com/13929023/55686380-193cf280-5993-11e9-865f-9005394db9f8.png">

And placeholders are maintained when a field is focussed:

<img width="642" alt="Screenshot 2019-04-08 at 00 13 44" src="https://user-images.githubusercontent.com/13929023/55686388-32de3a00-5993-11e9-9511-daf173b09653.png">

And `<Labelled />` is still fully intact when not accompanied by a text input:

<img width="1076" alt="Screenshot 2019-04-08 at 00 14 05" src="https://user-images.githubusercontent.com/13929023/55686403-45f10a00-5993-11e9-8c58-1339a2178f38.png">

