### PR TITLE
Fix signing tool

### DIFF
--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div`
     background-color: #0f0e0e7a;
   }
 
-  .unlock-overlay-warning {
+ .unlock-overlay-warning {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -185,8 +185,6 @@ class Sign extends React.PureComponent<Props, State> {
         };
       }
     );
-
-    console.log('state',this.state);
   }
 
   toggleUnlock = (): void => {

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -35,12 +35,14 @@ const Wrapper = styled.div`
     left:0;
     background-color: #0f0e0e7a;
   }
+
   .unlock-overlay-warning {
     display: flex;
     align-items: center;
     justify-content: center;
     height:100%;
   }
+
   .unlock-overlay-content {
     color:#fff;
     text-align:center;
@@ -79,8 +81,8 @@ class Sign extends React.PureComponent<Props, State> {
       <div className='toolbox--Sign'>
         {this.renderAccount()}
         <Wrapper>
-        {this.renderInput()}
-        {this.renderSignature()}
+          {this.renderInput()}
+          {this.renderSignature()}
           <div className='unlock-overlay' hidden={!isLocked}>
             {this.renderUnlockWarning()}
           </div>
@@ -118,7 +120,7 @@ class Sign extends React.PureComponent<Props, State> {
     return (
       <div className='unlock-overlay-warning'>
         <div className='unlock-overlay-content'>
-          You need to unlock this account to be able to sign data.<br/>
+          {t('You need to unlock this account to be able to sign data.')}<br/>
           <Button.Group>
             <Button
               isPrimary

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -31,6 +31,8 @@ class Sign extends React.PureComponent<Props, State> {
     const pairs = keyring.getPairs();
     const currentPair = pairs[0] || null;
 
+    console.log('currentPair  - constructor',currentPair && currentPair.address());
+
     this.state = {
       currentPair,
       data: '',
@@ -44,6 +46,10 @@ class Sign extends React.PureComponent<Props, State> {
   }
 
   render () {
+    const { currentPair } = this.state;
+
+    console.log('currentPair  - render',currentPair && currentPair.address());
+
     return (
       <div className='toolbox--Sign'>
         {this.renderAccount()}
@@ -63,7 +69,7 @@ class Sign extends React.PureComponent<Props, State> {
       <div className='ui--row'>
         <InputAddress
           className='full'
-          defaultValue={currentPair}
+          defaultValue={currentPair && currentPair.address()}
           help={t('select the account you wish to sign data with')}
           isInput={false}
           label={t('account')}
@@ -197,6 +203,8 @@ class Sign extends React.PureComponent<Props, State> {
 
   onChangeAccount = (accountId: string): void => {
     const currentPair = keyring.getPair(accountId);
+
+    console.log('-------- onChangeAccount:',accountId);
 
     this.nextState({ currentPair } as State);
   }

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -63,13 +63,11 @@ class Sign extends React.PureComponent<Props, State> {
 
   renderAccount () {
     const { t } = this.props;
-    const { currentPair } = this.state;
 
     return (
       <div className='ui--row'>
         <InputAddress
           className='full'
-          defaultValue={currentPair && currentPair.address()}
           help={t('select the account you wish to sign data with')}
           isInput={false}
           label={t('account')}

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -2,16 +2,16 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { I18nProps as Props } from '@polkadot/ui-app/types';
-import { KeyringPair } from '@polkadot/keyring/types';
-
-import React from 'react';
 import { Button , Input, InputAddress, Output, Static } from '@polkadot/ui-app';
+import { I18nProps as Props } from '@polkadot/ui-app/types';
 import keyring from '@polkadot/ui-keyring';
+import { KeyringPair } from '@polkadot/keyring/types';
 import { hexToU8a, isHex, stringToU8a, u8aToHex } from '@polkadot/util';
+import React from 'react';
 
-import Unlock from './Unlock';
+import styled from 'styled-components';
 import translate from './translate';
+import Unlock from './Unlock';
 
 type State = {
   currentPair: KeyringPair | null,
@@ -22,6 +22,35 @@ type State = {
   signature: string
 };
 
+const Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  .unlock-overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top:0;
+    left:0;
+    background-color: #0f0e0e7a;
+  }
+  .unlock-overlay-warning {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height:100%;
+  }
+  .unlock-overlay-content {
+    color:#fff;
+    text-align:center;
+
+    .ui--Button-Group {
+      text-align: center;
+    }
+  }
+`;
+
 class Sign extends React.PureComponent<Props, State> {
   state: State;
 
@@ -30,8 +59,6 @@ class Sign extends React.PureComponent<Props, State> {
 
     const pairs = keyring.getPairs();
     const currentPair = pairs[0] || null;
-
-    console.log('currentPair  - constructor',currentPair && currentPair.address());
 
     this.state = {
       currentPair,
@@ -46,17 +73,19 @@ class Sign extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { currentPair } = this.state;
-
-    console.log('currentPair  - render',currentPair && currentPair.address());
+    const { isLocked } = this.state;
 
     return (
       <div className='toolbox--Sign'>
         {this.renderAccount()}
+        <Wrapper>
         {this.renderInput()}
         {this.renderSignature()}
-        {this.renderUnlock()}
-        {this.renderButtons()}
+          <div className='unlock-overlay' hidden={!isLocked}>
+            {this.renderUnlockWarning()}
+          </div>
+          {this.renderUnlock()}
+        </Wrapper>
       </div>
     );
   }
@@ -78,7 +107,7 @@ class Sign extends React.PureComponent<Props, State> {
     );
   }
 
-  renderButtons () {
+  renderUnlockWarning () {
     const { t } = this.props;
     const { isLocked } = this.state;
 
@@ -87,13 +116,18 @@ class Sign extends React.PureComponent<Props, State> {
     }
 
     return (
-      <Button.Group>
-        <Button
-          isPrimary
-          onClick={this.toggleUnlock}
-          label={t('Unlock account')}
-        />
-      </Button.Group>
+      <div className='unlock-overlay-warning'>
+        <div className='unlock-overlay-content'>
+          You need to unlock this account to be able to sign data.<br/>
+          <Button.Group>
+            <Button
+              isPrimary
+              onClick={this.toggleUnlock}
+              label={t('Unlock account')}
+            />
+          </Button.Group>
+        </div>
+      </div>
     );
   }
 
@@ -201,8 +235,6 @@ class Sign extends React.PureComponent<Props, State> {
 
   onChangeAccount = (accountId: string): void => {
     const currentPair = keyring.getPair(accountId);
-
-    console.log('-------- onChangeAccount:',accountId);
 
     this.nextState({ currentPair } as State);
   }

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -15,7 +15,6 @@ import translate from './translate';
 
 type State = {
   currentPair: KeyringPair | null,
-  defaultValue?: string,
   data: string,
   isHexData: boolean,
   isLocked: boolean,
@@ -34,9 +33,6 @@ class Sign extends React.PureComponent<Props, State> {
 
     this.state = {
       currentPair,
-      defaultValue: currentPair
-        ? currentPair.address()
-        : void 0,
       data: '',
       isHexData: false,
       isLocked: currentPair
@@ -61,15 +57,16 @@ class Sign extends React.PureComponent<Props, State> {
 
   renderAccount () {
     const { t } = this.props;
-    const { defaultValue } = this.state;
+    const { currentPair } = this.state;
 
     return (
       <div className='ui--row'>
         <InputAddress
           className='full'
-          defaultValue={defaultValue}
+          defaultValue={currentPair}
+          help={t('select the account you wish to sign data with')}
           isInput={false}
-          label={t('using my account')}
+          label={t('account')}
           onChange={this.onChangeAccount}
           type='account'
         />
@@ -188,6 +185,8 @@ class Sign extends React.PureComponent<Props, State> {
         };
       }
     );
+
+    console.log('state',this.state);
   }
 
   toggleUnlock = (): void => {


### PR DESCRIPTION
fix https://github.com/polkadot-js/apps/issues/1139
added a help label for account.

Question before I implement it:
Rather than letting users click on the "Unlock" button, I'd fire up directly the unlock modal if a locked account is selected. If it's cancelled, then the unlock button will still be there. I would add a message also to say that the data can't be signed unless the account is unlocked (again it would only be visible if the modal is cancelled). What do you think?