### PR TITLE
Mark raw seed as invalid if smaller than 32 char

### DIFF
--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,7 +71,7 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  return ((seed.length > 0) && (seed.length <= 32)) || isHexSeed(seed));
+  return ((seed.length > 0) && (seed.length <= 32)) || isHexSeed(seed);
 }
 
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,7 +71,7 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  return seed.length >= 32 || isHexSeed(seed);
+  return ((seed.length > 0) && (seed.length <= 32)) || isHexSeed(seed));
 }
 
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,7 +71,9 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  return seed.length <= 32 || isHexSeed(seed);
+  console.log('seed', seed)
+  console.log('seed.length <= 32 || isHexSeed(seed)', seed.length <= 32 || isHexSeed(seed))
+  return seed.length > 0 && seed.length <= 32 || isHexSeed(seed);
 }
 
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {
@@ -83,7 +85,7 @@ function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairT
 class Creator extends React.PureComponent<Props, State> {
   state: State = { seedType: 'bip' } as State;
 
-  constructor (props: Props) {
+  constructor(props: Props) {
     super(props);
 
     const { match: { params: { seed } }, t } = this.props;

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,8 +71,6 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  console.log('seed', seed)
-  console.log('seed.length <= 32 || isHexSeed(seed)', seed.length <= 32 || isHexSeed(seed))
   return seed.length > 0 && seed.length <= 32 || isHexSeed(seed);
 }
 

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,7 +71,7 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  return seed.length > 0 && seed.length <= 32 || isHexSeed(seed);
+  return seed.length > 0 && (seed.length <= 32 || isHexSeed(seed));
 }
 
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {
@@ -83,7 +83,7 @@ function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairT
 class Creator extends React.PureComponent<Props, State> {
   state: State = { seedType: 'bip' } as State;
 
-  constructor(props: Props) {
+  constructor (props: Props) {
     super(props);
 
     const { match: { params: { seed } }, t } = this.props;

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -71,7 +71,7 @@ function isHexSeed (seed: string): boolean {
 }
 
 function rawValidate (seed: string): boolean {
-  return seed.length > 0 && (seed.length <= 32 || isHexSeed(seed));
+  return seed.length >= 32 || isHexSeed(seed);
 }
 
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {


### PR DESCRIPTION
- closes 1019

The bug reported in the issue happened when `seed===''`.