### PR TITLE
Don't set isValid on isDisabled (InputNumber)

### DIFF
--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -46,7 +46,7 @@ class InputNumber extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props);
 
-    const { defaultValue, isSi, value } = this.props;
+    const { defaultValue, isDisabled, isSi, value } = this.props;
     let valueBN = new BN(value || 0);
     const si = formatBalance.findSi('-');
 
@@ -55,7 +55,7 @@ class InputNumber extends React.PureComponent<Props, State> {
         ? new BN(defaultValue || valueBN).div(new BN(10).pow(new BN(si.power))).toString()
         : (defaultValue || valueBN).toString(),
       isPreKeyDown: false,
-      isValid: !isUndefined(value),
+      isValid: isDisabled || !isUndefined(value),
       siOptions: formatBalance.getOptions().map(({ power, text, value }) => ({
         value,
         text: power === 0


### PR DESCRIPTION
Lately this is happening - disabled field pops up, but it is marked as invalid. (In this case sending again makes everything all-ok. The `isValid` filed does not get reset for `isDisabled` - so start it off as valid. `isError` can still show errors)

![image](https://user-images.githubusercontent.com/1424473/57614320-37d96f00-7579-11e9-9810-58a293071cf5.png)
