### PR TITLE
Tooltip component, a react-tooltip wrapper (#938)

### DIFF
--- a/packages/apps/public/index.html
+++ b/packages/apps/public/index.html
@@ -13,5 +13,7 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
+    <div id="tooltips"></div>
   </body>
 </html>
+

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import Icon from './Icon';
 import media from './media';
 import { classes } from './util';
+import Tooltip from './Tooltip';
 
 type Props = BareProps & {
   help?: React.ReactNode,
@@ -18,6 +19,10 @@ type Props = BareProps & {
   label?: React.ReactNode,
   children: React.ReactNode,
   withLabel?: boolean
+};
+
+type State = {
+  tooltipOpen: boolean
 };
 
 const defaultLabel: any = (// node?
@@ -32,28 +37,10 @@ const Wrapper = styled.div`
     padding-right: 0.5rem;
     position: relative;
 
-    .help-hover {
-      background: #222;
-      border-radius: 0.25rem;
-      color: #fff;
-      display: none;
-      padding: 0.5rem 1rem;
-      position: absolute;
-      text-align: left;
-      top: 0.5rem;
-      left: 2.5rem;
-      right: -5rem;
-      z-index: 10;
-      opacity: .9;
-    }
-
     i.icon.help {
       margin: 0 0 0 0.25rem;
       line-height: 1rem;
-    }
-
-    &.with-help:hover .help-hover {
-      display: block;
+      cursor: help;
     }
   }
 
@@ -92,9 +79,42 @@ const Wrapper = styled.div`
   `}
 `;
 
-export default class Labelled extends React.PureComponent<Props> {
+export default class Labelled extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
+    super(props);
+    this.state = {
+      tooltipOpen: false
+    };
+  }
+
+  toggleTooltip () {
+    const { tooltipOpen } = this.state;
+    this.setState({ tooltipOpen: !tooltipOpen });
+  }
+
+  renderLabel () {
+    const { help, label = defaultLabel } = this.props;
+    const { tooltipOpen } = this.state;
+
+    return help
+      ? <label className='with-help' >
+          {label}
+          <Icon
+            name='help circle'
+            data-tip
+            data-for='default-trigger'
+            onMouseOver={() => this.toggleTooltip()}
+            onMouseOut={() => this.toggleTooltip()}
+          />
+          {tooltipOpen && (
+            <Tooltip>
+              {help}
+            </Tooltip>)}
+        </label>
+      : <label>{label}</label>;
+  }
   render () {
-    const { className, children, help, isSmall, isHidden, label = defaultLabel, style, withLabel = true } = this.props;
+    const { className, children, isSmall, isHidden, style, withLabel = true } = this.props;
 
     if (isHidden) {
       return null;
@@ -104,16 +124,12 @@ export default class Labelled extends React.PureComponent<Props> {
       );
     }
 
-    const labelNode = help
-      ? <label className='with-help'>{label}<Icon name='help circle' /><div className='help-hover'>{help}</div></label>
-      : <label>{label}</label>;
-
     return (
       <Wrapper
         className={classes('ui--Labelled', isSmall ? 'label-small' : '', className)}
         style={style}
       >
-        {labelNode}
+        {this.renderLabel()}
         <div className='ui--Labelled-content'>
           {children}
         </div>

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -102,12 +102,12 @@ export default class Labelled extends React.PureComponent<Props, State> {
           <Icon
             name='help circle'
             data-tip
-            data-for='default-trigger'
+            data-for='controlled-trigger'
             onMouseOver={() => this.toggleTooltip()}
             onMouseOut={() => this.toggleTooltip()}
           />
           {tooltipOpen && (
-            <Tooltip>
+            <Tooltip trigger={'controlled-trigger'}>
               {help}
             </Tooltip>)}
         </label>

--- a/packages/ui-app/src/RecentlyOffline.tsx
+++ b/packages/ui-app/src/RecentlyOffline.tsx
@@ -9,7 +9,7 @@ import BN from 'bn.js';
 import React from 'react';
 import { formatNumber } from '@polkadot/util';
 
-import ReactTooltip from 'react-tooltip';
+import Tooltip from './Tooltip';
 
 import translate from './translate';
 
@@ -70,14 +70,11 @@ class RecentlyOffline extends React.PureComponent<Props, State> {
         <div className='detail'>
           {text}
         </div>
-        <ReactTooltip
-          delayShow={250}
-          effect='solid'
-          id={`offline-${accountId}`}
-          place='bottom'
+        <Tooltip
+          trigger={`offline-${accountId}`}
         >
-            {text}
-        </ReactTooltip>
+          {text}
+        </Tooltip>
       </div>
     );
   }

--- a/packages/ui-app/src/Tooltip.tsx
+++ b/packages/ui-app/src/Tooltip.tsx
@@ -1,0 +1,63 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTooltip from 'react-tooltip';
+
+import { BareProps } from './types';
+
+const rootElement = document.getElementById('tooltips');
+
+type Props = BareProps & {
+  trigger?: string,
+  delayShow?: number,
+  place?: 'bottom' | 'top' | 'right' | 'left',
+  effect?: 'solid' | 'float'
+
+};
+
+export default class Tooltip extends React.PureComponent<Props> {
+
+  static defaultProps = {
+    trigger: 'default-trigger',
+    delayShow: 250,
+    effect: 'solid',
+    place: 'bottom',
+    className: 'ui--Tooltip'
+  };
+
+  tooltipContainer: HTMLElement;
+  constructor (props: Props) {
+    super(props);
+    this.tooltipContainer = document.createElement('div');
+  }
+
+  componentDidMount () {
+    if (rootElement !== null) {
+      rootElement.appendChild(this.tooltipContainer);
+    }
+  }
+
+  componentWillUnmount () {
+    if (rootElement !== null) {
+      rootElement.removeChild(this.tooltipContainer);
+    }
+  }
+
+  render () {
+    const { children, trigger, delayShow, effect, place, className } = this.props;
+    return ReactDOM.createPortal(
+      <ReactTooltip
+        id={trigger}
+        delayShow={delayShow}
+        effect={effect}
+        place={place}
+        className={className}
+      >
+        {children}
+      </ReactTooltip>,
+      this.tooltipContainer);
+  }
+}

--- a/packages/ui-app/src/Tooltip.tsx
+++ b/packages/ui-app/src/Tooltip.tsx
@@ -11,17 +11,14 @@ import { BareProps } from './types';
 const rootElement = document.getElementById('tooltips');
 
 type Props = BareProps & {
-  trigger?: string,
+  trigger: string,
   delayShow?: number,
   place?: 'bottom' | 'top' | 'right' | 'left',
   effect?: 'solid' | 'float'
-
 };
 
 export default class Tooltip extends React.PureComponent<Props> {
-
   static defaultProps = {
-    trigger: 'default-trigger',
     delayShow: 250,
     effect: 'solid',
     place: 'bottom',
@@ -29,6 +26,7 @@ export default class Tooltip extends React.PureComponent<Props> {
   };
 
   tooltipContainer: HTMLElement;
+
   constructor (props: Props) {
     super(props);
     this.tooltipContainer = document.createElement('div');

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -410,3 +410,9 @@ header .ui--Button-Group {
 .ui.tiny.progress {
   font-size: .5rem;
 }
+
+.ui--Tooltip {
+  text-align: center;
+  z-index: 1002;
+  max-width: 300px;
+}


### PR DESCRIPTION
Hello! 


I've been trying to solve #938 and came up with a possible solution:

<img width="822" alt="Screenshot 2019-04-27 at 19 31 53" src="https://user-images.githubusercontent.com/40487685/56853066-278f8600-6923-11e9-87c4-753eeaed318b.png">
<img width="763" alt="Screenshot 2019-04-27 at 19 31 46" src="https://user-images.githubusercontent.com/40487685/56853067-278f8600-6923-11e9-91b7-024ff81a97a5.png">
<img width="653" alt="Screenshot 2019-04-27 at 19 31 36" src="https://user-images.githubusercontent.com/40487685/56853068-28281c80-6923-11e9-9b5a-036d24d72786.png">

This component will allow to render a react-tooltip component easily at the body level (as recommended in the react-tooltip documentation) with literally no effort.

I'd like to know what are your thoughts about it 

Thanks!
