### PR TITLE
Display bonded amount on overview

### DIFF
--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -12,7 +12,7 @@ import { AccountId, Balance, Option, StakingLedger } from '@polkadot/types';
 import { withCalls, withMulti } from '@polkadot/ui-api/with';
 import { AddressMini, AddressRow } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
-import { formatNumber } from '@polkadot/util';
+import { formatBalance, formatNumber } from '@polkadot/util';
 
 import translate from '../translate';
 
@@ -32,6 +32,8 @@ type Props = I18nProps & {
 
 type State = {
   bondedId: string,
+  stashActive: string | null,
+  stashTotal: string | null,
   stashId: string | null,
   sessionId: string | null,
   badgeExpanded: boolean;
@@ -46,12 +48,17 @@ class Address extends React.PureComponent<Props, State> {
     this.state = {
       bondedId: props.address,
       sessionId: null,
+      stashActive: null,
+      stashTotal: null,
       stashId: null,
       badgeExpanded: false
     };
   }
 
-  static getDerivedStateFromProps ({ address, session_nextKeyFor, staking_bonded, staking_ledger }: Props, prevState: State): State | null {
+  static getDerivedStateFromProps ({ session_nextKeyFor, staking_bonded, staking_ledger }: Props, prevState: State): State | null {
+    const ledger = staking_ledger
+      ? staking_ledger.unwrapOr(null)
+      : null;
     return {
       bondedId: !staking_bonded || staking_bonded.isNone
         ? prevState.bondedId
@@ -59,20 +66,26 @@ class Address extends React.PureComponent<Props, State> {
       sessionId: !session_nextKeyFor || session_nextKeyFor.isNone
         ? prevState.sessionId
         : session_nextKeyFor.unwrap().toString(),
-      stashId: !staking_ledger || staking_ledger.isNone
+      stashActive: !ledger
+        ? prevState.stashActive
+        : formatBalance(ledger.active),
+      stashTotal: !ledger
+        ? prevState.stashTotal
+        : formatBalance(ledger.total),
+      stashId: !ledger
         ? prevState.stashId
-        : staking_ledger.unwrap().stash.toString()
+        : ledger.stash.toString()
     } as State;
   }
 
   render () {
-    const { balanceArray, isAuthor, lastBlock } = this.props;
-    const { bondedId, stashId } = this.state;
+    const { isAuthor, lastBlock } = this.props;
+    const { bondedId, stashActive, stashId } = this.state;
 
     return (
       <article key={stashId || bondedId}>
         <AddressRow
-          balance={balanceArray(stashId || '')}
+          extraInfo={stashActive ? `bonded ${stashActive}` : undefined}
           name={this.getDisplayName()}
           value={stashId}
           withCopy={false}

--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -23,6 +23,7 @@ class AddressRow extends AddressSummary {
           <div className='ui--AddressRow-details'>
             {this.renderAddress()}
             {this.renderBalance()}
+            {this.renderExtra()}
             {this.renderNonce()}
           </div>
         </div>

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -18,6 +18,7 @@ export type Props = I18nProps & {
   accounts_idAndIndex?: [AccountId?, AccountIndex?],
   balance?: Balance | Array<Balance>,
   children?: React.ReactNode,
+  extraInfo?: React.ReactNode,
   name?: string,
   value: AccountId | AccountIndex | Address | string | null,
   withBalance?: boolean,
@@ -48,6 +49,7 @@ class AddressSummary extends React.PureComponent<Props> {
           {this.renderAccountId()}
           {this.renderAccountIndex()}
           {this.renderBalance()}
+          {this.renderExtra()}
           {this.renderNonce()}
         </div>
         {this.renderChildren()}
@@ -145,6 +147,20 @@ class AddressSummary extends React.PureComponent<Props> {
         label={t('balance ')}
         value={accountId}
       />
+    );
+  }
+
+  protected renderExtra () {
+    const { extraInfo } = this.props;
+
+    if (!extraInfo) {
+      return null;
+    }
+
+    return (
+      <div className='ui--AddressSummary-extra'>
+        {extraInfo}
+      </div>
     );
   }
 

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -113,6 +113,7 @@ header .ui--Button-Group {
 
 .ui--Balance,
 .ui--AddressSummary-balance,
+.ui--AddressSummary-extra,
 .ui--AddressSummary-nonce {
   font-weight: 100;
   opacity: 0.75;


### PR DESCRIPTION
Sorry @kwingram25 - I KNOW this is on your list, but needed a view while trying to help. However, this is only one part, only on overview. (We still need it on accounts, which is probably more problematic since we need to display it on the stash - and query from the controller.)

- Added extraInfo to AddressSummary & AddressRow
- query bonded value from staking.ledgerr
- pass this amount through
- Part of https://github.com/polkadot-js/apps/issues/896

![image](https://user-images.githubusercontent.com/1424473/55690227-c5c8a580-598e-11e9-811c-ef1d787f6ea0.png)
