### PR TITLE
Add create proposal option to app-democracy

### DIFF
--- a/packages/app-democracy/src/Overview/Item.tsx
+++ b/packages/app-democracy/src/Overview/Item.tsx
@@ -10,7 +10,7 @@ import { Method, Proposal } from '@polkadot/types';
 import { Call } from '@polkadot/ui-app';
 import { formatNumber } from '@polkadot/util';
 
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   children?: React.ReactNode,

--- a/packages/app-democracy/src/Overview/Proposal.tsx
+++ b/packages/app-democracy/src/Overview/Proposal.tsx
@@ -12,7 +12,7 @@ import { withCalls, withMulti } from '@polkadot/ui-api';
 import { formatBalance } from '@polkadot/util';
 
 import Item from './Item';
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   democracy_depositOf?: Option<Tuple>,

--- a/packages/app-democracy/src/Overview/Proposals.tsx
+++ b/packages/app-democracy/src/Overview/Proposals.tsx
@@ -6,12 +6,10 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import { Tuple } from '@polkadot/types';
-import { Button } from '@polkadot/ui-app';
 import { withCalls, withMulti } from '@polkadot/ui-api';
 
 import Proposal from './Proposal';
-import Propose from './Propose';
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   democracy_publicProps?: Array<Tuple>
@@ -33,16 +31,8 @@ class Proposals extends React.PureComponent<Props> {
       <section className='democracy--Proposals'>
         <h1>
           {t('proposals')}
-          <Button
-            isPrimary
-            className='democracy--Proposal-new'
-            key='propose'
-            onClick={this.togglePropose}
-            label={t('Propose')}
-          />
         </h1>
         {this.renderProposals()}
-        {this.renderPropose()}
       </section>
     );
   }
@@ -65,23 +55,6 @@ class Proposals extends React.PureComponent<Props> {
         value={proposal}
       />
     ));
-  }
-
-  private renderPropose () {
-    const { isProposeOpen } = this.state;
-
-    return (
-      <Propose
-        isOpen={isProposeOpen}
-        onClose={this.togglePropose}
-      />
-    );
-  }
-
-  private togglePropose = () => {
-    this.setState(({ isProposeOpen }: State) => ({
-      isProposeOpen: !isProposeOpen
-    }));
   }
 }
 

--- a/packages/app-democracy/src/Overview/Referendum.tsx
+++ b/packages/app-democracy/src/Overview/Referendum.tsx
@@ -17,7 +17,7 @@ import { formatBalance, formatNumber } from '@polkadot/util';
 
 import Item from './Item';
 import Voting from './Voting';
-import translate from './translate';
+import translate from '../translate';
 
 const COLORS_YAY = settings.uiTheme === 'substrate'
   ? ['#4d4', '#4e4']

--- a/packages/app-democracy/src/Overview/Referendums.tsx
+++ b/packages/app-democracy/src/Overview/Referendums.tsx
@@ -10,7 +10,7 @@ import { Option } from '@polkadot/types';
 import { withCalls } from '@polkadot/ui-api';
 
 import Referendum from './Referendum';
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   democracy_referendums?: Array<Option<ReferendumInfoExtended>>

--- a/packages/app-democracy/src/Overview/Summary.tsx
+++ b/packages/app-democracy/src/Overview/Summary.tsx
@@ -10,7 +10,7 @@ import { SummaryBox, CardSummary } from '@polkadot/ui-app';
 import { withCalls } from '@polkadot/ui-api';
 import { formatNumber } from '@polkadot/util';
 
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   chain_bestNumber?: BN,

--- a/packages/app-democracy/src/Overview/Voting.tsx
+++ b/packages/app-democracy/src/Overview/Voting.tsx
@@ -12,7 +12,7 @@ import accountObservable from '@polkadot/ui-keyring/observable/accounts';
 import { withMulti, withObservable } from '@polkadot/ui-api';
 
 import VotingButtons from './VotingButtons';
-import translate from './translate';
+import translate from '../translate';
 
 type Props = I18nProps & {
   allAccounts?: SubjectInfo,

--- a/packages/app-democracy/src/Overview/VotingButtons.tsx
+++ b/packages/app-democracy/src/Overview/VotingButtons.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { Button, TxButton } from '@polkadot/ui-app';
 import { withApi, withMulti } from '@polkadot/ui-api';
 
-import translate from './translate';
+import translate from '../translate';
 
 type Props = ApiProps & I18nProps & {
   accountId?: string,

--- a/packages/app-democracy/src/Overview/index.tsx
+++ b/packages/app-democracy/src/Overview/index.tsx
@@ -1,0 +1,27 @@
+// Copyright 2017-2019 @polkadot/app-democracy authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { AppProps, BareProps, I18nProps } from '@polkadot/ui-app/types';
+
+import '../index.css';
+
+import React from 'react';
+
+import Proposals from './Proposals';
+import Referendums from './Referendums';
+import Summary from './Summary';
+
+type Props = AppProps & BareProps & I18nProps;
+
+export default class Overview extends React.PureComponent<Props> {
+  render () {
+    return (
+      <>
+        <Summary />
+        <Referendums />
+        <Proposals />
+      </>
+    );
+  }
+}

--- a/packages/app-democracy/src/Proposals.tsx
+++ b/packages/app-democracy/src/Proposals.tsx
@@ -38,7 +38,7 @@ class Proposals extends React.PureComponent<Props> {
             className='democracy--Proposal-new'
             key='propose'
             onClick={this.togglePropose}
-            label={t('Propose...')}
+            label={t('Propose')}
           />
         </h1>
         {this.renderProposals()}

--- a/packages/app-democracy/src/Proposals.tsx
+++ b/packages/app-democracy/src/Proposals.tsx
@@ -6,23 +6,43 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import { Tuple } from '@polkadot/types';
+import { Button } from '@polkadot/ui-app';
 import { withCalls, withMulti } from '@polkadot/ui-api';
 
 import Proposal from './Proposal';
+import Propose from './Propose';
 import translate from './translate';
 
 type Props = I18nProps & {
   democracy_publicProps?: Array<Tuple>
 };
 
+type State = {
+  isProposeOpen: boolean
+};
+
 class Proposals extends React.PureComponent<Props> {
+  state: State = {
+    isProposeOpen: false
+  };
+
   render () {
     const { t } = this.props;
 
     return (
       <section className='democracy--Proposals'>
-        <h1>{t('proposals')}</h1>
+        <h1>
+          {t('proposals')}
+          <Button
+            isPrimary
+            className='democracy--Proposal-new'
+            key='propose'
+            onClick={this.togglePropose}
+            label={t('Propose...')}
+          />
+        </h1>
         {this.renderProposals()}
+        {this.renderPropose()}
       </section>
     );
   }
@@ -45,6 +65,23 @@ class Proposals extends React.PureComponent<Props> {
         value={proposal}
       />
     ));
+  }
+
+  private renderPropose () {
+    const { isProposeOpen } = this.state;
+
+    return (
+      <Propose
+        isOpen={isProposeOpen}
+        onClose={this.togglePropose}
+      />
+    );
+  }
+
+  private togglePropose = () => {
+    this.setState(({ isProposeOpen }: State) => ({
+      isProposeOpen: !isProposeOpen
+    }));
   }
 }
 

--- a/packages/app-democracy/src/Propose.tsx
+++ b/packages/app-democracy/src/Propose.tsx
@@ -48,7 +48,7 @@ class Propose extends React.PureComponent<Props, State> {
 
     return (
       <Modal
-        className='staking--Bonding'
+        className='democracy--Propose'
         dimmer='inverted'
         open
         size='small'
@@ -95,12 +95,13 @@ class Propose extends React.PureComponent<Props, State> {
     return (
       <>
         <Modal.Header>
-          {t('Bonding Preferences')}
+          {t('Submit New Proposal')}
         </Modal.Header>
         <Modal.Content className='ui--signer-Signer-Content'>
           <InputAddress
             className='medium'
-            label={t('using the following account')}
+            label={t('account')}
+            help={t('The account used to make the new proposal')}
             type='account'
             onChange={this.onChangeAccount}
           />
@@ -112,6 +113,7 @@ class Propose extends React.PureComponent<Props, State> {
           <InputBalance
             className='medium'
             isError={!hasValue}
+            help={t('The amount that will be bonded to submit the proposal')}
             label={t('value')}
             onChange={this.onChangeValue}
           />

--- a/packages/app-democracy/src/Propose.tsx
+++ b/packages/app-democracy/src/Propose.tsx
@@ -16,7 +16,9 @@ import { withApi, withMulti } from '@polkadot/ui-api';
 
 import translate from './translate';
 
-type Props = I18nProps & ApiProps & RouteComponentProps;
+type Props = I18nProps & ApiProps & RouteComponentProps & {
+  basePath: string
+};
 
 type State = {
   accountId?: string,
@@ -116,9 +118,9 @@ class Propose extends React.PureComponent<Props, State> {
   }
 
   private onSubmitProposal = () => {
-    const { history } = this.props;
+    const { history, basePath } = this.props;
 
-    history.push('/democracy');
+    history.push(basePath);
   }
 }
 

--- a/packages/app-democracy/src/Propose.tsx
+++ b/packages/app-democracy/src/Propose.tsx
@@ -1,0 +1,160 @@
+// Copyright 2017-2019 @polkadot/ui-staking authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
+
+import BN from 'bn.js';
+import React from 'react';
+import { AccountId, Method, Proposal } from '@polkadot/types';
+
+import { Button, Extrinsic, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
+import { withApi, withMulti } from '@polkadot/ui-api';
+
+import translate from './translate';
+
+type Props = I18nProps & ApiProps & {
+  controllerId?: AccountId | null,
+  isOpen: boolean,
+  onClose: () => void
+};
+
+type State = {
+  accountId?: string,
+  method: Method | null,
+  value: BN,
+  isValid: boolean
+};
+
+class Propose extends React.PureComponent<Props, State> {
+  state: State = {
+    method: null,
+    value: new BN(0),
+    isValid: false
+  };
+  constructor (props: Props) {
+    super(props);
+  }
+
+  render () {
+    const { isOpen, onClose, t } = this.props;
+    const { isValid, accountId, method, value } = this.state;
+    const hasValue = !!value && value.gtn(0);
+
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <Modal
+        className='staking--Bonding'
+        dimmer='inverted'
+        open
+        size='small'
+      >
+        {this.renderContent()}
+        <Modal.Actions>
+          <Button.Group>
+            <Button
+              isNegative
+              onClick={onClose}
+              label={t('Cancel')}
+            />
+            <Button.Or />
+            <TxButton
+              accountId={accountId}
+              label={t('Submit')}
+              tx='democracy.propose'
+              isDisabled={!isValid}
+              params={[
+                ...(method ? [new Proposal(method)] : []),
+                ...(hasValue ? [value] : [])
+              ]}
+              onClick={onClose}
+            />
+          </Button.Group>
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+
+  private renderContent () {
+    const { api, apiDefaultTx, t } = this.props;
+    const { value } = this.state;
+    const hasValue = !!value && value.gtn(0);
+
+    const defaultExtrinsic = (() => {
+      try {
+        return api.tx.consensus.setCode;
+      } catch (error) {
+        return apiDefaultTx;
+      }
+    })();
+
+    return (
+      <>
+        <Modal.Header>
+          {t('Bonding Preferences')}
+        </Modal.Header>
+        <Modal.Content className='ui--signer-Signer-Content'>
+          <InputAddress
+            className='medium'
+            label={t('using the following account')}
+            type='account'
+            onChange={this.onChangeAccount}
+          />
+          <Extrinsic
+            defaultValue={defaultExtrinsic}
+            label={t('propose')}
+            onChange={this.onChangeExtrinsic}
+          />
+          <InputBalance
+            className='medium'
+            isError={!hasValue}
+            label={t('value')}
+            onChange={this.onChangeValue}
+          />
+        </Modal.Content>
+      </>
+    );
+  }
+
+  private nextState (newState: State): void {
+    this.setState(
+      (prevState: State): State => {
+        const { accountId = prevState.accountId, method = prevState.method, value = prevState.value } = newState;
+        const isValid = !!method && !!value && value.gt(new BN(0)) && !!accountId && accountId.length > 0;
+
+        return {
+          accountId,
+          method,
+          value,
+          isValid
+        };
+      }
+    );
+  }
+
+  private onChangeAccount = (accountId: string): void => {
+    this.nextState({ accountId } as State);
+  }
+
+  private onChangeExtrinsic = (method: Method): void => {
+    if (!method) {
+      return;
+    }
+
+    this.nextState({ method } as State);
+  }
+
+  private onChangeValue = (value?: BN): void => {
+    this.nextState({ value } as State);
+  }
+}
+
+export default withMulti(
+  Propose,
+  translate,
+  withApi
+);

--- a/packages/app-democracy/src/index.css
+++ b/packages/app-democracy/src/index.css
@@ -55,6 +55,10 @@
   margin-bottom: 0;
 }
 
+.democracy--Proposal-new {
+  float: right;
+}
+
 .democracy--Referendum-results {
   margin-bottom: 1em;
 }

--- a/packages/app-democracy/src/index.tsx
+++ b/packages/app-democracy/src/index.tsx
@@ -7,12 +7,12 @@ import { AppProps, BareProps, I18nProps } from '@polkadot/ui-app/types';
 import './index.css';
 
 import React from 'react';
+import { Route, Switch } from 'react-router';
 import { HelpOverlay,Tabs } from '@polkadot/ui-app';
 
 import basicMd from './md/basic.md';
-import Proposals from './Proposals';
-import Referendums from './Referendums';
-import Summary from './Summary';
+import Overview from './Overview';
+import Propose from './Propose';
 import translate from './translate';
 
 type Props = AppProps & BareProps & I18nProps;
@@ -27,15 +27,22 @@ class App extends React.PureComponent<Props> {
         <header>
           <Tabs
             basePath={basePath}
-            items={[{
-              name: 'overview',
-              text: t('Democracy overview')
-            }]}
+            items={[
+              {
+                name: 'overview',
+                text: t('Democracy overview')
+              },
+              {
+                name: 'propose',
+                text: t('Submit proposal')
+              }
+            ]}
           />
         </header>
-        <Summary />
-        <Referendums />
-        <Proposals />
+        <Switch>
+          <Route path={`${basePath}/propose`} component={Propose} />
+          <Route component={Overview} />
+        </Switch>
       </main>
     );
   }

--- a/packages/app-democracy/src/index.tsx
+++ b/packages/app-democracy/src/index.tsx
@@ -40,7 +40,7 @@ class App extends React.PureComponent<Props> {
           />
         </header>
         <Switch>
-          <Route path={`${basePath}/propose`} component={Propose} />
+          <Route path={`${basePath}/propose`} render={() => <Propose basePath={basePath} />} />
           <Route component={Overview} />
         </Switch>
       </main>


### PR DESCRIPTION
Closes #975

Adds button and modal to submit new proposals from app-democracy instead of going through app-extrinsics.

This also includes the relocated ui-app/Extrinsic I added for #1036 