### PR TITLE
Disable hot-start global controller query (RPC load)

### DIFF
--- a/packages/apps/src/Content/index.tsx
+++ b/packages/apps/src/Content/index.tsx
@@ -99,7 +99,10 @@ export default withMulti(
   withCalls<Props>(
     'derive.accounts.indexes',
     'derive.balances.fees',
-    'derive.staking.controllers',
+    // This is a very ineffective query that
+    //   (a) adds load to the RPC node when activated globally
+    //   (b) is used in additional information (next-up)
+    // 'derive.staking.controllers',
     'query.staking.nominators',
     'query.session.validators'
   )


### PR DESCRIPTION
- Recently have been struggling with the RPC load on the hosted nodes (where they finally run out of resources and bumps everybody)
- This alleviates the problem at the expense of making "next up" queries for staking take longer.
- multi queries for disparate types would help here, however we don't have API support for it as of yet (This specific query however does not benefit from multi, so it, for the time being, will remain ineffective)