### PR TITLE
sidebar <=> SrcreenSizes

### DIFF
--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -57,7 +57,7 @@ const Toggle = styled.img`
     top: 0.9rem;
   }
 
-  ${media.TABLET`
+  ${media.DESKTOP`
     opacity: 0 !important;
     top: -2.9rem !important;
   `}

--- a/packages/apps/src/constants.ts
+++ b/packages/apps/src/constants.ts
@@ -2,6 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { ScreenSizes } from '@polkadot/ui-app/constants';
+
 export enum SideBarTransition {
 	COLLAPSED = 'COLLAPSED',
 	EXPANDED = 'EXPANDED',
@@ -9,5 +11,5 @@ export enum SideBarTransition {
 	MINIMISED_AND_EXPANDED = 'MINIMISED_AND_EXPANDED'
 }
 
-export const SIDEBAR_MENU_THRESHOLD = 768;
+export const SIDEBAR_MENU_THRESHOLD = ScreenSizes.DESKTOP;
 export const SIDEBAR_TRANSITION_DURATION = 300;

--- a/packages/ui-app/src/styles/media.css
+++ b/packages/ui-app/src/styles/media.css
@@ -80,7 +80,7 @@ th.ui--media-small {
 }
 
 /* tabs */
-@media (max-width: 767px) {
+@media (max-width: 991px) {
   .ui.menu.tabular {
     padding-left: 5.2rem !important;
   }


### PR DESCRIPTION
Just a maintenance PR:

* `SIDEBAR_MENU_THRESHOLD` now takes `ScreenSizes.DESKTOP` value, conforming to media templates

* SideBar show/hide threshold has increased from 767px to 991px - expanding with this additional space feels more natural