### PR TITLE
use pre tag for new line display

### DIFF
--- a/packages/app-js/src/Output.tsx
+++ b/packages/app-js/src/Output.tsx
@@ -40,9 +40,9 @@ export default (props: Props) => {
     <article className='container js--Output'>
       <div className='logs-wrapper'>
         <div className='logs-container'>
-          <div className='logs-content'>
+          <pre className='logs-content'>
             {props.logs.map(renderEntry)}
-          </div>
+          </pre>
         </div>
       </div>
       {props.children}


### PR DESCRIPTION
so that output of
```
const { metadata } = await api.rpc.state.getMetadata();
console.log( JSON.stringify(metadata.asV3.modules.toJSON(), null, 2) );
```
in JS editor is readable