### PR TITLE
TxButton should not calc. on disabled

### DIFF
--- a/packages/ui-app/src/TxButton.tsx
+++ b/packages/ui-app/src/TxButton.tsx
@@ -50,8 +50,8 @@ class TxButtonInner extends React.PureComponent<InnerProps> {
     isSending: false
   } as State;
 
-  static getDerivedStateFromProps ({ api, params = [], txqueue = [], tx = '', extrinsic: propsExtrinsic }: InnerProps): State | null {
-    if (!propsExtrinsic && (!tx || tx.length === 0)) {
+  static getDerivedStateFromProps ({ api, isDisabled, params = [], txqueue = [], tx = '', extrinsic: propsExtrinsic }: InnerProps): State | null {
+    if (isDisabled || !propsExtrinsic && (!tx || tx.length === 0)) {
       return null;
     }
 


### PR DESCRIPTION
Makes TxButton more robust, and stops this on the sudo app.

<img width="623" alt="Polkadot:Substrate Portal 2019-05-02 16-11-12" src="https://user-images.githubusercontent.com/1424473/57081449-02b95b00-6cf5-11e9-8d8e-0fa2a56f6da3.png">
