### PR TITLE
Show explorer in light (but hide node info)

### DIFF
--- a/packages/app-explorer/src/index.tsx
+++ b/packages/app-explorer/src/index.tsx
@@ -9,6 +9,7 @@ import './index.css';
 import React from 'react';
 import { Route, Switch } from 'react-router';
 import Tabs, { TabItem } from '@polkadot/ui-app/Tabs';
+import uiSettings from '@polkadot/ui-settings';
 import translate from './translate';
 
 import BlockInfo from './BlockInfo';
@@ -49,12 +50,16 @@ class ExplorerApp extends React.Component<Props, State> {
   render () {
     const { basePath } = this.props;
     const { items } = this.state;
+    const hidden = uiSettings.uiMode === 'full'
+      ? []
+      : ['node'];
 
     return (
       <main className='explorer--App'>
         <header>
           <Tabs
             basePath={basePath}
+            hidden={hidden}
             items={items}
             query={[undefined, 'query']}
           />

--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -25,6 +25,7 @@ import transfer from './transfer';
 const routes: Routes = appSettings.uiMode === 'light'
   ? ([] as Routes).concat(
     dashboard,
+    explorer,
     transfer,
     staking,
     democracy,
@@ -57,8 +58,6 @@ const routes: Routes = appSettings.uiMode === 'light'
   );
 
 export default ({
-  default: appSettings.uiMode === 'light'
-    ? 'transfer'
-    : 'explorer',
+  default: 'explorer',
   routes
 } as Routing);


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/941. Light vs Full -

<img width="947" alt="Polkadot:Substrate Portal 2019-05-10 17-08-06" src="https://user-images.githubusercontent.com/1424473/57537270-396f2100-7346-11e9-91b1-f65531bc5735.png">
<img width="946" alt="Polkadot:Substrate Portal 2019-05-10 17-07-37" src="https://user-images.githubusercontent.com/1424473/57537271-396f2100-7346-11e9-8413-5c4a4e79ee5f.png">
