### PR TITLE
refactor: Relates to #1060. Consistent top padding across apps

### DIFF
--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -38,7 +38,7 @@ const Wrapper = styled.div`
     text-align: center;
 
     ${media.TABLET`
-      margin-bottom: 2.8rem;
+      margin-bottom: 2rem;
    `}
   }
 `;

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -34,11 +34,11 @@ const Wrapper = styled.div`
   min-height: 100vh;
 
   header {
-    margin-bottom: 0.8rem;
+    margin-bottom: 1.4rem;
     text-align: center;
 
     ${media.TABLET`
-      margin-bottom: 1.1rem;
+      margin-bottom: 2.8rem;
    `}
   }
 `;

--- a/packages/ui-app/src/CardSummary.tsx
+++ b/packages/ui-app/src/CardSummary.tsx
@@ -22,8 +22,7 @@ const Card = styled.article`
   flex: 0 1 auto;
   flex-flow: row wrap;
   justify-content: flex-end;
-  min-height: 5.7rem;
-  padding: 0.5rem 1.5rem;
+  padding: 0rem 1.5rem 0.5rem 1.5rem;
 
   > div {
     font-size: 2.1rem;

--- a/packages/ui-app/src/SummaryBox.tsx
+++ b/packages/ui-app/src/SummaryBox.tsx
@@ -17,7 +17,7 @@ const StyledSummary = styled.div`
   display: flex;
   flex-wrap: no-wrap;
   justify-content: space-between;
-  margin-bottom: 2.5em;
+  margin-bottom: 1.4rem;
 
   > section {
 		display: flex;
@@ -47,6 +47,10 @@ const StyledSummary = styled.div`
     .ui--media-small {
       display: none !important;
     }
+  }
+
+  @media(min-width: 768px) {
+    margin-bottom: 2.8rem;
   }
 
   .ui.label {


### PR DESCRIPTION
Removes min-height and padding-top from CardSummary for consistent vertical spacing between the tab menu items and the contents below across different apps, and some responsive tweaks so not too much padding on mobile devices.