### PR TITLE
Add isMulti param for withCall

### DIFF
--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -159,9 +159,10 @@ class Address extends React.PureComponent<Props, State> {
 
   private getNominators () {
     const { staking_stakers } = this.props;
+
     return staking_stakers
-            ? staking_stakers.others.map(({ who, value }): [AccountId, Balance] => [who, value])
-            : [];
+      ? staking_stakers.others.map(({ who, value }): [AccountId, Balance] => [who, value])
+      : [];
   }
 
   private iNominated () {

--- a/packages/ui-api/src/with/types.ts
+++ b/packages/ui-api/src/with/types.ts
@@ -17,6 +17,7 @@ export type Options = {
   at?: Uint8Array | string,
   atProp?: string,
   callOnResult?: OnChangeCb,
+  isMulti?: boolean,
   params?: Array<any>,
   paramName?: string,
   paramValid?: boolean,


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/800

Usage:

```js
withCalls(
  // single param passed in the form of an array
  ['query.balances.freeBalance', { params: [Alice, Bob, Dave], isMulti: true }]
)
```