### PR TITLE
Cleanup status display with address

### DIFF
--- a/packages/ui-app/src/Status/index.tsx
+++ b/packages/ui-app/src/Status/index.tsx
@@ -6,6 +6,7 @@ import { I18nProps } from '../types';
 import { QueueStatus, QueueTx, QueueTx$Status } from './types';
 
 import React from 'react';
+import styled from 'styled-components';
 import { Method } from '@polkadot/types';
 
 import AddressMini from '../AddressMini';
@@ -17,6 +18,75 @@ type Props = I18nProps & {
   stqueue?: Array<QueueStatus>,
   txqueue?: Array<QueueTx>
 };
+
+const Wrapper = styled.div`
+  display: inline-block;
+  position: fixed;
+  right: 0.25rem;
+  top: 0.25rem;
+  width: 20rem;
+  z-index: 1001;
+
+  .item {
+    display: block;
+    text-align: right;
+
+    > .wrapper > .container {
+      align-items: center;
+      background: #00688b;
+      border-radius: $small-corner;
+      color: white;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 0.25rem;
+      padding: 0 0.5rem;
+      text-align: center;
+      opacity: 0.95;
+      vertical-align: middle;
+
+      .desc {
+        flex: 1;
+        padding: 0.5rem 1rem;
+
+        .status {
+          font-weight: 700;
+        }
+      }
+
+      .short {
+        font-size: 2.5rem;
+        padding: 0.5rem;
+
+        i.icon {
+          line-height: 1;
+        }
+      }
+    }
+
+    &.cancelled > .wrapper > .container {
+      background: #cd9b1d
+    }
+
+    &.event > .wrapper > .container {
+      background: teal;
+    }
+
+    &.completed > .wrapper > .container,
+    &.finalized > .wrapper > .container,
+    &.sent > .wrapper > .container,
+    &.success > .wrapper > .container {
+      background: green;
+    }
+
+    &.dropped > .wrapper > .container,
+    &.error > .wrapper > .container,
+    &.invalid > .wrapper > .container,
+    &.usurped > .wrapper > .container {
+      background: red;
+    }
+  }
+`;
 
 class Status extends React.PureComponent<Props> {
   render () {
@@ -31,10 +101,10 @@ class Status extends React.PureComponent<Props> {
     }
 
     return (
-      <div className='ui--Status'>
+      <Wrapper className='ui--Status'>
         {alltx.map(this.renderItem)}
         {allst.map(this.renderStatus)}
-      </div>
+      </Wrapper>
     );
   }
 

--- a/packages/ui-app/src/Tooltip.tsx
+++ b/packages/ui-app/src/Tooltip.tsx
@@ -46,6 +46,7 @@ export default class Tooltip extends React.PureComponent<Props> {
 
   render () {
     const { children, trigger, delayShow, effect, place, className } = this.props;
+
     return ReactDOM.createPortal(
       <ReactTooltip
         id={trigger}
@@ -56,6 +57,7 @@ export default class Tooltip extends React.PureComponent<Props> {
       >
         {children}
       </ReactTooltip>,
-      this.tooltipContainer);
+      this.tooltipContainer
+    );
   }
 }

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -334,87 +334,9 @@ header .ui--Button-Group {
   }
 }
 
-
 .ui--Static {
   overflow: hidden;
   word-break: break-all;
-}
-
-.ui--Status {
-  display: inline-block;
-  position: fixed;
-  right: 0.25rem;
-  top: 0.25rem;
-  width: 20rem;
-  z-index: 1001;
-
-  .ui--IdentityIcon {
-    margin-left: 0 !important;
-  }
-
-  .item {
-    display: block;
-    text-align: right;
-
-    > .wrapper > .container {
-      align-items: center;
-      background: #00688b;
-      border-radius: $small-corner;
-      color: white;
-      cursor: pointer;
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 0.25rem;
-      padding: 0 0.5rem;
-      text-align: center;
-      opacity: 0.95;
-      vertical-align: middle;
-
-      .desc {
-        flex: 1;
-        padding: 0.5rem 1rem;
-
-        .status {
-          font-weight: 700;
-        }
-      }
-
-      .short {
-        font-size: 2.5rem;
-        padding: 0.5rem;
-
-        i.icon {
-          line-height: 1;
-        }
-      }
-    }
-
-    &.cancelled > .wrapper > .container {
-      background: #cd9b1d
-    }
-
-    &.event > .wrapper > .container {
-      background: teal;
-    }
-
-    &.completed > .wrapper > .container,
-    &.finalized > .wrapper > .container,
-    &.sent > .wrapper > .container,
-    &.success > .wrapper > .container {
-      background: green;
-    }
-
-    &.dropped > .wrapper > .container,
-    &.error > .wrapper > .container,
-    &.invalid > .wrapper > .container,
-    &.usurped > .wrapper > .container {
-      background: red;
-    }
-  }
-}
-
-.ui.tiny.progress {
-  font-size: .5rem;
 }
 
 .ui--Tooltip {

--- a/packages/ui-app/src/styles/semantic.css
+++ b/packages/ui-app/src/styles/semantic.css
@@ -129,8 +129,14 @@
   display: flex !important;
 }
 
-.ui.progress .bar {
-  min-width: 0 !important;
+.ui.progress {
+  &.tiny {
+    font-size: .5rem;
+  }
+
+  .bar {
+    min-width: 0 !important;
+  }
 }
 
 .ui.secondary.vertical.menu > .item {


### PR DESCRIPTION
- Move Status to use styled-components
- Fix the following (pre and post)

<img width="289" alt="Polkadot:Substrate Portal 2019-05-07 13-02-30" src="https://user-images.githubusercontent.com/1424473/57294958-8db99d00-70c9-11e9-9143-bb6c6bd8c20c.png">
<img width="288" alt="Polkadot:Substrate Portal 2019-05-07 13-08-33" src="https://user-images.githubusercontent.com/1424473/57294962-914d2400-70c9-11e9-8a2f-967bd56f1d49.png">

(Actual fix here is only removing the 3 lines starting at https://github.com/polkadot-js/apps/pull/1097/files#diff-ac54e2de59aa4a9d39d402ceaa550154L351 - not quite visible since it has been copied to styled, but the copy does not have those 3, otherwise identical)