### PR TITLE
Make sure labels aren't above help-hover

### DIFF
--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -31,7 +31,6 @@ const Wrapper = styled.div`
     margin: 0.25rem 0 0 0;
     padding-right: 0.5rem;
     position: relative;
-    z-index: 1;
 
     .help-hover {
       background: #222;
@@ -45,6 +44,7 @@ const Wrapper = styled.div`
       left: 2.5rem;
       right: -5rem;
       z-index: 10;
+      opacity: .9;
     }
 
     i.icon.help {

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -33,13 +33,12 @@ h3, h4, h5 {
 
 label {
   box-sizing: border-box;
-  color: #4e4e4e;
+  color: rgba(78,78,78,.75);
   display: block;
   font-family: sans-serif;
   font-size: 1rem;
   font-weight: 100;
   margin: 0.25rem;
-  opacity: 0.75;
 }
 
 /*


### PR DESCRIPTION
- closes #1024

It turned out to be more complex than I expected. TL;DR It was due to the fact that a parent element had an `opacitiy`<1 in our case the `label` and also had a z-index. (a [good article](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/) about it).

I modified the color of `label` to make it match what it looked like before (with the opacity). Here is how things look like now (basically the same, the background of the help-hover is a little darker, which makes the help text easier to read). 
![image](https://user-images.githubusercontent.com/33178835/56236932-19bc4400-608b-11e9-9dd3-e9dcdbca54c2.png)
