### PR TITLE
Adjust extrinsic hash formatting

### DIFF
--- a/packages/ui-app/src/Call.tsx
+++ b/packages/ui-app/src/Call.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { Method, getTypeDef } from '@polkadot/types';
 import Params from '@polkadot/ui-params';
 
-import Labelled from './Labelled';
+import Static from './Static';
 import { classes } from './util';
 
 export type Props = BareProps & {
@@ -19,10 +19,11 @@ export type Props = BareProps & {
 };
 
 const Wrapper = styled.div`
-  .hash {
-    opacity: 0.5;
+  .hash .ui--Static {
     overflow: hidden;
     text-overflow: ellipsis;
+    word-break: unset;
+    word-wrap: unset;
   }
 `;
 
@@ -47,13 +48,7 @@ export default class Call extends React.PureComponent<Props> {
         {children}
         {
           hash
-            ? (
-              <Labelled label='extrinsic hash'>
-                <div className='hash'>
-                  {hash.toHex()}
-                </div>
-              </Labelled>
-            )
+            ? <Static className='hash' label='extrinsic hash'>{hash.toHex()}</Static>
             : null
         }
         <Params


### PR DESCRIPTION
<img width="617" alt="Polkadot:Substrate Portal 2019-04-12 12-34-37" src="https://user-images.githubusercontent.com/1424473/56031406-b2676280-5d1f-11e9-8660-7111dbb76c31.png">
<img width="569" alt="Polkadot:Substrate Portal 2019-04-12 12-33-59" src="https://user-images.githubusercontent.com/1424473/56031407-b2676280-5d1f-11e9-9397-7c8183ca0482.png">
