### PR TITLE
Don't display errors on Input with isDisabled

### DIFF
--- a/packages/ui-app/src/Input.tsx
+++ b/packages/ui-app/src/Input.tsx
@@ -119,7 +119,7 @@ export default class Input extends React.PureComponent<Props, State> {
               : undefined
           }
           disabled={isDisabled}
-          error={isError}
+          error={!isDisabled && isError}
           hidden={isHidden}
           id={name}
           iconPosition={

--- a/packages/ui-app/src/InputNumber.tsx
+++ b/packages/ui-app/src/InputNumber.tsx
@@ -52,7 +52,7 @@ class InputNumber extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props);
 
-    const { defaultValue, isDisabled, isSi, value } = this.props;
+    const { defaultValue, isSi, value } = this.props;
     let valueBN = new BN(value || 0);
     const si = formatBalance.findSi('-');
 
@@ -61,7 +61,7 @@ class InputNumber extends React.PureComponent<Props, State> {
         ? new BN(defaultValue || valueBN).div(new BN(10).pow(new BN(si.power))).toString()
         : (defaultValue || valueBN).toString(),
       isPreKeyDown: false,
-      isValid: isDisabled || !isUndefined(value),
+      isValid: !isUndefined(value),
       siOptions: formatBalance.getOptions().map(({ power, text, value }) => ({
         value,
         text: power === 0


### PR DESCRIPTION
This is quite heavy-handed, but we actually don't use the combination anywhere. Additional, it allows us to not have this (check the current master balance here - in red) -

![image](https://user-images.githubusercontent.com/1424473/58176808-63f49e80-7ca3-11e9-89ab-4338f3c1342e.png)
