### PR TITLE
Restore wiki link

### DIFF
--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -156,6 +156,7 @@ class SideBar extends React.PureComponent<Props> {
         <a
           className='apps--SideBar-Item-NavLink'
           href='https://github.com/polkadot-js/apps'
+          target='_blank'
         >
           <Icon name='github' /><span className='text'>GitHub</span>
         </a>
@@ -190,19 +191,17 @@ class SideBar extends React.PureComponent<Props> {
   }
 
   private renderWiki () {
-    return null;
-
-    // disabled for now, we need the space
-    // return (
-    //   <Menu.Item className='apps--SideBar-Item'>
-    //     <a
-    //       className='apps--SideBar-Item-NavLink'
-    //       href='https://github.com/w3f/Web3-wiki/wiki/Polkadot'
-    //     >
-    //       <Icon name='book' /> Wiki
-    //     </a>
-    //   </Menu.Item>
-    // );
+    return (
+      <Menu.Item className='apps--SideBar-Item'>
+        <a
+          className='apps--SideBar-Item-NavLink'
+          href='https://wiki.polkadot.network'
+          target='_blank'
+        >
+          <Icon name='book' /><span className='text'>Wiki</span>
+        </a>
+      </Menu.Item>
+    );
   }
 }
 


### PR DESCRIPTION
Closes #1014

Restores link to new wiki ([https://wiki.polkadot.network]()) and makes external links open in new tab