### PR TITLE
Adjust toolbox layout (.small is problematic)

### DIFF
--- a/packages/app-toolbox/src/Hash.tsx
+++ b/packages/app-toolbox/src/Hash.tsx
@@ -38,24 +38,28 @@ class Hash extends React.PureComponent<Props, State> {
     const { data, isHexData } = this.state;
 
     return (
-      <div className='ui--row'>
-        <Input
-          autoFocus
-          className='large'
-          label={t('from the following data (hex or string)')}
-          onChange={this.onChangeData}
-          value={data}
-        />
-        <Static
-          className='small'
-          label={t('hex input data')}
-          value={
-            isHexData
-              ? t('Yes')
-              : t('No')
-          }
-        />
-      </div>
+      <>
+        <div className='ui--row'>
+          <Input
+            autoFocus
+            className='full'
+            label={t('from the following data (hex or string)')}
+            onChange={this.onChangeData}
+            value={data}
+          />
+        </div>
+        <div className='ui--row'>
+          <Static
+            className='medium'
+            label={t('hex input data')}
+            value={
+              isHexData
+                ? t('Yes')
+                : t('No')
+            }
+          />
+        </div>
+      </>
     );
   }
 

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -101,24 +101,28 @@ class Sign extends React.PureComponent<Props, State> {
     const { data, isHexData } = this.state;
 
     return (
-      <div className='ui--row'>
-        <Input
-          autoFocus
-          className='large'
-          label={t('sign the following data (hex or string)')}
-          onChange={this.onChangeData}
-          value={data}
-        />
-        <Static
-          className='small'
-          label={t('hex input data')}
-          value={
-            isHexData
-              ? t('Yes')
-              : t('No')
-          }
-        />
-      </div>
+      <>
+        <div className='ui--row'>
+          <Input
+            autoFocus
+            className='full'
+            label={t('sign the following data (hex or string)')}
+            onChange={this.onChangeData}
+            value={data}
+          />
+        </div>
+        <div className='ui--row'>
+          <Static
+            className='medium'
+            label={t('hex input data')}
+            value={
+              isHexData
+                ? t('Yes')
+                : t('No')
+            }
+          />
+        </div>
+      </>
     );
   }
 

--- a/packages/app-toolbox/src/Verify.tsx
+++ b/packages/app-toolbox/src/Verify.tsx
@@ -80,24 +80,28 @@ class Verify extends React.PureComponent<Props, State> {
     const { data, isHexData } = this.state;
 
     return (
-      <div className='ui--row'>
-        <Input
-          autoFocus
-          className='large'
-          label={t('using the following data (hex or string)')}
-          onChange={this.onChangeData}
-          value={data}
-        />
-        <Static
-          className='small'
-          label={t('hex input data')}
-          value={
-            isHexData
-              ? t('Yes')
-              : t('No')
-          }
-        />
-      </div>
+      <>
+        <div className='ui--row'>
+          <Input
+            autoFocus
+            className='full'
+            label={t('using the following data (hex or string)')}
+            onChange={this.onChangeData}
+            value={data}
+          />
+        </div>
+        <div className='ui--row'>
+          <Static
+            className='medium'
+            label={t('hex input data')}
+            value={
+              isHexData
+                ? t('Yes')
+                : t('No')
+            }
+          />
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/1004

- Remove .small, replace by .medium & split into rows
- Initially tried to adjust the min-width of the content holder, but then it breaks the text on resize - the label just takes up too much space

<img width="764" alt="Polkadot:Substrate Portal 2019-05-08 12-26-27" src="https://user-images.githubusercontent.com/1424473/57368898-92935500-718c-11e9-8364-51cdd40042ef.png">
