### PR TITLE
Label icon -> middle

### DIFF
--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -67,8 +67,9 @@ const Wrapper = styled.div`
       z-index: 10;
     }
 
-    .icon.help {
-      margin-right: 0;
+    i.icon.help {
+      margin: 0;
+      line-height: 1rem;
     }
 
     &.with-help:hover .help-hover {


### PR DESCRIPTION
It was just slightly off-center, very small adjustment to make it fit. (Also tested with multi-line labels)

![image](https://user-images.githubusercontent.com/1424473/56019203-593e0580-5d04-11e9-8551-033c12aa399a.png)
