### PR TITLE
Mark ExtrinsicFailed as error

### DIFF
--- a/packages/ui-app/src/Status/Queue.tsx
+++ b/packages/ui-app/src/Status/Queue.tsx
@@ -139,9 +139,13 @@ export default class Queue extends React.Component<Props, State> {
         return;
       }
 
+      const status = section === 'system' && method === 'ExtrinsicFailed'
+        ? 'error'
+        : 'event';
+
       this.queueAction({
         action: `${section}.${method}`,
-        status: 'event',
+        status,
         message: 'extrinsic event'
       });
     });


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/1183 - doesn't try to solve the world's problems, specifically focusses on `ExtrinsicFailed`