### PR TITLE
feat: Relates to #976 - Add ability to second a public proposal

### DIFF
--- a/packages/app-democracy/src/Proposal.tsx
+++ b/packages/app-democracy/src/Proposal.tsx
@@ -42,6 +42,10 @@ class ProposalDisplay extends React.PureComponent<Props> {
     const balance = depositOfs[0] as Balance;
     const addresses = depositOfs[1] as Vector<AccountId>;
 
+    if (!addresses) {
+      return null;
+    }
+
     console.log('addresses', addresses.map(address => address.toString()));
     console.log('allAccounts', Object.keys(allAccounts as SubjectInfo));
 
@@ -56,19 +60,19 @@ class ProposalDisplay extends React.PureComponent<Props> {
      * are not included in the list of account ids in the `depositOfs`
      * vector.
      */
-    const addressesWithoutDepositOnProposal = new Set(
-      [...addressesSet].filter(x => !allAccountsSet.has(x)));
+    const addressesWithoutDepositOnProposal = Array.from(new Set(
+      [...allAccountsSet].filter(x => !addressesSet.has(x))));
 
-    // FIXME - currently it is still allowing all the addresses second the proposal
-    // even though we are only providing the list of addresses that haven't yet
-    // placed a deposit on the proposal
     return (
       <Item
         idNumber={idNumber}
         proposal={value[1] as Proposal}
-        proposalExtra={this.renderExtra(balance, (addressesWithoutDepositOnProposal as unknown) as Vector<AccountId>)}
+        proposalExtra={this.renderExtra(balance, addresses)}
       >
-        <Seconding propIndex={idNumber} />
+        <Seconding
+          addressesWithoutDepositOnProposal={(addressesWithoutDepositOnProposal as unknown) as Vector<AccountId>}
+          propIndex={idNumber}
+        />
       </Item>
     );
   }

--- a/packages/app-democracy/src/Proposal.tsx
+++ b/packages/app-democracy/src/Proposal.tsx
@@ -12,6 +12,7 @@ import { withCall, withMulti } from '@polkadot/ui-api';
 import { formatBalance } from '@polkadot/util';
 
 import Item from './Item';
+import Seconding from './Seconding';
 import translate from './translate';
 
 type Props = I18nProps & {
@@ -29,7 +30,9 @@ class ProposalDisplay extends React.PureComponent<Props> {
         idNumber={idNumber}
         proposal={value[1] as Proposal}
         proposalExtra={this.renderExtra()}
-      />
+      >
+        <Seconding propIndex={idNumber} />
+      </Item>
     );
   }
 

--- a/packages/app-democracy/src/Seconding.tsx
+++ b/packages/app-democracy/src/Seconding.tsx
@@ -7,6 +7,7 @@ import { QueueProps } from '@polkadot/ui-app/Status/types';
 
 import BN from 'bn.js';
 import React from 'react';
+import { AccountId, Vector } from '@polkadot/types';
 import { InputAddress } from '@polkadot/ui-app';
 import { QueueConsumer } from '@polkadot/ui-app/Status/Context';
 
@@ -14,6 +15,7 @@ import SecondingButtons from './SecondingButtons';
 import translate from './translate';
 
 type Props = I18nProps & {
+  addressesWithoutDepositOnProposal: Vector<AccountId>,
   propIndex: BN
 };
 
@@ -25,7 +27,13 @@ class Seconding extends React.PureComponent<Props, State> {
   state: State = {};
 
   render () {
-    const { t } = this.props;
+    const { addressesWithoutDepositOnProposal, t } = this.props;
+
+    console.log('addressesWithoutDepositOnProposal', addressesWithoutDepositOnProposal);
+    // FIXME - currently it is still allowing any address to second a proposal.
+    // but instead we only want `InputAddress` to list of addresses that haven't yet
+    // placed a deposit on the proposal (i.e. `addressesWithoutDepositOnProposal`),
+    // but how do we do that??
 
     return (
       <div className='democracy--Proposal-second'>

--- a/packages/app-democracy/src/Seconding.tsx
+++ b/packages/app-democracy/src/Seconding.tsx
@@ -4,20 +4,16 @@
 
 import { I18nProps } from '@polkadot/ui-app/types';
 import { QueueProps } from '@polkadot/ui-app/Status/types';
-import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 
 import BN from 'bn.js';
 import React from 'react';
 import { InputAddress } from '@polkadot/ui-app';
 import { QueueConsumer } from '@polkadot/ui-app/Status/Context';
-import accountObservable from '@polkadot/ui-keyring/observable/accounts';
-import { withMulti, withObservable } from '@polkadot/ui-api';
 
 import SecondingButtons from './SecondingButtons';
 import translate from './translate';
 
 type Props = I18nProps & {
-  allAccounts?: SubjectInfo,
   propIndex: BN
 };
 
@@ -29,12 +25,7 @@ class Seconding extends React.PureComponent<Props, State> {
   state: State = {};
 
   render () {
-    const { allAccounts, t } = this.props;
-    const hasAccounts = allAccounts && Object.keys(allAccounts).length !== 0;
-
-    if (!hasAccounts) {
-      return null;
-    }
+    const { t } = this.props;
 
     return (
       <div className='democracy--Proposal-second'>
@@ -76,8 +67,4 @@ class Seconding extends React.PureComponent<Props, State> {
   }
 }
 
-export default withMulti(
-  Seconding,
-  translate,
-  withObservable(accountObservable.subject, { propName: 'allAccounts' })
-);
+export default translate(Seconding);

--- a/packages/app-democracy/src/Seconding.tsx
+++ b/packages/app-democracy/src/Seconding.tsx
@@ -1,0 +1,83 @@
+// Copyright 2017-2019 @polkadot/app-democracy authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { QueueProps } from '@polkadot/ui-app/Status/types';
+import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
+
+import BN from 'bn.js';
+import React from 'react';
+import { InputAddress } from '@polkadot/ui-app';
+import { QueueConsumer } from '@polkadot/ui-app/Status/Context';
+import accountObservable from '@polkadot/ui-keyring/observable/accounts';
+import { withMulti, withObservable } from '@polkadot/ui-api';
+
+import SecondingButtons from './SecondingButtons';
+import translate from './translate';
+
+type Props = I18nProps & {
+  allAccounts?: SubjectInfo,
+  propIndex: BN
+};
+
+type State = {
+  accountId?: string
+};
+
+class Seconding extends React.PureComponent<Props, State> {
+  state: State = {};
+
+  render () {
+    const { allAccounts, t } = this.props;
+    const hasAccounts = allAccounts && Object.keys(allAccounts).length !== 0;
+
+    if (!hasAccounts) {
+      return null;
+    }
+
+    return (
+      <div className='democracy--Proposal-second'>
+        <InputAddress
+          label={t('second using my account')}
+          onChange={this.onChangeAccount}
+          placeholder='0x...'
+          type='account'
+          withLabel
+        />
+        {this.renderButtons()}
+      </div>
+    );
+  }
+
+  private renderButtons () {
+    const { propIndex } = this.props;
+    const { accountId } = this.state;
+
+    if (!accountId) {
+      return null;
+    }
+
+    return (
+      <QueueConsumer>
+        {({ queueExtrinsic }: QueueProps) => (
+          <SecondingButtons
+            accountId={accountId}
+            queueExtrinsic={queueExtrinsic}
+            propIndex={propIndex}
+          />
+        )}
+      </QueueConsumer>
+    );
+  }
+
+  private onChangeAccount = (accountId?: string) => {
+    this.setState({ accountId });
+  }
+}
+
+export default withMulti(
+  Seconding,
+  translate,
+  withObservable(accountObservable.subject, { propName: 'allAccounts' })
+);

--- a/packages/app-democracy/src/SecondingButtons.tsx
+++ b/packages/app-democracy/src/SecondingButtons.tsx
@@ -1,0 +1,56 @@
+// Copyright 2017-2019 @polkadot/app-democracy authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { QueueTx$ExtrinsicAdd } from '@polkadot/ui-app/Status/types';
+import { ApiProps } from '@polkadot/ui-api/types';
+
+import BN from 'bn.js';
+import React from 'react';
+import { Button } from '@polkadot/ui-app';
+import { withApi, withMulti } from '@polkadot/ui-api';
+
+import translate from './translate';
+
+type Props = ApiProps & I18nProps & {
+  accountId?: string,
+  queueExtrinsic: QueueTx$ExtrinsicAdd,
+  propIndex: BN
+};
+
+class SecondingButton extends React.PureComponent<Props> {
+  render () {
+    const { accountId, t } = this.props;
+
+    return (
+      <Button.Group>
+        <Button
+          isDisabled={!accountId}
+          isPositive
+          label={t('Sponsor')}
+          onClick={this.doSponsor}
+        />
+      </Button.Group>
+    );
+  }
+
+  private doSponsor () {
+    const { accountId, api, propIndex, queueExtrinsic } = this.props;
+
+    if (!accountId) {
+      return;
+    }
+
+    queueExtrinsic({
+      extrinsic: api.tx.democracy.second(propIndex),
+      accountId
+    });
+  }
+}
+
+export default withMulti(
+  SecondingButton,
+  translate,
+  withApi
+);

--- a/packages/app-democracy/src/SecondingButtons.tsx
+++ b/packages/app-democracy/src/SecondingButtons.tsx
@@ -29,7 +29,7 @@ class SecondingButton extends React.PureComponent<Props> {
           isDisabled={!accountId}
           isPositive
           label={t('Sponsor')}
-          onClick={this.doSponsor}
+          onClick={this.onClickSponsor}
         />
       </Button.Group>
     );
@@ -46,6 +46,10 @@ class SecondingButton extends React.PureComponent<Props> {
       extrinsic: api.tx.democracy.second(propIndex),
       accountId
     });
+  }
+
+  private onClickSponsor = () => {
+    this.doSponsor();
   }
 }
 


### PR DESCRIPTION
* [x] A user can go to the Extrinsics tab, the choose ALICE as the sender and CHARLIE as the recipient, choose an extrinsic 'democracy > propose', then choose 'balances > setBalance' , and lastly enter a value of 100, and then click 'Submit Transaction'. Then quickly go to the Democracy tab before the end of the launch period (when it elevates it into a referendum), and it will display the proposal.
It should list ALICE as a depositor (since she created the proposal).
Now choose BOB from the list of accounts where it says 'second using my account', and click "Sponsor" (second) to have him second this proposal. Shortly afterward the list of depositors will update and include BOB.
* [ ] **Determine how to only list the `addressesWithoutDepositOnProposal` addresses in the selection box 'second using my account' so a user can only choose to click "Sponsor" and second a proposal using an address that hasn't already placed a deposit on that proposal (i.e. the list of addresses shouldn't include the proposer of the proposal or anyone who has already sponsored it). At the moment the `InputAddress` component is used and it's listing all the accounts**
* [ ] Find out how else to do `(addressesWithoutDepositOnProposal as unknown) as Vector<AccountId>` so TypeScript doesn't complain, since this doesn't look good 
* [ ] Remove console.logs