### PR TITLE
Added a simple filter to the staking overview (#971) .

### DIFF
--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -75,18 +75,18 @@ class Address extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { address, lastAuthor, lastBlock, stashId, staking_stakers, filter, recentlyOffline } = this.props;
+    const { address, lastAuthor, lastBlock, stashId, staking_stakers, filter } = this.props;
     const { controllerId } = this.state;
     const isAuthor = [address, controllerId, stashId].includes(lastAuthor);
     const bonded = staking_stakers && !staking_stakers.own.isZero()
       ? [staking_stakers.own, staking_stakers.total.sub(staking_stakers.own)]
       : undefined;
-    
-    if ((filter == 'hasNominators' && !this.hasNominators()) 
-        || (filter == 'noNominators' && this.hasNominators()) 
-        || (filter == "hasWarnings" && !this.hasWarnings()) 
-        || (filter == "noWarnings" && this.hasWarnings()) 
-        || (filter == "iNominated" && !this.iNominated())){
+
+    if ((filter === 'hasNominators' && !this.hasNominators())
+        || (filter === 'noNominators' && this.hasNominators())
+        || (filter === 'hasWarnings' && !this.hasWarnings())
+        || (filter === 'noWarnings' && this.hasWarnings())
+        || (filter === 'iNominated' && !this.iNominated())) {
       return null;
     }
 
@@ -156,28 +156,28 @@ class Address extends React.PureComponent<Props, State> {
       </div>
     );
   }
-  
+
   private getNominators () {
     const { staking_stakers } = this.props;
     return staking_stakers
             ? staking_stakers.others.map(({ who, value }): [AccountId, Balance] => [who, value])
-            : []; 
+            : [];
   }
 
-  private iNominated (){
+  private iNominated () {
     const { address } = this.props;
     const nominators = this.getNominators();
 
-    return nominators.filter(nom => nom[0].toString() == address ).length > 0
+    return nominators.filter(nom => nom[0].toString() === address).length > 0;
   }
 
-  private hasNominators (){
+  private hasNominators () {
     const nominators = this.getNominators();
-    
-    return !!nominators.length; 
+
+    return !!nominators.length;
   }
 
-  private hasWarnings (){
+  private hasWarnings () {
     const { recentlyOffline, stashId } = this.props;
 
     if (!stashId || !recentlyOffline[stashId]) {

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -4,7 +4,7 @@
 
 import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
-import { RecentlyOfflineMap } from '../types';
+import { ValidatorFilter, RecentlyOfflineMap } from '../types';
 
 import React from 'react';
 import { AccountId, Balance, Option, StakingLedger, Exposure } from '@polkadot/types';
@@ -22,6 +22,7 @@ type Props = I18nProps & {
   lastAuthor: string,
   lastBlock: string,
   recentlyOffline: RecentlyOfflineMap,
+  filter: ValidatorFilter,
   session_nextKeyFor?: Option<AccountId>,
   staking_bonded?: Option<AccountId>,
   staking_ledger?: Option<StakingLedger>,
@@ -74,12 +75,20 @@ class Address extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { address, lastAuthor, lastBlock, stashId, staking_stakers } = this.props;
+    const { address, lastAuthor, lastBlock, stashId, staking_stakers, filter, recentlyOffline } = this.props;
     const { controllerId } = this.state;
     const isAuthor = [address, controllerId, stashId].includes(lastAuthor);
     const bonded = staking_stakers && !staking_stakers.own.isZero()
       ? [staking_stakers.own, staking_stakers.total.sub(staking_stakers.own)]
       : undefined;
+    
+    if ((filter == 'hasNominators' && !this.hasNominators()) 
+        || (filter == 'noNominators' && this.hasNominators()) 
+        || (filter == "hasWarnings" && !this.hasWarnings()) 
+        || (filter == "noWarnings" && this.hasWarnings()) 
+        || (filter == "iNominated" && !this.iNominated())){
+      return null;
+    }
 
     return (
       <article key={stashId || controllerId}>
@@ -147,12 +156,40 @@ class Address extends React.PureComponent<Props, State> {
       </div>
     );
   }
+  
+  private getNominators () {
+    const { staking_stakers } = this.props;
+    return staking_stakers
+            ? staking_stakers.others.map(({ who, value }): [AccountId, Balance] => [who, value])
+            : []; 
+  }
+
+  private iNominated (){
+    const { address } = this.props;
+    const nominators = this.getNominators();
+
+    return nominators.filter(nom => nom[0].toString() == address ).length > 0
+  }
+
+  private hasNominators (){
+    const nominators = this.getNominators();
+    
+    return !!nominators.length; 
+  }
+
+  private hasWarnings (){
+    const { recentlyOffline, stashId } = this.props;
+
+    if (!stashId || !recentlyOffline[stashId]) {
+      return false;
+    }
+
+    return true;
+  }
 
   private renderNominators () {
-    const { staking_stakers, t } = this.props;
-    const nominators = staking_stakers
-      ? staking_stakers.others.map(({ who, value }): [AccountId, Balance] => [who, value])
-      : [];
+    const { t } = this.props;
+    const nominators = this.getNominators();
 
     if (!nominators.length) {
       return null;

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -13,7 +13,6 @@ import { Dropdown } from '@polkadot/ui-app';
 import translate from '../translate';
 import Address from './Address';
 
-
 type Props = I18nProps & {
   balances: DerivedBalancesMap,
   current: Array<string>,
@@ -67,12 +66,12 @@ class CurrentList extends React.PureComponent<Props, State> {
       <Wrapper>
         <div className='filter'>
           <Dropdown
-                help={t('Select which validators/intentions you want to display, all, only the ones you nominated, only the ones that has/no nominators, only the ones that has/no warnings.')}
-                label={t('filter')}
-                onChange={this.onChangeFilter}
-                options={filterOptions}
-                value={filter}
-              />
+            help={t('Select which validators/intentions you want to display, all, only the ones you nominated, only the ones that has/no nominators, only the ones that has/no warnings.')}
+            label={t('filter')}
+            onChange={this.onChangeFilter}
+            options={filterOptions}
+            value={filter}
+          />
         </div>
         <div className='validator--ValidatorsList ui--flex-medium'>
           <div className='validator--current'>

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -26,6 +26,7 @@ type State = {
   filter: ValidatorFilter,
   filterOptions: Array<{ text: React.ReactNode, value: ValidatorFilter }>
 };
+
 const Wrapper = styled.div`
   .filter {
     display: flex;
@@ -66,7 +67,7 @@ class CurrentList extends React.PureComponent<Props, State> {
       <Wrapper>
         <div className='filter'>
           <Dropdown
-            help={t('Select which validators/intentions you want to display, all, only the ones you nominated, only the ones that has/no nominators, only the ones that has/no warnings.')}
+            help={t('Select which validators/intentions you want to display.')}
             label={t('filter')}
             onChange={this.onChangeFilter}
             options={filterOptions}

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -4,12 +4,15 @@
 
 import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
-import { RecentlyOfflineMap } from '../types';
+import { ValidatorFilter, RecentlyOfflineMap } from '../types';
 
 import React from 'react';
+import styled from 'styled-components';
+import { Dropdown } from '@polkadot/ui-app';
 
 import translate from '../translate';
 import Address from './Address';
+
 
 type Props = I18nProps & {
   balances: DerivedBalancesMap,
@@ -20,17 +23,66 @@ type Props = I18nProps & {
   recentlyOffline: RecentlyOfflineMap
 };
 
-class CurrentList extends React.PureComponent<Props> {
+type State = {
+  filter: ValidatorFilter,
+  filterOptions: Array<{ text: React.ReactNode, value: ValidatorFilter }>
+};
+const Wrapper = styled.div`
+  .filter {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 0.75rem;
+
+    > div {
+      max-width: 35rem;
+    }
+  }
+`;
+
+class CurrentList extends React.PureComponent<Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props);
+
+    const { t } = props;
+
+    this.state = {
+      filter: 'all',
+      filterOptions: [
+        { text: t('Show all validators and intentions'), value: 'all' },
+        { text: t('Show only my nominations'), value: 'iNominated' },
+        { text: t('Show only with nominators'), value: 'hasNominators' },
+        { text: t('Show only without nominators'), value: 'noNominators' },
+        { text: t('Show only with warnings'), value: 'hasWarnings' },
+        { text: t('Show only without warnings'), value: 'noWarnings' }
+      ]
+    };
+  }
+
   render () {
+    const { t } = this.props;
+    const { filter, filterOptions } = this.state;
     return (
-      <div className='validator--ValidatorsList ui--flex-medium'>
-        <div className='validator--current'>
-          {this.renderCurrent()}
+      <Wrapper>
+        <div className='filter'>
+          <Dropdown
+                help={t('Select which validators/intentions you want to display, all, only the ones you nominated, only the ones that has/no nominators, only the ones that has/no warnings.')}
+                label={t('filter')}
+                onChange={this.onChangeFilter}
+                options={filterOptions}
+                value={filter}
+              />
         </div>
-        <div className='validator--next'>
-          {this.renderNext()}
+        <div className='validator--ValidatorsList ui--flex-medium'>
+          <div className='validator--current'>
+            {this.renderCurrent()}
+          </div>
+          <div className='validator--next'>
+            {this.renderNext()}
+          </div>
         </div>
-      </div>
+      </Wrapper>
     );
   }
 
@@ -64,6 +116,7 @@ class CurrentList extends React.PureComponent<Props> {
 
   private renderColumn (addresses: Array<string>, defaultName: string) {
     const { balances, lastAuthor, lastBlock, recentlyOffline, t } = this.props;
+    const { filter } = this.state;
 
     if (addresses.length === 0) {
       return (
@@ -79,6 +132,7 @@ class CurrentList extends React.PureComponent<Props> {
             balances={balances}
             defaultName={defaultName}
             key={address}
+            filter={filter}
             lastAuthor={lastAuthor}
             lastBlock={lastBlock}
             recentlyOffline={recentlyOffline}
@@ -86,6 +140,9 @@ class CurrentList extends React.PureComponent<Props> {
         ))}
       </div>
     );
+  }
+  private onChangeFilter = (filter: ValidatorFilter): void => {
+    this.setState({ filter });
   }
 }
 

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -31,3 +31,5 @@ export interface OfflineStatus {
 }
 
 export type AccountFilter = 'all' | 'controller' | 'session' | 'stash' | 'unbonded';
+
+export type ValidatorFilter = 'all' |'hasNominators' | 'noNominators' |  'hasWarnings' | 'noWarnings' | 'iNominated';

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -32,4 +32,4 @@ export interface OfflineStatus {
 
 export type AccountFilter = 'all' | 'controller' | 'session' | 'stash' | 'unbonded';
 
-export type ValidatorFilter = 'all' |'hasNominators' | 'noNominators' |  'hasWarnings' | 'noWarnings' | 'iNominated';
+export type ValidatorFilter = 'all' | 'hasNominators' | 'noNominators' | 'hasWarnings' | 'noWarnings' | 'iNominated';


### PR DESCRIPTION
Hello!
I'm in love with this project and I'd like to help as much as I can, this is my first attempt resolving the issue  #971.

Implementation of a basic "non-tag" filtering in the staking overview page inspired in #965:

<img width="1215" alt="Screenshot 2019-04-22 at 00 20 56" src="https://user-images.githubusercontent.com/40487685/56476210-b0766f80-6494-11e9-8a6f-75eedaea481f.png">

<img width="1235" alt="Screenshot 2019-04-22 at 00 21 15" src="https://user-images.githubusercontent.com/40487685/56476212-b8ceaa80-6494-11e9-8821-9a6688e544df.png">


