### PR TITLE
Old json checksum & imports

### DIFF
--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -114,6 +114,7 @@ class Restore extends React.PureComponent<Props, State> {
       });
     } catch (error) {
       this.setState({
+        address: null,
         isFileValid: false,
         json: null
       });

--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -4,6 +4,7 @@
 
 import { KeyringPair$Json } from '@polkadot/keyring/types';
 import { I18nProps } from '@polkadot/ui-app/types';
+import { ActionStatus } from '@polkadot/ui-app/Status/types';
 import { ComponentProps } from './types';
 
 import React from 'react';
@@ -13,7 +14,6 @@ import { isHex, isObject, u8aToString } from '@polkadot/util';
 import keyring from '@polkadot/ui-keyring';
 
 import translate from './translate';
-import { ActionStatus } from '@polkadot/ui-app/Status/types';
 
 type Props = ComponentProps & I18nProps;
 

--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -18,6 +18,7 @@ import { ActionStatus } from '@polkadot/ui-app/Status/types';
 type Props = ComponentProps & I18nProps;
 
 type State = {
+  address: string | null,
   isFileValid: boolean,
   isPassValid: boolean,
   json: KeyringPair$Json | null,
@@ -26,6 +27,7 @@ type State = {
 
 class Restore extends React.PureComponent<Props, State> {
   state: State = {
+    address: null,
     isFileValid: false,
     isPassValid: false,
     json: null,
@@ -34,7 +36,7 @@ class Restore extends React.PureComponent<Props, State> {
 
   render () {
     const { t } = this.props;
-    const { isFileValid, isPassValid, json } = this.state;
+    const { address, isFileValid, isPassValid } = this.state;
 
     return (
       <div className='accounts--Restore'>
@@ -42,8 +44,8 @@ class Restore extends React.PureComponent<Props, State> {
           <AddressSummary
             className='shrink'
             value={
-              isFileValid && json
-                ? json.address
+              isFileValid && address
+                ? address
                 : null
               }
           />
@@ -97,13 +99,16 @@ class Restore extends React.PureComponent<Props, State> {
   private onChangeFile = (file: Uint8Array): void => {
     try {
       const json = JSON.parse(u8aToString(file));
-      const isFileValid = keyring.decodeAddress(json.address).length === 32 && isHex(json.encoded) && isObject(json.meta) && (
+      const publicKey = keyring.decodeAddress(json.address, true);
+      const address = keyring.encodeAddress(publicKey);
+      const isFileValid = publicKey.length === 32 && isHex(json.encoded) && isObject(json.meta) && (
         Array.isArray(json.encoding.content)
           ? json.encoding.content[0] === 'pkcs8'
           : json.encoding.content === 'pkcs8'
       );
 
       this.setState({
+        address,
         isFileValid,
         json
       });


### PR DESCRIPTION
Summary: old checksum formats doesn't pass the validation. Relax checksum check (via decodeAddress) and re-encode address to be able to retrieve info.

![image](https://user-images.githubusercontent.com/1424473/56961418-0c578d00-6b54-11e9-9aab-9617c3e703d0.png)

@chevdor I would appreciate if you can verify with one of your problematic accounts that it actually _does_ import. (It certainly gets past the first step now)