### PR TITLE
Fix Safari Intl issue

### DIFF
--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -46,10 +46,9 @@ type State = {
 };
 
 // Find decimal separator used in current locale
-const getDecimalSeparator = (): string => Intl.NumberFormat()
-    .formatToParts(1.1)
-    .find(part => part.type === 'decimal')!
-    .value;
+const getDecimalSeparator = (): string => 1.1
+  .toLocaleString()
+  .replace(/\d/g, '');
 
 // note: KeyboardEvent.keyCode and KeyboardEvent.which are deprecated
 const KEYS = {


### PR DESCRIPTION
Closes #921 

Use toLocaleString() instead of Intl to find local decimal separator