### PR TITLE
Tweak block staking icon display

### DIFF
--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -8,7 +8,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import BN from 'bn.js';
 import React from 'react';
 import SummarySession from '@polkadot/app-explorer/SummarySession';
-import { AddressMini, SummaryBox, CardSummary } from '@polkadot/ui-app';
+import { CardSummary, IdentityIcon, SummaryBox } from '@polkadot/ui-app';
 import { withCalls, withMulti } from '@polkadot/ui-api';
 
 import translate from '../translate';
@@ -46,11 +46,10 @@ class Summary extends React.PureComponent<Props> {
         <section>
           <CardSummary label={t('last block')}>
             {lastAuthor && (
-              <AddressMini
-                className='summary'
-                isPadded={false}
+              <IdentityIcon
+                className='validator--Account-block-icon'
+                size={24}
                 value={lastAuthor}
-                withAddress={false}
               />
             )}
             {lastBlock}

--- a/packages/app-staking/src/Overview/index.css
+++ b/packages/app-staking/src/Overview/index.css
@@ -27,6 +27,12 @@
   margin-right: 1rem;
 }
 
+.validator--Account-block-icon {
+  margin-right: 0.75rem;
+  margin-top: -0.25rem;
+  vertical-align: middle;
+}
+
 .validator--Account-validating {
   opacity: 0.25 !important;
   padding-top: 0.5em;


### PR DESCRIPTION
- It is slightly off after the AdrressMini changes (no spacing/padding)
- swap to IdentityIcon

Old vs new:

<img width="154" alt="Polkadot:Substrate Portal 2019-05-02 12-21-23" src="https://user-images.githubusercontent.com/1424473/57069469-0341f980-6cd5-11e9-933a-961dfc1e2bd4.png">
<img width="154" alt="Polkadot:Substrate Portal 2019-05-02 12-23-21" src="https://user-images.githubusercontent.com/1424473/57069506-1c4aaa80-6cd5-11e9-95fa-ece2e21d7daf.png">

