### PR TITLE
Fix staking account actions layout -md -sm

### DIFF
--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -86,11 +86,13 @@ class Account extends React.PureComponent<Props, State> {
         >
           <div className='staking--Account-expand'>
             {this.renderButtons()}
-            {this.renderControllerId()}
-            {this.renderStashId()}
-            {this.renderSessionId()}
-            {this.renderNominee()}
-            {this.renderNominators()}
+            <div className='staking--Account-links'>
+              {this.renderControllerId()}
+              {this.renderStashId()}
+              {this.renderSessionId()}
+              {this.renderNominee()}
+              {this.renderNominators()}
+            </div>
           </div>
         </AddressSummary>
       </article>

--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -19,16 +19,6 @@
   .ui--AddressMini {
     display: block;
   }
-
-  .ui--AddressSummary {
-    display: flex;
-    justify-content: space-between;
-    padding: 0;
-
-    .ui--AddressSummary-base, .ui--AddressSummary-children {
-      min-width: 0;
-    }
-  }
 }
 
 .ui--Nominators {
@@ -40,6 +30,12 @@
 .staking--Account-expand {
   min-width: 18rem;
   text-align: right;
+}
+
+.staking--Account-links {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
 }
 
 .staking--Account-details {
@@ -117,5 +113,73 @@
 .staking--accounts-info {
   .staking--label {
     margin: 0 2.25rem -0.5rem 0;
+  }
+}
+
+@media (min-width: 1281px) {
+  .ui--AddressSummary {
+    display: flex;
+    justify-content: space-between;
+    padding: 0;
+
+    .ui--AddressSummary-base, .ui--AddressSummary-children {
+      min-width: 0;
+    }
+  }
+}
+
+@media (max-width: 1280px) {
+  .staking--Account {
+    min-width: 31%;
+
+    .ui--AddressMini {
+      display: block;
+    }
+
+    .ui--AddressSummary {
+      display: block;
+
+      .ui--AddressSummary-base, .ui--AddressSummary-children {
+        min-width: 0;
+        display: block;
+      }
+
+      .ui--AddressSummary-base {
+        min-height: 16rem;
+      }
+
+      .ui--AddressSummary-children {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+  }
+
+  .staking--Account-expand {
+    min-width: auto;
+  }
+
+  .staking--Account-links {
+    max-width: 12rem;
+  }
+}
+
+@media (max-width: 1020px) {
+  .staking--Account {
+    min-width: 48%;
+  }
+}
+
+@media (max-width: 860px) {
+  .staking--Account {
+    min-width: 48%;
+  }
+}
+
+@media (max-width: 620px) {
+  .staking--Account {
+    min-width: 100%;
   }
 }


### PR DESCRIPTION
Closes #1089 

Collapse account actions items to columns on lower browser widths (< 1280px)

![Screenshot from 2019-05-06 18-08-28](https://user-images.githubusercontent.com/879755/57238656-3b756f00-702a-11e9-8499-613d82563371.png)
