### PR TITLE
Hide Sidebar scrollbar on Firefox (like chrome)

### DIFF
--- a/packages/apps/src/SideBar/SideBar.css
+++ b/packages/apps/src/SideBar/SideBar.css
@@ -69,8 +69,9 @@
       display: flex;
       flex-direction: column;
       height: 100vh;
-      overflow-y: scroll;
+      overflow-y: auto;
       width: 100%;
+      scrollbar-width: none;
 
       &::-webkit-scrollbar {
         display: none;


### PR DESCRIPTION
- closes #1025 

Couldn't find any better hack than what's said in [this thread](https://stackoverflow.com/questions/20997183/how-to-hide-scrollbar-in-firefox) to make the behaviour on Firefox the same as chrome.