### PR TITLE
Fix errant bonded call (with invalid address)

### DIFF
--- a/packages/app-123code/src/SummaryBar.tsx
+++ b/packages/app-123code/src/SummaryBar.tsx
@@ -93,7 +93,6 @@ export default translate(
     'derive.chain.bestNumberLag',
     'query.balances.totalIssuance',
     'query.session.validators',
-    'query.staking.intentions',
     'rpc.chain.getRuntimeVersion',
     'rpc.system.chain',
     'rpc.system.name',

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -148,8 +148,7 @@ export default withMulti(
   withCalls<Props>(
     'derive.staking.controllers',
     'query.session.validators',
-    'query.staking.nominators',
-    ['derive.staking.intentionsBalances', { propName: 'balances' }]
+    'query.staking.nominators'
   ),
   withObservable(accountObservable.subject, { propName: 'allAccounts' })
 );

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { AccountId, AccountIndex, Address, Balance } from '@polkadot/types';
 import { Nonce } from '@polkadot/ui-reactive';
 import { withCalls } from '@polkadot/ui-api';
+import BaseIdentityIcon from '@polkadot/ui-identicon';
 
 import { classes, toShortAddress } from './util';
 import BalanceDisplay from './Balance';
@@ -174,11 +175,17 @@ class AddressSummary extends React.PureComponent<Props> {
     const [_accountId] = accounts_idAndIndex;
     const accountId = (_accountId || value || '').toString();
 
+    // Since we do queries to storage in the wrapped example, we don't want
+    // to follow that route if we don't have a valid address.
+    const Component = accountId
+      ? IdentityIcon
+      : BaseIdentityIcon;
+
     return (
-      <IdentityIcon
+      <Component
         className={className}
         size={size || identIconSize}
-        value={accountId || DEFAULT_ADDR}
+        value={accountId}
       />
     );
   }


### PR DESCRIPTION
Also mentioned in watercooler. Basically since we display a placeholder for the stash (while retrieving the id), we ended up calling staking.bonded on an invalid address (inside the IdentityIcon).

Swap to the base component for invalid addresses (spacing and all others remain in-tact)