### PR TITLE
2-column staking layout

### DIFF
--- a/packages/app-staking/src/StakeList.tsx
+++ b/packages/app-staking/src/StakeList.tsx
@@ -18,10 +18,11 @@ type Props = I18nProps & ComponentProps;
 class StakeList extends React.PureComponent<Props> {
   render () {
     const { balances, balanceArray, intentions, nominators, validators } = this.props;
+    const accounts = keyring.getAccounts();
 
     return (
       <div className='staking--StakeList'>
-        {keyring.getAccounts().map((account) => {
+        {accounts.map((account) => {
           const address = account.address();
           const name = account.getMeta().name || '';
 
@@ -40,7 +41,20 @@ class StakeList extends React.PureComponent<Props> {
             />
           );
         })}
+        {this.renderSpacer(accounts.length)}
       </div>
+    );
+  }
+
+  // HACK This is a hack of a dummy element to get the spacing right, i.e. the last
+  // element in an oddly spaced list should still only take up a single column
+  private renderSpacer (accountsLen: number) {
+    if (accountsLen % 2 === 0) {
+      return null;
+    }
+
+    return (
+      <div className='spacer' />
     );
   }
 

--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -12,15 +12,21 @@
 }
 
 .staking--Account {
-  display: inline-block;
   position: relative;
+  flex: 1 1;
 
   .ui--AddressMini {
     display: block;
   }
 
   .ui--AddressSummary {
+    display: flex;
+    justify-content: space-between;
     padding: 0;
+
+    .ui--AddressSummary-base, .ui--AddressSummary-children {
+      min-width: 0;
+    }
   }
 }
 
@@ -100,6 +106,17 @@
 
   .staking--label {
     margin-bottom: -0.5rem;
+  }
+}
+
+.staking--StakeList {
+  display: flex;
+  flex-wrap: wrap;
+
+  .spacer {
+    flex: 1 1;
+    margin: .25rem;
+    padding: 1rem 1.5rem;
   }
 }
 


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/862
- Not sure about the spacer hack to get the last one right, but life is too short...

<img width="1250" alt="Polkadot:Substrate Portal 2019-04-08 09-32-27" src="https://user-images.githubusercontent.com/1424473/55706351-4ca66e00-59e1-11e9-9731-f9d6f0ae1cda.png">
