### PR TITLE
Allow exports of dumb components

### DIFF
--- a/packages/ui-reactive/src/AccountIndex.tsx
+++ b/packages/ui-reactive/src/AccountIndex.tsx
@@ -14,7 +14,7 @@ type Props = BareProps & CallProps & {
   accounts_idAndIndex?: [AccountId?, AccountIndex?]
 };
 
-class AccountIndexDisplay extends React.PureComponent<Props> {
+export class AccountIndexDisplay extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, accounts_idAndIndex = [] } = this.props;
     const [, accountIndex] = accounts_idAndIndex;

--- a/packages/ui-reactive/src/Balance.tsx
+++ b/packages/ui-reactive/src/Balance.tsx
@@ -15,7 +15,7 @@ type Props = BareProps & CallProps & {
   balances_freeBalance?: Balance
 };
 
-class BalanceDisplay extends React.PureComponent<Props> {
+export class BalanceDisplay extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, balances_freeBalance } = this.props;
 

--- a/packages/ui-reactive/src/BestFinalized.tsx
+++ b/packages/ui-reactive/src/BestFinalized.tsx
@@ -15,7 +15,7 @@ type Props = BareProps & CallProps & {
   chain_bestNumberFinalized?: BlockNumber
 };
 
-class BestFinalized extends React.PureComponent<Props> {
+export class BestFinalized extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, chain_bestNumberFinalized } = this.props;
 

--- a/packages/ui-reactive/src/BestNumber.tsx
+++ b/packages/ui-reactive/src/BestNumber.tsx
@@ -15,7 +15,7 @@ type Props = BareProps & CallProps & {
   chain_bestNumber?: BlockNumber
 };
 
-class BestNumber extends React.PureComponent<Props> {
+export class BestNumber extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, chain_bestNumber } = this.props;
 
@@ -28,7 +28,7 @@ class BestNumber extends React.PureComponent<Props> {
           chain_bestNumber
             ? formatNumber(chain_bestNumber)
             : '-'
-          }{children}
+        }{children}
       </div>
     );
   }

--- a/packages/ui-reactive/src/Bonded.tsx
+++ b/packages/ui-reactive/src/Bonded.tsx
@@ -17,7 +17,7 @@ type Props = BareProps & CallProps & {
   staking_ledger?: Option<StakingLedger>
 };
 
-class BondedDisplay extends React.PureComponent<Props> {
+export class BondedDisplay extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, staking_ledger } = this.props;
 
@@ -36,7 +36,7 @@ class BondedDisplay extends React.PureComponent<Props> {
           bonded
             ? formatBalance(bonded)
             : '0'
-          }{children}
+        }{children}
       </div>
     );
   }

--- a/packages/ui-reactive/src/Chain.tsx
+++ b/packages/ui-reactive/src/Chain.tsx
@@ -14,7 +14,7 @@ type Props = BareProps & CallProps & {
   system_chain?: Text
 };
 
-class Chain extends React.PureComponent<Props> {
+export class Chain extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, system_chain = 'unknown' } = this.props;
 

--- a/packages/ui-reactive/src/NodeName.tsx
+++ b/packages/ui-reactive/src/NodeName.tsx
@@ -14,7 +14,7 @@ type Props = BareProps & CallProps & {
   system_name?: Text
 };
 
-class NodeName extends React.PureComponent<Props> {
+export class NodeName extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, system_name = 'unknown' } = this.props;
 

--- a/packages/ui-reactive/src/NodeVersion.tsx
+++ b/packages/ui-reactive/src/NodeVersion.tsx
@@ -14,7 +14,7 @@ type Props = BareProps & CallProps & {
   system_version?: Text
 };
 
-class NodeVersion extends React.PureComponent<Props> {
+export class NodeVersion extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, system_version = '-' } = this.props;
 

--- a/packages/ui-reactive/src/Nonce.tsx
+++ b/packages/ui-reactive/src/Nonce.tsx
@@ -15,7 +15,7 @@ type Props = BareProps & CallProps & {
   system_accountNonce?: Index
 };
 
-class Nonce extends React.PureComponent<Props> {
+export class Nonce extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, system_accountNonce } = this.props;
 

--- a/packages/ui-reactive/src/TimeNow.tsx
+++ b/packages/ui-reactive/src/TimeNow.tsx
@@ -16,7 +16,7 @@ type Props = BareProps & CallProps & {
   timestamp_now?: Moment
 };
 
-class TimeNow extends React.PureComponent<Props> {
+export class TimeNow extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, timestamp_now } = this.props;
 

--- a/packages/ui-reactive/src/TimePeriod.tsx
+++ b/packages/ui-reactive/src/TimePeriod.tsx
@@ -16,7 +16,7 @@ type Props = BareProps & CallProps & {
   timestamp_minimumPeriod?: Moment // support for new version
 };
 
-class TimePeriod extends React.PureComponent<Props> {
+export class TimePeriod extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', style, timestamp_blockPeriod, timestamp_minimumPeriod } = this.props;
     const period = timestamp_minimumPeriod || (
@@ -38,7 +38,7 @@ class TimePeriod extends React.PureComponent<Props> {
           period
             ? `${formatNumber(period.toNumber() * 2)}s`
             : '-'
-          }{children}
+        }{children}
       </div>
     );
   }

--- a/packages/ui-signer/src/Checks/Proposal.tsx
+++ b/packages/ui-signer/src/Checks/Proposal.tsx
@@ -25,7 +25,7 @@ type State = ExtraFees & {
   isBelowMinimum: boolean
 };
 
-class Proposal extends React.PureComponent<Props, State> {
+export class Proposal extends React.PureComponent<Props, State> {
   state: State = {
     extraFees: new BN(0),
     extraAmount: new BN(0),

--- a/packages/ui-signer/src/Checks/Transfer.tsx
+++ b/packages/ui-signer/src/Checks/Transfer.tsx
@@ -29,7 +29,7 @@ type State = ExtraFees & {
   isNoEffect: boolean
 };
 
-class Transfer extends React.PureComponent<Props, State> {
+export class Transfer extends React.PureComponent<Props, State> {
   state: State = {
     extraFees: new BN(0),
     extraAmount: new BN(0),

--- a/packages/ui-signer/src/Checks/index.tsx
+++ b/packages/ui-signer/src/Checks/index.tsx
@@ -46,7 +46,7 @@ const LENGTH_SIGNATURE = 64;
 const LENGTH_ERA = 1;
 const SIGNATURE_SIZE = LENGTH_PUBLICKEY + LENGTH_SIGNATURE + LENGTH_ERA;
 
-class FeeDisplay extends React.PureComponent<Props, State> {
+export class FeeDisplay extends React.PureComponent<Props, State> {
   state: State = {
     allFees: new BN(0),
     allTotal: new BN(0),
@@ -131,7 +131,7 @@ class FeeDisplay extends React.PureComponent<Props, State> {
         allWarn
           ? 'warning'
           : 'normal'
-        );
+      );
 
     // display all the errors, warning and information messages (in that order)
     return (


### PR DESCRIPTION
Other projects might (hopefully) want to re-use components from apps. Right now, it's kind of hard because they need to provide a React.Context with an api object, which is not what every project wants to do.

This PR allows exporting the dumb components. Dumb components are easy to share/test/re-use, pass in props and they render correctly.

```javascript
import Chain from 'ui-reactive/Chain'; // Smart HOC'd component 
import { Chain } from 'ui-reactive/Chain'; // Dumb component
```