### PR TITLE
withCall can't handle Tuple parameter

### DIFF
--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -109,7 +109,7 @@ export default function withCall<P extends ApiProps> (endpoint: string, { at, at
         const values = isUndefined(paramValue)
           ? params
           : params.concat(
-            Array.isArray(paramValue)
+            (Array.isArray(paramValue) && !(paramValue as any).toU8a)
               ? paramValue
               : [paramValue]
           );


### PR DESCRIPTION
This is more of issue report instead of proper fix. Please feel free to reject this and do it properly.

with
```
export default withCalls<Props>(
  ['query.kitties.ownedKitties', { paramName: 'accountKey', propName: 'item' }]
)
```

and 

```
export class OwnedKittiesKey extends Tuple.with([AccountId, Option.with(KittyIndex)]) {
  get account (): AccountId {
    return this[0] as AccountId;
  }

  get kittyId (): Option<KittyIndex> {
    return this[1] as Option<KittyIndex>;
  }
}
```

it just won't work because tuple is also array so it got unpacked and resulting unexpected behavior.

(Yes I am writing another Substrate Kitties)