### PR TITLE
Add maximum balance button to app-transfer and app-staking

### DIFF
--- a/packages/app-staking/src/Account/Bond.tsx
+++ b/packages/app-staking/src/Account/Bond.tsx
@@ -76,7 +76,7 @@ class Bond extends React.PureComponent<Props, State> {
 
   render () {
     const { accountId, isOpen, onClose, t } = this.props;
-    const { bondValue, controllerError, controllerId, destination, extrinsic, maxBalance } = this.state;
+    const { bondValue, controllerError, controllerId, extrinsic, maxBalance } = this.state;
     const hasValue = !!bondValue && bondValue.gtn(0) && (!maxBalance || bondValue.lt(maxBalance));
     const canSubmit = hasValue && !controllerError && !!controllerId;
 
@@ -171,13 +171,14 @@ class Bond extends React.PureComponent<Props, State> {
   private nextState (newState: Partial<State>): void {
     this.setState((prevState: State): State => {
       const { api } = this.props;
-      const { bondValue = prevState.bondValue, controllerId = prevState.controllerId, destination = prevState.destination, maxBalance = prevState.maxBalance } = newState;
+      const { bondValue = prevState.bondValue, controllerError = prevState.controllerError, controllerId = prevState.controllerId, destination = prevState.destination, maxBalance = prevState.maxBalance } = newState;
       const extrinsic = (bondValue && controllerId)
         ? api.tx.staking.bond(controllerId, bondValue, destination)
         : null;
 
       return {
         bondValue,
+        controllerError,
         controllerId,
         destination,
         extrinsic,

--- a/packages/app-staking/src/Account/Bond.tsx
+++ b/packages/app-staking/src/Account/Bond.tsx
@@ -187,11 +187,11 @@ class Bond extends React.PureComponent<Props, State> {
   }
 
   private setMaxBalance = () => {
-    const { api, system_accountNonce = ZERO, balances_fees = ZERO_FEES, balances_votingBalance = ZERO_BALANCE } = this.props;
+    const { api, system_accountNonce = ZERO, balances_fees = ZERO_FEES, balances_all = ZERO_BALANCE } = this.props;
     const { controllerId, destination } = this.state;
 
     const { transactionBaseFee, transactionByteFee } = balances_fees;
-    const { freeBalance } = balances_votingBalance;
+    const { freeBalance } = balances_all;
 
     let prevMax = new BN(0);
     let maxBalance = new BN(1);
@@ -245,7 +245,7 @@ export default withMulti(
   withApi,
   withCalls<Props>(
     'derive.balances.fees',
-    ['derive.balances.votingBalance', { paramName: 'accountId' }],
+    ['derive.balances.all', { paramName: 'accountId' }],
     ['query.system.accountNonce', { paramName: 'accountId' }]
   )
 );

--- a/packages/app-staking/src/Account/Bond.tsx
+++ b/packages/app-staking/src/Account/Bond.tsx
@@ -192,8 +192,6 @@ class Bond extends React.PureComponent<Props, State> {
 
     const { transactionBaseFee, transactionByteFee } = balances_fees;
     const { freeBalance } = balances_votingBalance;
-    // api.derive.balances.votingBalance(accountId!, ({ freeBalance: senderBalance }) => {
-      // api.derive.balances.votingBalance(recipientId!, ({ freeBalance: recipientBalance }) => {
 
     let prevMax = new BN(0);
     let maxBalance = new BN(1);
@@ -222,8 +220,6 @@ class Bond extends React.PureComponent<Props, State> {
       extrinsic,
       maxBalance
     });
-      // });
-    // });
   }
 
   private onChangeController = (controllerId: string) => {

--- a/packages/app-staking/src/Account/Bond.tsx
+++ b/packages/app-staking/src/Account/Bond.tsx
@@ -8,7 +8,6 @@ import { CalculateBalanceProps } from '../types';
 
 import BN from 'bn.js';
 import React from 'react';
-import { AccountId } from '@polkadot/types';
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { Button, InputAddress, InputBalance, Modal, TxButton, Dropdown } from '@polkadot/ui-app';
 import { withCalls, withApi, withMulti } from '@polkadot/ui-api';

--- a/packages/app-staking/src/Account/BondExtra.tsx
+++ b/packages/app-staking/src/Account/BondExtra.tsx
@@ -3,30 +3,56 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
+import { CalculateBalanceProps } from '../types';
 
 import BN from 'bn.js';
 import React from 'react';
 import { Button, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
+import { IExtrinsic } from '@polkadot/types/types';
+import { withCalls, withApi, withMulti } from '@polkadot/ui-api';
+import { compactToU8a } from '@polkadot/util';
+import { SIGNATURE_SIZE } from '@polkadot/ui-signer/Checks';
+import { ZERO_BALANCE, ZERO_FEES } from '@polkadot/ui-signer/Checks/constants';
 
 import translate from '../translate';
 
-type Props = I18nProps & {
+type Props = I18nProps & ApiProps & CalculateBalanceProps & {
   accountId: string,
   isOpen: boolean,
   onClose: () => void
 };
 
 type State = {
-  maxAdditional?: BN
+  maxAdditional?: BN,
+  extrinsic: IExtrinsic | null,
+  maxBalance?: BN
 };
 
+const ZERO = new BN(0);
+
 class BondExtra extends React.PureComponent<Props, State> {
-  state: State = {};
+  state: State = {
+    extrinsic: null
+  };
+
+  componentDidUpdate (prevProps: Props, prevState: State) {
+    const { balances_fees } = this.props;
+    const { extrinsic } = this.state;
+
+    const hasLengthChanged = ((extrinsic && extrinsic.encodedLength) || 0) !== ((prevState.extrinsic && prevState.extrinsic.encodedLength) || 0);
+
+    if ((balances_fees !== prevProps.balances_fees) ||
+      hasLengthChanged
+    ) {
+      this.setMaxBalance();
+    }
+  }
 
   render () {
-    const { accountId, isOpen, onClose, t } = this.props;
-    const { maxAdditional } = this.state;
-    const canSubmit = !!maxAdditional && maxAdditional.gtn(0);
+    const { accountId, balances_votingBalance = ZERO_BALANCE, isOpen, onClose, t } = this.props;
+    const { extrinsic, maxAdditional, maxBalance = balances_votingBalance.freeBalance } = this.state;
+    const canSubmit = !!maxAdditional && maxAdditional.gtn(0) && maxAdditional.lte(maxBalance);
 
     if (!isOpen) {
       return null;
@@ -54,8 +80,7 @@ class BondExtra extends React.PureComponent<Props, State> {
               isPrimary
               label={t('Bond')}
               onClick={onClose}
-              params={[maxAdditional]}
-              tx='staking.bondExtra'
+              extrinsic={extrinsic}
             />
           </Button.Group>
         </Modal.Actions>
@@ -65,6 +90,7 @@ class BondExtra extends React.PureComponent<Props, State> {
 
   private renderContent () {
     const { accountId, t } = this.props;
+    const { maxBalance } = this.state;
 
     return (
       <>
@@ -83,16 +109,79 @@ class BondExtra extends React.PureComponent<Props, State> {
             className='medium'
             help={t('The maximum amount to increase the bonded value, this is adjusted using the available free funds on the account.')}
             label={t('max additional value')}
+            maxValue={maxBalance}
             onChange={this.onChangeValue}
+            withMax
           />
         </Modal.Content>
       </>
     );
   }
 
+  private nextState (newState: Partial<State>): void {
+    this.setState((prevState: State): State => {
+      const { api } = this.props;
+      const { maxAdditional = prevState.maxAdditional, maxBalance = prevState.maxBalance } = newState;
+      const extrinsic = (maxAdditional && maxAdditional.gte(ZERO))
+        ? api.tx.staking.bondExtra(maxAdditional)
+        : null;
+
+      return {
+        maxAdditional,
+        extrinsic,
+        maxBalance
+      };
+    });
+  }
+
+  private setMaxBalance = () => {
+    const { api, system_accountNonce = ZERO, balances_fees = ZERO_FEES, balances_votingBalance = ZERO_BALANCE } = this.props;
+    const { maxAdditional } = this.state;
+
+    const { transactionBaseFee, transactionByteFee } = balances_fees;
+    const { freeBalance } = balances_votingBalance;
+
+    let prevMax = new BN(0);
+    let maxBalance = new BN(1);
+    let extrinsic;
+
+    while (!prevMax.eq(maxBalance)) {
+      prevMax = maxBalance;
+
+      extrinsic = (maxAdditional && maxAdditional.gte(ZERO))
+        ? api.tx.staking.bondExtra(maxAdditional)
+        : null;
+
+      const txLength = SIGNATURE_SIZE + compactToU8a(system_accountNonce).length + (
+        extrinsic
+          ? extrinsic.encodedLength
+          : 0
+      );
+
+      const fees = transactionBaseFee
+        .add(transactionByteFee.muln(txLength));
+
+      maxBalance = new BN(freeBalance).sub(fees);
+    }
+
+    this.nextState({
+      extrinsic,
+      maxBalance
+    });
+  }
+
   private onChangeValue = (maxAdditional?: BN) => {
-    this.setState({ maxAdditional });
+    this.nextState({ maxAdditional });
   }
 }
 
-export default translate(BondExtra);
+export default withMulti(
+  BondExtra,
+  translate,
+  withApi,
+  withCalls<Props>(
+    'derive.balances.fees',
+    ['derive.balances.votingBalance', { paramName: 'accountId' }],
+    ['query.system.accountNonce', { paramName: 'accountId' }]
+  )
+);

--- a/packages/app-staking/src/Account/BondExtra.tsx
+++ b/packages/app-staking/src/Account/BondExtra.tsx
@@ -10,10 +10,9 @@ import BN from 'bn.js';
 import React from 'react';
 import { Button, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
 import { Option, StakingLedger } from '@polkadot/types';
-import { IExtrinsic } from '@polkadot/types/types';
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { withCalls, withApi, withMulti } from '@polkadot/ui-api';
-import { compactToU8a } from '@polkadot/util';
-import { SIGNATURE_SIZE } from '@polkadot/ui-signer/Checks';
+import { calcSignatureLength } from '@polkadot/ui-signer/Checks';
 import { ZERO_BALANCE, ZERO_FEES } from '@polkadot/ui-signer/Checks/constants';
 
 import translate from '../translate';
@@ -28,7 +27,7 @@ type Props = I18nProps & ApiProps & CalculateBalanceProps & {
 
 type State = {
   maxAdditional?: BN,
-  extrinsic: IExtrinsic | null,
+  extrinsic: SubmittableExtrinsic | null,
   maxBalance?: BN
 };
 
@@ -160,11 +159,7 @@ class BondExtra extends React.PureComponent<Props, State> {
         ? api.tx.staking.bondExtra(maxAdditional.sub(bonded))
         : null;
 
-      const txLength = SIGNATURE_SIZE + compactToU8a(system_accountNonce).length + (
-        extrinsic
-          ? extrinsic.encodedLength
-          : 0
-      );
+      const txLength = calcSignatureLength(extrinsic, system_accountNonce);
 
       const fees = transactionBaseFee
         .add(transactionByteFee.muln(txLength));

--- a/packages/app-staking/src/Account/Unbond.tsx
+++ b/packages/app-staking/src/Account/Unbond.tsx
@@ -118,7 +118,6 @@ class Unbond extends React.PureComponent<Props, State> {
   }
 
   private setMaxBalance = () => {
-    console.log('setMaxBalance2');
     const { staking_ledger } = this.props;
 
     if (!staking_ledger || staking_ledger.isNone) {

--- a/packages/app-staking/src/Account/Unbond.tsx
+++ b/packages/app-staking/src/Account/Unbond.tsx
@@ -2,25 +2,39 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import BN from 'bn.js';
-import { Button, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
 import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
+
+import BN from 'bn.js';
 import React from 'react';
+import { AccountId, Option, StakingLedger } from '@polkadot/types';
+import { Button, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
+import { withCalls, withApi, withMulti } from '@polkadot/ui-api';
 
 import translate from '../translate';
 
-type Props = I18nProps & {
-  controllerId?: string | null,
+type Props = I18nProps & ApiProps & {
+  controllerId?: AccountId | null,
   isOpen: boolean,
-  onClose: () => void
+  onClose: () => void,
+  staking_ledger?: Option<StakingLedger>
 };
 
 type State = {
+  maxBalance?: BN
   maxUnbond?: BN
 };
 
 class Unbond extends React.PureComponent<Props, State> {
   state: State = {};
+
+  componentDidUpdate (prevProps: Props) {
+    const { staking_ledger } = this.props;
+
+    if (staking_ledger !== prevProps.staking_ledger) {
+      this.setMaxBalance();
+    }
+  }
 
   render () {
     const { controllerId, isOpen, onClose, t } = this.props;
@@ -64,6 +78,7 @@ class Unbond extends React.PureComponent<Props, State> {
 
   private renderContent () {
     const { controllerId, t } = this.props;
+    const { maxBalance } = this.state;
 
     return (
       <>
@@ -75,23 +90,58 @@ class Unbond extends React.PureComponent<Props, State> {
             className='medium'
             defaultValue={controllerId}
             isDisabled
-            label={t('controler account')}
+            label={t('controller account')}
           />
           <InputBalance
             autoFocus
             className='medium'
             help={t('The maximum amount to unbond, this is adjusted using the bonded funds on the account.')}
             label={t('unbond amount')}
+            maxValue={maxBalance}
             onChange={this.onChangeValue}
+            withMax
           />
         </Modal.Content>
       </>
     );
   }
 
+  private nextState (newState: Partial<State>): void {
+    this.setState((prevState: State): State => {
+      const { maxUnbond = prevState.maxUnbond, maxBalance = prevState.maxBalance } = newState;
+
+      return {
+        maxUnbond,
+        maxBalance
+      };
+    });
+  }
+
+  private setMaxBalance = () => {
+    console.log('setMaxBalance2');
+    const { staking_ledger } = this.props;
+
+    if (!staking_ledger || staking_ledger.isNone) {
+      return;
+    }
+
+    const { active: maxBalance } = staking_ledger.unwrap();
+
+    this.nextState({
+      maxBalance
+    });
+  }
+
   private onChangeValue = (maxUnbond?: BN) => {
-    this.setState({ maxUnbond });
+    this.nextState({ maxUnbond });
   }
 }
 
-export default translate(Unbond);
+export default withMulti(
+  Unbond,
+  translate,
+  withApi,
+  withCalls<Props>(
+    ['query.staking.ledger', { paramName: 'controllerId' }]
+  )
+);

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -115,12 +115,13 @@ class Account extends React.PureComponent<Props, State> {
   }
 
   private renderBondExtra () {
-    const { accountId } = this.props;
+    const { accountId, controllerId } = this.props;
     const { isBondExtraOpen } = this.state;
 
     return (
       <BondExtra
         accountId={accountId}
+        controllerId={controllerId}
         isOpen={isBondExtraOpen}
         onClose={this.toggleBondExtra}
       />

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import BN from 'bn.js';
-import { DerivedBalancesMap } from '@polkadot/api-derive/types';
+import { DerivedFees, DerivedBalances, DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { AccountId, BlockNumber } from '@polkadot/types';
 
 export type Nominators = {
@@ -17,6 +17,12 @@ export type ComponentProps = {
   recentlyOffline: RecentlyOfflineMap,
   stashes: Array<string>,
   validators: Array<string>
+};
+
+export type CalculateBalanceProps = {
+  balances_fees?: DerivedFees,
+  balances_votingBalance?: DerivedBalances,
+  system_accountNonce?: BN
 };
 
 export type RecentlyOffline = Array<[AccountId, BlockNumber, BN]>;

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -21,7 +21,7 @@ export type ComponentProps = {
 
 export type CalculateBalanceProps = {
   balances_fees?: DerivedFees,
-  balances_votingBalance?: DerivedBalances,
+  balances_all?: DerivedBalances,
   system_accountNonce?: BN
 };
 

--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -4,26 +4,33 @@
 
 import { I18nProps } from '@polkadot/ui-app/types';
 import { ApiProps } from '@polkadot/ui-api/types';
+import { DerivedFees, DerivedBalances } from '@polkadot/api-derive/types';
 
 import BN from 'bn.js';
 import React from 'react';
 import styled from 'styled-components';
 import { IExtrinsic } from '@polkadot/types/types';
 import { AddressSummary, InputAddress, InputBalance } from '@polkadot/ui-app';
-import { withApi, withMulti } from '@polkadot/ui-api';
+import { withApi, withCalls, withMulti } from '@polkadot/ui-api';
 import keyring from '@polkadot/ui-keyring';
-import Checks from '@polkadot/ui-signer/Checks';
+import Checks, { SIGNATURE_SIZE } from '@polkadot/ui-signer/Checks';
+import { ZERO_FEES } from '@polkadot/ui-signer/Checks/constants';
 
 import Submit from './Submit';
 import translate from './translate';
 
-type Props = I18nProps & ApiProps & {};
+type Props = I18nProps & ApiProps & {
+  balances_fees?: DerivedFees,
+  balances_votingBalance?: DerivedBalances,
+  system_accountNonce?: BN
+};
 
 type State = {
   accountId: string | null,
   amount: BN,
   extrinsic: IExtrinsic | null,
   hasAvailable: boolean,
+  maxBalance?: BN,
   recipientId: string | null
 };
 
@@ -55,12 +62,28 @@ class Transfer extends React.PureComponent<Props, State> {
     amount: ZERO,
     extrinsic: null,
     hasAvailable: true,
+    maxBalance: ZERO,
     recipientId: null
   };
 
+  componentDidUpdate (prevProps: Props, prevState: State) {
+    const { balances_fees } = this.props;
+    const { accountId, extrinsic, recipientId } = this.state;
+
+    const hasLengthChanged = ((extrinsic && extrinsic.encodedLength) || 0) !== ((prevState.extrinsic && prevState.extrinsic.encodedLength) || 0);
+
+    if ((accountId && prevState.accountId !== accountId) ||
+      (recipientId && prevState.recipientId !== recipientId) ||
+      (balances_fees !== prevProps.balances_fees) ||
+      hasLengthChanged
+    ) {
+      this.setMaxBalance();
+    }
+  }
+
   render () {
     const { t } = this.props;
-    const { accountId, extrinsic, recipientId, hasAvailable } = this.state;
+    const { accountId, extrinsic, recipientId, hasAvailable, maxBalance } = this.state;
 
     return (
       <Wrapper>
@@ -84,7 +107,9 @@ class Transfer extends React.PureComponent<Props, State> {
               help={t('Type the amount you want to transfer. Note that you can select the unit on the right e.g sending 1 mili is equivalent to sending 0.001.')}
               isError={!hasAvailable}
               label={t('amount')}
+              maxValue={maxBalance}
               onChange={this.onChangeAmount}
+              withMax
             />
             <Checks
               accountId={accountId}
@@ -128,7 +153,7 @@ class Transfer extends React.PureComponent<Props, State> {
   private nextState (newState: Partial<State>): void {
     this.setState((prevState: State): State => {
       const { api } = this.props;
-      const { accountId = prevState.accountId, amount = prevState.amount, recipientId = prevState.recipientId, hasAvailable = prevState.hasAvailable } = newState;
+      const { accountId = prevState.accountId, amount = prevState.amount, recipientId = prevState.recipientId, hasAvailable = prevState.hasAvailable, maxBalance = prevState.maxBalance } = newState;
       const extrinsic = accountId && recipientId
         ? api.tx.balances.transfer(recipientId, amount)
         : null;
@@ -138,8 +163,54 @@ class Transfer extends React.PureComponent<Props, State> {
         amount,
         extrinsic,
         hasAvailable,
+        maxBalance,
         recipientId
       };
+    });
+  }
+
+  private setMaxBalance = async () => {
+    const { api, balances_fees = ZERO_FEES } = this.props;
+    const { accountId, recipientId } = this.state;
+
+    const accountNonce = await api.query.system.accountNonce(accountId);
+
+    const { transferFee, transactionBaseFee, transactionByteFee, creationFee } = balances_fees;
+
+    api.derive.balances.votingBalance(accountId!, ({ freeBalance: senderBalance }) => {
+      api.derive.balances.votingBalance(recipientId!, ({ freeBalance: recipientBalance }) => {
+
+        let prevMax = new BN(0);
+        let maxBalance = new BN(1);
+        let extrinsic;
+
+        while (!prevMax.eq(maxBalance)) {
+          prevMax = maxBalance;
+
+          extrinsic = accountId && recipientId
+            ? api.tx.balances.transfer(recipientId, prevMax)
+            : null;
+
+          const txLength = SIGNATURE_SIZE + accountNonce.length + (
+            extrinsic
+              ? extrinsic.encodedLength
+              : 0
+          );
+
+          const fees = transactionBaseFee
+            .add(transactionByteFee.muln(txLength))
+            .add(transferFee)
+            .add(senderBalance.isZero() ? creationFee : ZERO)
+            .add(recipientBalance.isZero() ? creationFee : ZERO);
+
+          maxBalance = new BN(senderBalance).sub(fees);
+        }
+
+        this.nextState({
+          extrinsic,
+          maxBalance
+        });
+      });
     });
   }
 
@@ -163,5 +234,8 @@ class Transfer extends React.PureComponent<Props, State> {
 export default withMulti(
   Transfer,
   translate,
-  withApi
+  withApi,
+  withCalls<Props>(
+    'derive.balances.fees'
+  )
 );

--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -181,8 +181,8 @@ class Transfer extends React.PureComponent<Props, State> {
 
       const { transferFee, transactionBaseFee, transactionByteFee, creationFee } = balances_fees;
 
-      void api.derive.balances.votingBalance(accountId, ({ freeBalance: senderBalance }) => {
-        void api.derive.balances.votingBalance(recipientId, ({ freeBalance: recipientBalance }) => {
+      void api.derive.balances.all(accountId, ({ availableBalance: senderBalance }) => {
+        void api.derive.balances.all(recipientId, ({ availableBalance: recipientBalance }) => {
 
           let prevMax = new BN(0);
           let maxBalance = new BN(1);

--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -9,11 +9,11 @@ import { DerivedFees, DerivedBalances } from '@polkadot/api-derive/types';
 import BN from 'bn.js';
 import React from 'react';
 import styled from 'styled-components';
-import { IExtrinsic } from '@polkadot/types/types';
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { AddressSummary, InputAddress, InputBalance } from '@polkadot/ui-app';
 import { withApi, withCalls, withMulti } from '@polkadot/ui-api';
 import keyring from '@polkadot/ui-keyring';
-import Checks, { SIGNATURE_SIZE } from '@polkadot/ui-signer/Checks';
+import Checks, { calcSignatureLength } from '@polkadot/ui-signer/Checks';
 import { ZERO_FEES } from '@polkadot/ui-signer/Checks/constants';
 
 import Submit from './Submit';
@@ -28,7 +28,7 @@ type Props = I18nProps & ApiProps & {
 type State = {
   accountId: string | null,
   amount: BN,
-  extrinsic: IExtrinsic | null,
+  extrinsic: SubmittableExtrinsic | null,
   hasAvailable: boolean,
   maxBalance?: BN,
   recipientId: string | null
@@ -195,11 +195,7 @@ class Transfer extends React.PureComponent<Props, State> {
               ? api.tx.balances.transfer(recipientId, prevMax)
               : null;
 
-            const txLength = SIGNATURE_SIZE + accountNonce.length + (
-              extrinsic
-                ? extrinsic.encodedLength
-                : 0
-            );
+            const txLength = calcSignatureLength(extrinsic, accountNonce);
 
             const fees = transactionBaseFee
               .add(transactionByteFee.muln(txLength))

--- a/packages/ui-app/src/Dropdown.tsx
+++ b/packages/ui-app/src/Dropdown.tsx
@@ -14,6 +14,7 @@ import Labelled from './Labelled';
 
 type Props<Option> = BareProps & {
   defaultValue?: any,
+  dropdownClassName?: string,
   help?: React.ReactNode,
   isButton?: boolean,
   isDisabled?: boolean,
@@ -57,9 +58,10 @@ export default class Dropdown<Option> extends React.PureComponent<Props<Option>>
   }
 
   render () {
-    const { className, defaultValue, help, isButton, isDisabled, isError, isMultiple, label, onSearch, options, placeholder, renderLabel, style, withLabel, value } = this.props;
+    const { className, defaultValue, dropdownClassName, help, isButton, isDisabled, isError, isMultiple, label, onSearch, options, placeholder, renderLabel, style, withLabel, value } = this.props;
     const dropdown = (
       <SUIDropdown
+        className={dropdownClassName}
         button={isButton}
         compact={isButton}
         disabled={isDisabled}
@@ -99,7 +101,7 @@ export default class Dropdown<Option> extends React.PureComponent<Props<Option>>
       );
   }
 
-  private onChange = (event: React.SyntheticEvent<HTMLElement>, { value }: DropdownProps): void => {
+  private onChange = (_: React.SyntheticEvent<HTMLElement>, { value }: DropdownProps): void => {
     const { onChange, transform } = this.props;
 
     onChange && onChange(

--- a/packages/ui-app/src/InputBalance.tsx
+++ b/packages/ui-app/src/InputBalance.tsx
@@ -16,17 +16,19 @@ type Props = BareProps & {
   isDisabled?: boolean,
   isError?: boolean,
   label?: any,
+  maxValue?: BN,
   onChange?: (value?: BN) => void,
   placeholder?: string,
   value?: BN | string,
-  withLabel?: boolean
+  withLabel?: boolean,
+  withMax?: boolean
 };
 
 const DEFAULT_BITLENGTH = BitLengthOption.CHAIN_SPEC as BitLength;
 
 export default class InputBalance extends React.PureComponent<Props> {
   render () {
-    const { autoFocus, className, defaultValue, help, isDisabled, isError, label, onChange, placeholder, style, value, withLabel } = this.props;
+    const { autoFocus, className, defaultValue, help, isDisabled, isError, label, maxValue, onChange, placeholder, style, value, withLabel, withMax } = this.props;
 
     return (
       <InputNumber
@@ -39,11 +41,13 @@ export default class InputBalance extends React.PureComponent<Props> {
         isError={isError}
         isSi
         label={label}
+        maxValue={maxValue}
         onChange={onChange}
         placeholder={placeholder}
         style={style}
         value={value}
         withLabel={withLabel}
+        withMax={withMax}
       />
     );
   }

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -247,6 +247,21 @@ header .ui--Button-Group {
       white-space: nowrap;
     }
   }
+
+  .ui--SiDropdown {
+    width: 6rem;
+    text-align: center;
+  }
+
+  .ui--MaxButton {
+    position: absolute;
+    right: 6.5rem;
+    top: 20%;
+    height: 60%;
+    text-transform: uppercase;
+    padding: 0 0.5rem !important;
+    border-radius: 0.3rem !important;
+  }
 }
 
 .ui--InputFile {

--- a/packages/ui-signer/src/Checks/constants.ts
+++ b/packages/ui-signer/src/Checks/constants.ts
@@ -7,8 +7,11 @@ import { DerivedFees, DerivedBalances } from '@polkadot/api-derive/types';
 import BN from 'bn.js';
 
 export const ZERO_BALANCE = {
+  availableBalance: new BN(0),
+  lockedBalance: new BN(0),
   freeBalance: new BN(0),
   reservedBalance: new BN(0),
+  vestedBalance: new BN(0),
   votingBalance: new BN(0)
 } as DerivedBalances;
 

--- a/packages/ui-signer/src/Checks/index.tsx
+++ b/packages/ui-signer/src/Checks/index.tsx
@@ -37,14 +37,14 @@ type Props = I18nProps & {
   accountId?: string | null,
   extrinsic?: IExtrinsic | null,
   isSendable: boolean,
-  onChange?: (hasAvailble: boolean) => void,
+  onChange?: (hasAvailable: boolean) => void,
   system_accountNonce?: BN
 };
 
 const LENGTH_PUBLICKEY = 32 + 1; // publicKey + prefix
 const LENGTH_SIGNATURE = 64;
 const LENGTH_ERA = 1;
-const SIGNATURE_SIZE = LENGTH_PUBLICKEY + LENGTH_SIGNATURE + LENGTH_ERA;
+export const SIGNATURE_SIZE = LENGTH_PUBLICKEY + LENGTH_SIGNATURE + LENGTH_ERA;
 
 export class FeeDisplay extends React.PureComponent<Props, State> {
   state: State = {
@@ -110,7 +110,7 @@ export class FeeDisplay extends React.PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate () {
+  componentDidUpdate (_: Props, prevState: State) {
     const { onChange } = this.props;
     const { hasAvailable } = this.state;
 

--- a/packages/ui-signer/src/Checks/index.tsx
+++ b/packages/ui-signer/src/Checks/index.tsx
@@ -46,6 +46,12 @@ const LENGTH_SIGNATURE = 64;
 const LENGTH_ERA = 1;
 export const SIGNATURE_SIZE = LENGTH_PUBLICKEY + LENGTH_SIGNATURE + LENGTH_ERA;
 
+export const calcSignatureLength = (extrinsic?: IExtrinsic | null, accountNonce?: BN): number => {
+  return SIGNATURE_SIZE +
+    (accountNonce ? compactToU8a(accountNonce).length : 0) +
+    (extrinsic ? extrinsic.encodedLength : 0);
+};
+
 export class FeeDisplay extends React.PureComponent<Props, State> {
   state: State = {
     allFees: new BN(0),
@@ -68,11 +74,8 @@ export class FeeDisplay extends React.PureComponent<Props, State> {
     const fn = Method.findFunction(extrinsic.callIndex);
     const extMethod = fn.method;
     const extSection = fn.section;
-    const txLength = SIGNATURE_SIZE + compactToU8a(system_accountNonce).length + (
-      extrinsic
-        ? extrinsic.encodedLength
-        : 0
-    );
+    const txLength = calcSignatureLength(extrinsic, system_accountNonce);
+
     const isSameExtrinsic = prevState.extMethod === extMethod && prevState.extSection === extSection;
     const extraAmount = isSameExtrinsic
       ? prevState.extraAmount
@@ -110,7 +113,7 @@ export class FeeDisplay extends React.PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate (_: Props, prevState: State) {
+  componentDidUpdate () {
     const { onChange } = this.props;
     const { hasAvailable } = this.state;
 


### PR DESCRIPTION
Closes #1043 

- Adds MAX button to auto-fill maximum available balance when using Transfer and Staking app
- Adds checks for too-high values to InputNumber if maximum is specified