### PR TITLE
Add last block to staking overview, reposition warning

### DIFF
--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -99,7 +99,7 @@ class Address extends React.PureComponent<Props, State> {
         </AddressRow>
         {
           isAuthor
-            ? <div className='blockNumber'>{lastBlock}</div>
+            ? <div className='blockNumber'>#{lastBlock}</div>
             : null
         }
       </article>
@@ -199,6 +199,7 @@ class Address extends React.PureComponent<Props, State> {
       <RecentlyOffline
         accountId={stashId}
         offline={offline}
+        tooltip
       />
     );
   }

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -7,9 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import { Nominators, RecentlyOfflineMap } from '../types';
 
 import React from 'react';
-import { AccountId, Balance, HeaderExtended } from '@polkadot/types';
-import { withCalls, withMulti } from '@polkadot/ui-api/with';
-import { formatNumber } from '@polkadot/util';
+import { AccountId, Balance } from '@polkadot/types';
 
 import translate from '../translate';
 import Address from './Address';
@@ -17,8 +15,9 @@ import Address from './Address';
 type Props = I18nProps & {
   balances: DerivedBalancesMap,
   balanceArray: (_address: AccountId | string) => Array<Balance> | undefined,
-  chain_subscribeNewHead?: HeaderExtended,
   current: Array<string>,
+  lastAuthor?: string,
+  lastBlock: string,
   next: Array<string>,
   nominators: Nominators,
   recentlyOffline: RecentlyOfflineMap
@@ -67,20 +66,12 @@ class CurrentList extends React.PureComponent<Props> {
   }
 
   private renderColumn (addresses: Array<string>, defaultName: string) {
-    const { balances, balanceArray, chain_subscribeNewHead, nominators, recentlyOffline, t } = this.props;
+    const { balances, balanceArray, lastAuthor, lastBlock, nominators, recentlyOffline, t } = this.props;
 
     if (addresses.length === 0) {
       return (
         <div>{t('no addresses found')}</div>
       );
-    }
-
-    let lastBlock: string = '';
-    let lastAuthor: string;
-
-    if (chain_subscribeNewHead) {
-      lastBlock = `#${formatNumber(chain_subscribeNewHead.blockNumber)}`;
-      lastAuthor = (chain_subscribeNewHead.author || '').toString();
     }
 
     return (
@@ -103,10 +94,4 @@ class CurrentList extends React.PureComponent<Props> {
   }
 }
 
-export default withMulti(
-  CurrentList,
-  translate,
-  withCalls<Props>(
-    'derive.chain.subscribeNewHead'
-  )
-);
+export default translate(CurrentList);

--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -8,7 +8,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import BN from 'bn.js';
 import React from 'react';
 import SummarySession from '@polkadot/app-explorer/SummarySession';
-import { SummaryBox, CardSummary } from '@polkadot/ui-app';
+import { AddressMini, SummaryBox, CardSummary } from '@polkadot/ui-app';
 import { withCall, withMulti } from '@polkadot/ui-api';
 
 import translate from '../translate';
@@ -16,6 +16,8 @@ import translate from '../translate';
 type Props = I18nProps & {
   balances: DerivedBalancesMap,
   intentions: Array<string>,
+  lastAuthor?: string,
+  lastBlock: string,
   lastLengthChange?: BN,
   staking_validatorCount?: BN,
   validators: Array<string>
@@ -23,7 +25,7 @@ type Props = I18nProps & {
 
 class Summary extends React.PureComponent<Props> {
   render () {
-    const { className, intentions, style, t, staking_validatorCount, validators } = this.props;
+    const { className, intentions, lastAuthor, lastBlock, style, t, staking_validatorCount, validators } = this.props;
     const waiting = intentions.length > validators.length
       ? (intentions.length - validators.length)
       : 0;
@@ -41,7 +43,18 @@ class Summary extends React.PureComponent<Props> {
             {waiting}
           </CardSummary>
         </section>
-        <section className='ui--media-medium'>
+        <section>
+          <CardSummary label={t('last block')}>
+            {lastAuthor && (
+              <AddressMini
+                className='summary'
+                isPadded={false}
+                value={lastAuthor}
+                withAddress={false}
+              />
+            )}
+            {lastBlock}
+          </CardSummary>
           <SummarySession withBroken={false} />
         </section>
       </SummaryBox>

--- a/packages/ui-app/src/AddressMini.tsx
+++ b/packages/ui-app/src/AddressMini.tsx
@@ -113,6 +113,7 @@ export default class AddressMini extends React.PureComponent<Props> {
         accountId={value.toString()}
         offline={offlineStatus}
         tooltip
+        inline
       />
     );
   }

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -28,6 +28,7 @@ const Card = styled.article`
   > div {
     font-size: 2.1rem;
     font-weight: 100;
+    position: relative;
     line-height: 2.1rem;
     text-align: right;
 

--- a/packages/ui-app/src/RecentlyOffline.tsx
+++ b/packages/ui-app/src/RecentlyOffline.tsx
@@ -16,7 +16,8 @@ import translate from './translate';
 type Props = I18nProps & {
   accountId: AccountId | string,
   offline: Array<OfflineStatus>,
-  tooltip?: boolean
+  tooltip?: boolean,
+  inline?: boolean
 };
 
 type State = {
@@ -29,7 +30,7 @@ class RecentlyOffline extends React.PureComponent<Props, State> {
   };
 
   render () {
-    const { offline, tooltip = false, t } = this.props;
+    const { offline, inline, tooltip = false, t } = this.props;
     const { isOpen } = this.state;
     const accountId = this.props.accountId.toString();
 
@@ -54,7 +55,8 @@ class RecentlyOffline extends React.PureComponent<Props, State> {
         className={[
           'ui--RecentlyOffline',
           isOpen ? 'expand' : '',
-          tooltip ? 'tooltip' : ''
+          tooltip ? 'tooltip' : '',
+          inline ? 'inline' : ''
         ].join(' ')}
         {...(!tooltip ?
           { onClick: this.toggleOpen } :

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -49,6 +49,11 @@ header .ui--Button-Group {
   padding: 0.25rem 0 0 0;
 }
 
+.ui--AddressMini.summary {
+  position: relative;
+  top: -0.2rem;
+}
+
 .ui--AddressMini-info div {
   display: inline-block;
   vertical-align: middle;
@@ -264,12 +269,12 @@ header .ui--Button-Group {
 
 .ui--RecentlyOffline {
   position: absolute;
-  bottom: 0.75rem;
+  top: 0.75rem;
   font-size: 12px;
   cursor: help;
   display: flex;
   justify-content: center;
-  right: 0.75rem;
+  left: 0.75rem;
   width: 22px;
   height: 22px;
   padding: 0;
@@ -307,7 +312,7 @@ header .ui--Button-Group {
     }
   }
 
-  &.tooltip {
+  &.inline {
     position: static;
     margin: .3rem 0 .3rem .5rem;
   }


### PR DESCRIPTION
Closes #948, rel #936 

Adds last block and portrait to staking overview summary

Also experimenting with placement of offline warning badge because I noticed it was overlapping the block label that pops up for each entry