### PR TITLE
Add available balances to transfer modal

### DIFF
--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -7,7 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import styled from 'styled-components';
-import { AddressSummary, Available, Balance, Bonded, Button, CryptoType, Icon, Label, Nonce, Unlocking } from '@polkadot/ui-app';
+import { AddressRow, Available, Balance, Bonded, Button, CryptoType, Icon, Label, Nonce, Unlocking } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
 
 import Backup from './modals/Backup';
@@ -50,14 +50,17 @@ const Wrapper = styled.article`
     padding: 0;
   }
 
-  .ui--AddressSummary-children {
-    flex: 1;
-    display: flex;
+  .account--Account-expand {
     align-items: flex-start;
-    justify-content: flex-end;
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    padding-top: 0.75rem;
   }
 
   .account--Account-balances {
+    min-width: 49%;
+    max-width: 49%;
     display: grid;
     color: #4e4e4e;
     opacity: 1;
@@ -116,26 +119,28 @@ class Account extends React.PureComponent<Props> {
     return (
       <Wrapper className='overview--Account'>
         {this.renderModals()}
-        <AddressSummary
-          value={address}
+        <AddressRow
+          buttons={this.renderButtons()}
           isEditable={isEditable}
+          value={address}
           withBalance={false}
+          withIndex
           withNonce={false}
           withTags
         >
           <div className='account--Account-expand'>
-            {this.renderButtons()}
             <div className='account--Account-balances'>
               {this.renderTotal()}
               {this.renderAvailable()}
               {this.renderBonded()}
               {this.renderUnlocking()}
-              <br/>
+            </div>
+            <div className='account--Account-balances'>
               {this.renderNonce()}
               {this.renderCryptoType()}
             </div>
           </div>
-        </AddressSummary>
+        </AddressRow>
       </Wrapper>
     );
   }
@@ -355,7 +360,7 @@ class Account extends React.PureComponent<Props> {
     const { isEditable } = this.state;
 
     return (
-      <div className='accounts--Account-buttons'>
+      <div className='accounts--Account-buttons buttons'>
         {isEditable && (
           <>
             <Button

--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -118,7 +118,6 @@ class Account extends React.PureComponent<Props> {
         {this.renderModals()}
         <AddressSummary
           value={address}
-          identIconSize={96}
           isEditable={isEditable}
           withBalance={false}
           withNonce={false}

--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -7,7 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import styled from 'styled-components';
-import { AddressSummary, Available, Balance, Bonded, Button, CryptoType, Icon, Nonce, Unlocking } from '@polkadot/ui-app';
+import { AddressSummary, Available, Balance, Bonded, Button, CryptoType, Icon, Label, Nonce, Unlocking } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
 
 import Backup from './modals/Backup';
@@ -59,13 +59,11 @@ const Wrapper = styled.article`
 
   .account--Account-balances {
     display: grid;
-    grid-column-gap: .5em;
     color: #4e4e4e;
     opacity: 1;
 
-    .label {
+    label {
       grid-column:  1;
-      opacity: 0.7;
       text-align: right;
     }
 
@@ -148,7 +146,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('available')}</div>
+        <Label
+          help={t('funds that that can be transfered or bonded')}
+          label={t('available')}
+        />
         <Available
           className='result'
           params={address}
@@ -162,7 +163,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('bonded')}</div>
+        <Label
+          help={t('funds bonded for validating or nominating. They are locked and cannot be transfered')}
+          label={t('bonded')}
+        />
         <Bonded
           className='result'
           params={address}
@@ -176,7 +180,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('crypto type')}</div>
+        <Label
+          help={t('cryptographic curve chosen for this account upon creation')}
+          label={t('crypto type')}
+        />
         <CryptoType
           accountId={address}
           className='result'
@@ -298,7 +305,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('transactions')}</div>
+        <Label
+          help={t('number of transactions made from this account')}
+          label={t('transactions')}
+        />
         <Nonce
           className='result'
           params={address}
@@ -312,7 +322,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('total')}</div>
+        <Label
+          help={t('overall amount of funds (be they vested, available for transfer or locked)')}
+          label={t('total')}
+        />
         <Balance
           className='result'
           params={address}
@@ -326,7 +339,10 @@ class Account extends React.PureComponent<Props> {
 
     return (
       <>
-        <div className='label'>{t('locked')}</div>
+        <Label
+          help={t('the funds that are being unlocked or available for withdrawal')}
+          label={t('locked')}
+        />
         <Unlocking
           className='accounts--Account-balances-unlocking'
           params={address}

--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -49,6 +49,7 @@ const Wrapper = styled.article`
     flex: 1;
     padding: 0;
   }
+
   .ui--AddressSummary-children {
     flex: 1;
     display: flex;
@@ -61,27 +62,16 @@ const Wrapper = styled.article`
     grid-column-gap: .5em;
     color: #4e4e4e;
     opacity: 1;
-  }
 
-  .label-available,
-  .label-balance,
-  .label-bonded,
-  .label-cryptotype,
-  .label-locked,
-  .label-nonce,
-  .label-redeemable {
-    grid-column:  1;
-    text-align: right;
-  }
+    .label {
+      grid-column:  1;
+      opacity: 0.7;
+      text-align: right;
+    }
 
-  .result-available,
-  .result-balance,
-  .result-bonded,
-  .result-cryptotype,
-  .result-locked,
-  .result-nonce,
-  .result-redeemable {
-    grid-column:  2;
+    .result {
+      grid-column:  2;
+    }
   }
 
   .accounts--Account-buttons > button {
@@ -157,11 +147,13 @@ class Account extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <Available
-        className='accounts--Account-balances-available'
-        label={t('available')}
-        params={address}
-      />
+      <>
+        <div className='label'>{t('available')}</div>
+        <Available
+          className='result'
+          params={address}
+        />
+      </>
     );
   }
 
@@ -169,11 +161,13 @@ class Account extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <Bonded
-        className='accounts--Account-balances-bonded'
-        label={t('bonded')}
-        params={address}
-      />
+      <>
+        <div className='label'>{t('bonded')}</div>
+        <Bonded
+          className='result'
+          params={address}
+        />
+      </>
     );
   }
 
@@ -181,11 +175,13 @@ class Account extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <CryptoType
-        accountId={address}
-        className='accounts--Account-details-crypto'
-        label={t('crypto type')}
-      />
+      <>
+        <div className='label'>{t('crypto type')}</div>
+        <CryptoType
+          accountId={address}
+          className='result'
+        />
+      </>
     );
   }
 
@@ -301,11 +297,13 @@ class Account extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <Nonce
-        className='accounts--Account-details-nonce'
-        params={address}
-        label={t('transactions')}
-      />
+      <>
+        <div className='label'>{t('transactions')}</div>
+        <Nonce
+          className='result'
+          params={address}
+        />
+      </>
     );
   }
 
@@ -313,22 +311,27 @@ class Account extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <Balance
-        className='accounts--Account-balances-balance'
-        label={t('total')}
-        params={address}
-      />
+      <>
+        <div className='label'>{t('total')}</div>
+        <Balance
+          className='result'
+          params={address}
+        />
+      </>
     );
   }
 
   private renderUnlocking () {
-    const { address } = this.props;
+    const { address, t } = this.props;
 
     return (
-      <Unlocking
-        className='accounts--Account-balances-unlocking'
-        params={address}
-      />
+      <>
+        <div className='label'>{t('locked')}</div>
+        <Unlocking
+          className='accounts--Account-balances-unlocking'
+          params={address}
+        />
+      </>
     );
   }
 

--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -7,7 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import styled from 'styled-components';
-import { AddressRow, Available, Balance, Bonded, Button, CryptoType, Icon, Label, Nonce, Unlocking } from '@polkadot/ui-app';
+import { AddressInfo, AddressRow, Button, Icon } from '@polkadot/ui-app';
 import keyring from '@polkadot/ui-keyring';
 
 import Backup from './modals/Backup';
@@ -41,38 +41,9 @@ const Wrapper = styled.article`
     margin-bottom: 2em;
   }
 
-  .ui--AddressSummary {
-    justify-content: space-around;
-  }
-
   .ui--AddressSummary-base {
     flex: 1;
     padding: 0;
-  }
-
-  .account--Account-expand {
-    align-items: flex-start;
-    display: flex;
-    flex: 1;
-    justify-content: center;
-    padding-top: 0.75rem;
-  }
-
-  .account--Account-balances {
-    min-width: 49%;
-    max-width: 49%;
-    display: grid;
-    color: #4e4e4e;
-    opacity: 1;
-
-    label {
-      grid-column:  1;
-      text-align: right;
-    }
-
-    .result {
-      grid-column:  2;
-    }
   }
 
   .accounts--Account-buttons > button {
@@ -128,71 +99,13 @@ class Account extends React.PureComponent<Props> {
           withNonce={false}
           withTags
         >
-          <div className='account--Account-expand'>
-            <div className='account--Account-balances'>
-              {this.renderTotal()}
-              {this.renderAvailable()}
-              {this.renderBonded()}
-              {this.renderUnlocking()}
-            </div>
-            <div className='account--Account-balances'>
-              {this.renderNonce()}
-              {this.renderCryptoType()}
-            </div>
-          </div>
+          <AddressInfo
+            withBalance
+            withExtended
+            value={address}
+          />
         </AddressRow>
       </Wrapper>
-    );
-  }
-
-  private renderAvailable () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('funds that that can be transfered or bonded')}
-          label={t('available')}
-        />
-        <Available
-          className='result'
-          params={address}
-        />
-      </>
-    );
-  }
-
-  private renderBonded () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('funds bonded for validating or nominating. They are locked and cannot be transfered')}
-          label={t('bonded')}
-        />
-        <Bonded
-          className='result'
-          params={address}
-        />
-      </>
-    );
-  }
-
-  private renderCryptoType () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('cryptographic curve chosen for this account upon creation')}
-          label={t('crypto type')}
-        />
-        <CryptoType
-          accountId={address}
-          className='result'
-        />
-      </>
     );
   }
 
@@ -302,57 +215,6 @@ class Account extends React.PureComponent<Props> {
       status.status = 'error';
       status.message = error.message;
     }
-  }
-
-  private renderNonce () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('number of transactions made from this account')}
-          label={t('transactions')}
-        />
-        <Nonce
-          className='result'
-          params={address}
-        />
-      </>
-    );
-  }
-
-  private renderTotal () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('overall amount of funds (be they vested, available for transfer or locked)')}
-          label={t('total')}
-        />
-        <Balance
-          className='result'
-          params={address}
-        />
-      </>
-    );
-  }
-
-  private renderUnlocking () {
-    const { address, t } = this.props;
-
-    return (
-      <>
-        <Label
-          help={t('the funds that are being unlocked or available for withdrawal')}
-          label={t('locked')}
-        />
-        <Unlocking
-          className='accounts--Account-balances-unlocking'
-          params={address}
-        />
-      </>
-    );
   }
 
   private renderButtons () {

--- a/packages/app-accounts/src/modals/Backup.tsx
+++ b/packages/app-accounts/src/modals/Backup.tsx
@@ -29,12 +29,15 @@ class Backup extends TxComponent<Props, State> {
   };
 
   render () {
+    const { t } = this.props;
+
     return (
       <Modal
         className='app--accounts-Modal'
         dimmer='inverted'
         open
       >
+        <Modal.Header>{t('Backup account')}</Modal.Header>
         {this.renderContent()}
         {this.renderButtons()}
       </Modal>
@@ -71,31 +74,26 @@ class Backup extends TxComponent<Props, State> {
     const { isPassValid, password } = this.state;
 
     return (
-      <>
-        <Modal.Header>
-          {t('Backup account')}
-        </Modal.Header>
-        <Modal.Content className='app--account-Backup-content'>
-          <AddressRow
-            isInline
-            value={address}
-          >
-            <p>{t('An encrypted backup file will be created once you have pressed the "Download" button. This can be used to re-import your account on any other machine.')}</p>
-            <p>{t('Save this backup file in a secure location. Additionally, the password associated with this account is needed together with this backup file in order to restore your account.')}</p>
-            <div>
-              <Password
-                help={t('The account password as specified when creating the account. This is used to encrypt the backup file and subsequently decrypt it when restoring the account.')}
-                isError={!isPassValid}
-                label={t('password')}
-                onChange={this.onChangePass}
-                onEnter={this.submit}
-                tabIndex={0}
-                value={password}
-              />
-            </div>
-          </AddressRow>
-        </Modal.Content>
-      </>
+      <Modal.Content>
+        <AddressRow
+          isInline
+          value={address}
+        >
+          <p>{t('An encrypted backup file will be created once you have pressed the "Download" button. This can be used to re-import your account on any other machine.')}</p>
+          <p>{t('Save this backup file in a secure location. Additionally, the password associated with this account is needed together with this backup file in order to restore your account.')}</p>
+          <div>
+            <Password
+              help={t('The account password as specified when creating the account. This is used to encrypt the backup file and subsequently decrypt it when restoring the account.')}
+              isError={!isPassValid}
+              label={t('password')}
+              onChange={this.onChangePass}
+              onEnter={this.submit}
+              tabIndex={0}
+              value={password}
+            />
+          </div>
+        </AddressRow>
+      </Modal.Content>
     );
   }
 

--- a/packages/app-accounts/src/modals/ChangePass.tsx
+++ b/packages/app-accounts/src/modals/ChangePass.tsx
@@ -32,12 +32,15 @@ class ChangePass extends TxComponent<Props, State> {
   };
 
   render () {
+    const { t } = this.props;
+
     return (
       <Modal
         className='app--accounts-Modal'
         dimmer='inverted'
         open
       >
+        <Modal.Header>{t('Change account password')}</Modal.Header>
         {this.renderContent()}
         {this.renderButtons()}
       </Modal>
@@ -74,39 +77,34 @@ class ChangePass extends TxComponent<Props, State> {
     const { isNewValid, isOldValid, newPass, oldPass } = this.state;
 
     return (
-      <>
-        <Modal.Header>
-          {t('Change account password')}
-        </Modal.Header>
-        <Modal.Content>
-          <AddressRow
-            isInline
-            value={address}
-          >
-            <p>{t('This will apply to any future use of this account as stored on this browser. Ensure that you securely store this new password and that it is strong and unique to the account.')}</p>
-            <div>
-              <Password
-                autoFocus
-                help={t('The existing account password as specified when this account was created or when it was last changed.')}
-                isError={!isOldValid}
-                label={t('your current password')}
-                onChange={this.onChangeOld}
-                tabIndex={1}
-                value={oldPass}
-              />
-              <Password
-                help={t('The new account password. Once set, all future account unlocks will be performed with this new password.')}
-                isError={!isNewValid}
-                label={t('your new password')}
-                onChange={this.onChangeNew}
-                onEnter={this.submit}
-                tabIndex={2}
-                value={newPass}
-              />
-            </div>
-          </AddressRow>
-        </Modal.Content>
-      </>
+      <Modal.Content>
+        <AddressRow
+          isInline
+          value={address}
+        >
+          <p>{t('This will apply to any future use of this account as stored on this browser. Ensure that you securely store this new password and that it is strong and unique to the account.')}</p>
+          <div>
+            <Password
+              autoFocus
+              help={t('The existing account password as specified when this account was created or when it was last changed.')}
+              isError={!isOldValid}
+              label={t('your current password')}
+              onChange={this.onChangeOld}
+              tabIndex={1}
+              value={oldPass}
+            />
+            <Password
+              help={t('The new account password. Once set, all future account unlocks will be performed with this new password.')}
+              isError={!isNewValid}
+              label={t('your new password')}
+              onChange={this.onChangeNew}
+              onEnter={this.submit}
+              tabIndex={2}
+              value={newPass}
+            />
+          </div>
+        </AddressRow>
+      </Modal.Content>
     );
   }
 

--- a/packages/app-accounts/src/modals/Forgetting.tsx
+++ b/packages/app-accounts/src/modals/Forgetting.tsx
@@ -17,13 +17,15 @@ type Props = I18nProps & {
 
 class Forgetting extends React.PureComponent<Props> {
   render () {
+    const { t } = this.props;
 
     return (
       <Modal
-        className='accounts--Forgetting-Modal'
+        className='app--accounts-Modal'
         dimmer='inverted'
         open
       >
+        <Modal.Header>{t('Confirm account removal')}</Modal.Header>
         {this.renderContent()}
         {this.renderButtons()}
       </Modal>
@@ -56,20 +58,15 @@ class Forgetting extends React.PureComponent<Props> {
     const { address, t } = this.props;
 
     return (
-      <>
-        <Modal.Header>
-          {t('Confirm account removal')}
-        </Modal.Header>
-        <Modal.Content>
-          <AddressRow
-            isInline
-            value={address}
-          >
-            <p>{t('You are about to remove this account from your list of available accounts. Once completed, should you need to access it again, you will have to re-create the account either via seed or via a backup file.')}</p>
-            <p>{t('This operaion does not remove the history of the account from the chain, nor any associated funds from the account. The forget operation only limits your access to the account on this browser.')}</p>
-          </AddressRow>
-        </Modal.Content>
-      </>
+      <Modal.Content>
+        <AddressRow
+          isInline
+          value={address}
+        >
+          <p>{t('You are about to remove this account from your list of available accounts. Once completed, should you need to access it again, you will have to re-create the account either via seed or via a backup file.')}</p>
+          <p>{t('This operaion does not remove the history of the account from the chain, nor any associated funds from the account. The forget operation only limits your access to the account on this browser.')}</p>
+        </AddressRow>
+      </Modal.Content>
     );
   }
 }

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -48,9 +48,8 @@ const Wrapper = styled.div`
     text-align: right;
     padding-right: 1rem;
 
-    .label-available {
+    .label {
       opacity: 0.7;
-      margin-right: 0.75rem;
     }
   }
 
@@ -161,7 +160,7 @@ class Transfer extends React.PureComponent<Props> {
   private renderContent () {
     const { address, t } = this.props;
     const { extrinsic, hasAvailable, maxBalance, recipientId, senderId } = this.state;
-    const available = t('available balance');
+    const available = <span className='label'>{t('available ')}</span>;
 
     return (
       <Modal.Content className='app--account-Backup-content'>

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -56,8 +56,8 @@ const Wrapper = styled.div`
 
   ${media.DESKTOP`
     article.padded {
-      margin: .75rem 15rem;
-      padding: 0;
+      margin: .75rem 0 0.75rem 15rem;
+      padding: 0.25rem 1rem;
     }
   `}
 

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -235,10 +235,7 @@ class Transfer extends React.PureComponent<Props> {
 
     while (!prevMax.eq(maxBalance)) {
       prevMax = maxBalance;
-
-      extrinsic = address && recipientId
-        ? api.tx.balances.transfer(recipientId, prevMax)
-        : null;
+      extrinsic = api.tx.balances.transfer(recipientId, prevMax);
 
       const txLength = calcSignatureLength(extrinsic, accountNonce);
       const fees = transactionBaseFee

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -170,13 +170,13 @@ class Transfer extends React.PureComponent<Props> {
             defaultValue={address}
             help={t('The account you will send funds from.')}
             isDisabled
-            label={t('from')}
+            label={t('send from account')}
             type='account'
           />
           <div className='balance'><Available label={available} params={senderId} /></div>
           <InputAddress
             help={t('Select a contact or paste the address you want to send funds to.')}
-            label={t('to')}
+            label={t('send to address')}
             onChange={this.onChangeTo}
             type='all'
           />

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -163,7 +163,7 @@ class Transfer extends React.PureComponent<Props> {
     const available = <span className='label'>{t('available ')}</span>;
 
     return (
-      <Modal.Content className='app--account-Backup-content'>
+      <Modal.Content>
         <Wrapper>
           <InputAddress
             defaultValue={address}

--- a/packages/app-accounts/src/modals/Transfer.tsx
+++ b/packages/app-accounts/src/modals/Transfer.tsx
@@ -11,7 +11,8 @@ import BN from 'bn.js';
 import React from 'react';
 import styled from 'styled-components';
 import { Index } from '@polkadot/types';
-import { Button, InputAddress, InputBalance, Modal, TxButton } from '@polkadot/ui-app';
+import { Button, InputAddress, InputBalance, Modal, TxButton, media } from '@polkadot/ui-app';
+import { Available } from '@polkadot/ui-reactive';
 import Checks, { calcSignatureLength } from '@polkadot/ui-signer/Checks';
 import { withApi, withCalls, withMulti } from '@polkadot/ui-api';
 import { ZERO_FEES } from '@polkadot/ui-signer/Checks/constants';
@@ -31,7 +32,8 @@ type State = {
   extrinsic: SubmittableExtrinsic | null,
   hasAvailable: boolean,
   maxBalance?: BN,
-  recipientId: string | null
+  recipientId: string | null,
+  senderId: string
 };
 
 const ZERO = new BN(0);
@@ -39,37 +41,55 @@ const ZERO = new BN(0);
 const Wrapper = styled.div`
   article.padded {
     box-shadow: none;
-    margin: .75rem 15rem;
-    padding: 0;
   }
+
+  .balance {
+    margin-bottom: 0.5rem;
+    text-align: right;
+    padding-right: 1rem;
+
+    .label-available {
+      opacity: 0.7;
+      margin-right: 0.75rem;
+    }
+  }
+
+  ${media.DESKTOP`
+    article.padded {
+      margin: .75rem 15rem;
+      padding: 0;
+    }
+  `}
 
   label.with-help {
     flex-basis: 10rem;
   }
-
-  .ui--Labelled-content {
-    flex: initial;
-    width: 40em;
-  }
 `;
 
 class Transfer extends React.PureComponent<Props> {
-  state: State = {
-    amount: ZERO,
-    extrinsic: null,
-    hasAvailable: true,
-    maxBalance: ZERO,
-    recipientId: null
-  };
+  state: State;
+
+  constructor (props: Props) {
+    super(props);
+
+    this.state = {
+      amount: ZERO,
+      extrinsic: null,
+      hasAvailable: true,
+      maxBalance: ZERO,
+      recipientId: null,
+      senderId: props.address
+    };
+  }
 
   componentDidUpdate (prevProps: Props, prevState: State) {
     const { balances_fees } = this.props;
-    const { extrinsic, recipientId } = this.state;
+    const { extrinsic, recipientId, senderId } = this.state;
 
     const hasLengthChanged = ((extrinsic && extrinsic.encodedLength) || 0) !== ((prevState.extrinsic && prevState.extrinsic.encodedLength) || 0);
 
     if ((recipientId && prevState.recipientId !== recipientId) ||
-      (balances_fees !== prevProps.balances_fees) ||
+      (balances_fees !== prevProps.balances_fees) || (prevState.senderId !== senderId) ||
       hasLengthChanged
     ) {
       this.setMaxBalance().catch(console.error);
@@ -77,12 +97,15 @@ class Transfer extends React.PureComponent<Props> {
   }
 
   render () {
+    const { t } = this.props;
+
     return (
       <Modal
         className='app--accounts-Modal'
         dimmer='inverted'
         open
       >
+        <Modal.Header>{t('Send funds')}</Modal.Header>
         {this.renderContent()}
         {this.renderButtons()}
       </Modal>
@@ -92,7 +115,7 @@ class Transfer extends React.PureComponent<Props> {
   private nextState (newState: Partial<State>): void {
     this.setState((prevState: State): State => {
       const { api } = this.props;
-      const { amount = prevState.amount, recipientId = prevState.recipientId, hasAvailable = prevState.hasAvailable, maxBalance = prevState.maxBalance } = newState;
+      const { amount = prevState.amount, recipientId = prevState.recipientId, hasAvailable = prevState.hasAvailable, maxBalance = prevState.maxBalance, senderId = prevState.senderId } = newState;
       const extrinsic = recipientId
         ? api.tx.balances.transfer(recipientId, amount)
         : null;
@@ -102,7 +125,8 @@ class Transfer extends React.PureComponent<Props> {
         extrinsic,
         hasAvailable,
         maxBalance,
-        recipientId
+        recipientId,
+        senderId
       };
     });
   }
@@ -136,46 +160,43 @@ class Transfer extends React.PureComponent<Props> {
 
   private renderContent () {
     const { address, t } = this.props;
-    const { extrinsic, hasAvailable, maxBalance } = this.state;
+    const { extrinsic, hasAvailable, maxBalance, recipientId, senderId } = this.state;
+    const available = t('available balance');
 
     return (
-      <>
-        <Modal.Header>
-          {t('Send funds')}
-        </Modal.Header>
-        <Modal.Content className='app--account-Backup-content'>
-          <Wrapper className='account--Transfer-data'>
-            <InputAddress
-              defaultValue={address}
-              help={t('The account you will send funds from.')}
-              isDisabled
-              label={t('from')}
-              type='account'
-            />
-            <InputAddress
-              defaultValue={'5xxxxxxxxxxxxxxx'}
-              help={t('Select a contact or paste the address you want to send funds to.')}
-              label={t('to')}
-              onChange={this.onChangeTo}
-              type='all'
-            />
-            <InputBalance
-              help={t('Type the amount you want to transfer. Note that you can select the unit on the right e.g sending 1 mili is equivalent to sending 0.001.')}
-              isError={!hasAvailable}
-              label={t('amount')}
-              maxValue={maxBalance}
-              onChange={this.onChangeAmount}
-              withMax
-            />
-            <Checks
-              accountId={address}
-              extrinsic={extrinsic}
-              isSendable
-              onChange={this.onChangeFees}
-            />
-          </Wrapper>
-        </Modal.Content>
-      </>
+      <Modal.Content className='app--account-Backup-content'>
+        <Wrapper>
+          <InputAddress
+            defaultValue={address}
+            help={t('The account you will send funds from.')}
+            isDisabled
+            label={t('from')}
+            type='account'
+          />
+          <div className='balance'><Available label={available} params={senderId} /></div>
+          <InputAddress
+            help={t('Select a contact or paste the address you want to send funds to.')}
+            label={t('to')}
+            onChange={this.onChangeTo}
+            type='all'
+          />
+          <div className='balance'><Available label={available} params={recipientId} /></div>
+          <InputBalance
+            help={t('Type the amount you want to transfer. Note that you can select the unit on the right e.g sending 1 mili is equivalent to sending 0.001.')}
+            isError={!hasAvailable}
+            label={t('amount')}
+            maxValue={maxBalance}
+            onChange={this.onChangeAmount}
+            withMax
+          />
+          <Checks
+            accountId={address}
+            extrinsic={extrinsic}
+            isSendable
+            onChange={this.onChangeFees}
+          />
+        </Wrapper>
+      </Modal.Content>
     );
   }
 

--- a/packages/app-extrinsics/src/Selection.tsx
+++ b/packages/app-extrinsics/src/Selection.tsx
@@ -81,6 +81,7 @@ class Selection extends TxComponent<Props, State> {
         <br></br>
         <Button.Group>
           <TxButton
+            isBasic
             isDisabled={!isValidUnsigned}
             isUnsigned
             label={t('Submit Inherent')}

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -10,7 +10,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import { KeyringSectionOption } from '@polkadot/ui-keyring/options/types';
 
 import React from 'react';
-import { AddressMini, AddressSummary, Button, TxButton } from '@polkadot/ui-app';
+import { AddressMini, AddressRow, Button, TxButton } from '@polkadot/ui-app';
 import { withCalls } from '@polkadot/ui-api';
 
 import Bond from './Bond';
@@ -114,7 +114,8 @@ class Account extends React.PureComponent<Props, State> {
         {this.renderSessionKey()}
         {this.renderUnbond()}
         {this.renderValidating()}
-        <AddressSummary
+        <AddressRow
+          buttons={this.renderButtons()}
           value={accountId}
           withAvailable
           withBonded
@@ -123,7 +124,6 @@ class Account extends React.PureComponent<Props, State> {
           withUnlocking
         >
           <div className='staking--Account-expand'>
-            {this.renderButtons()}
             <div className='staking--Account-links'>
               {this.renderControllerId()}
               {this.renderStashId()}
@@ -131,7 +131,7 @@ class Account extends React.PureComponent<Props, State> {
               {this.renderNominee()}
             </div>
           </div>
-        </AddressSummary>
+        </AddressRow>
       </article>
     );
   }

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -116,7 +116,6 @@ class Account extends React.PureComponent<Props, State> {
         {this.renderValidating()}
         <AddressSummary
           value={accountId}
-          identIconSize={96}
           withAvailable
           withBonded
           withIndex={false}

--- a/packages/app-staking/src/Account/index.tsx
+++ b/packages/app-staking/src/Account/index.tsx
@@ -10,7 +10,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import { KeyringSectionOption } from '@polkadot/ui-keyring/options/types';
 
 import React from 'react';
-import { AddressMini, AddressRow, Button, TxButton } from '@polkadot/ui-app';
+import { AddressInfo, AddressMini, AddressRow, Button, TxButton } from '@polkadot/ui-app';
 import { withCalls } from '@polkadot/ui-api';
 
 import Bond from './Bond';
@@ -117,20 +117,24 @@ class Account extends React.PureComponent<Props, State> {
         <AddressRow
           buttons={this.renderButtons()}
           value={accountId}
-          withAvailable
-          withBonded
+          withAvailable={false}
+          withBalance={false}
+          withBonded={false}
           withIndex={false}
           withNonce={false}
-          withUnlocking
+          withUnlocking={false}
         >
-          <div className='staking--Account-expand'>
+          <AddressInfo
+            withBalance
+            value={accountId}
+          >
             <div className='staking--Account-links'>
               {this.renderControllerId()}
               {this.renderStashId()}
               {this.renderSessionId()}
               {this.renderNominee()}
             </div>
-          </div>
+          </AddressInfo>
         </AddressRow>
       </article>
     );

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -93,13 +93,13 @@ class Address extends React.PureComponent<Props, State> {
       <article key={stashId || controllerId}>
         <AddressRow
           bonded={bonded}
+          buttons={this.renderKeys()}
           defaultName={defaultName}
           value={stashId}
           withBalance={false}
           withBonded
           withNonce={false}
         >
-          {this.renderKeys()}
           {this.renderNominators()}
           {this.renderOffline()}
         </AddressRow>

--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -98,10 +98,6 @@
   line-height: 1.2rem;
 }
 
-.staking--Account-detail {
-  margin-top: 0.75rem;
-}
-
 .staking--accounts-info {
   text-align: right;
 }

--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -103,9 +103,6 @@
 }
 
 .staking--accounts-info {
-  position: absolute;
-  top: 0.75rem;
-  right: 1rem;
   text-align: right;
 }
 

--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -26,12 +26,12 @@ const routes: Routes = appSettings.uiMode === 'light'
   ? ([] as Routes).concat(
     dashboard,
     explorer,
-    transfer,
     staking,
     democracy,
     null,
     accounts,
     addressbook,
+    transfer,
     null,
     settings,
     template
@@ -39,12 +39,12 @@ const routes: Routes = appSettings.uiMode === 'light'
   : ([] as Routes).concat(
     dashboard,
     explorer,
-    transfer,
     staking,
     democracy,
     null,
     accounts,
     addressbook,
+    transfer,
     null,
     contracts,
     storage,

--- a/packages/apps-routing/src/transfer.ts
+++ b/packages/apps-routing/src/transfer.ts
@@ -10,7 +10,7 @@ export default ([
   {
     Component: Transfer,
     display: {
-      isHidden: true,
+      isHidden: false,
       needsAccounts: true,
       needsApi: [
         'tx.balances.transfer'

--- a/packages/apps-routing/src/transfer.ts
+++ b/packages/apps-routing/src/transfer.ts
@@ -10,6 +10,7 @@ export default ([
   {
     Component: Transfer,
     display: {
+      isHidden: true,
       needsAccounts: true,
       needsApi: [
         'tx.balances.transfer'

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-app": "^0.33.0-beta.82",
-    "@polkadot/ui-assets": "^0.39.1",
+    "@polkadot/ui-assets": "^0.40.0-beta.0",
     "@polkadot/ui-signer": "^0.33.0-beta.82"
   }
 }

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-app": "^0.33.0-beta.82",
-    "@polkadot/ui-assets": "^0.40.0-beta.0",
+    "@polkadot/ui-assets": "^0.40.0-beta.1",
     "@polkadot/ui-signer": "^0.33.0-beta.82"
   }
 }

--- a/packages/ui-api/package.json
+++ b/packages/ui-api/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/api": "^0.80.0-beta.2",
-    "@polkadot/extension-dapp": "^0.1.1-beta.4",
+    "@polkadot/extension-dapp": "^0.1.1-beta.5",
     "rxjs-compat": "^6.4.0"
   }
 }

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-api": "^0.33.0-beta.82",
-    "@polkadot/ui-identicon": "^0.39.1",
-    "@polkadot/ui-keyring": "^0.39.1",
+    "@polkadot/ui-identicon": "^0.40.0-beta.0",
+    "@polkadot/ui-keyring": "^0.40.0-beta.0",
     "@polkadot/ui-reactive": "^0.33.0-beta.82",
-    "@polkadot/ui-settings": "^0.39.1",
+    "@polkadot/ui-settings": "^0.40.0-beta.0",
     "@types/chart.js": "^2.7.45",
     "@types/classnames": "^2.2.7",
     "@types/i18next": "^12.1.0",

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-api": "^0.33.0-beta.82",
-    "@polkadot/ui-identicon": "^0.40.0-beta.0",
-    "@polkadot/ui-keyring": "^0.40.0-beta.0",
+    "@polkadot/ui-identicon": "^0.40.0-beta.1",
+    "@polkadot/ui-keyring": "^0.40.0-beta.1",
     "@polkadot/ui-reactive": "^0.33.0-beta.82",
-    "@polkadot/ui-settings": "^0.40.0-beta.0",
+    "@polkadot/ui-settings": "^0.40.0-beta.1",
     "@types/chart.js": "^2.7.45",
     "@types/classnames": "^2.2.7",
     "@types/i18next": "^12.1.0",

--- a/packages/ui-app/src/AddressInfo.tsx
+++ b/packages/ui-app/src/AddressInfo.tsx
@@ -100,7 +100,7 @@ export default translate(styled(AddressInfo)`
   display: flex;
   flex: 1;
   justify-content: center;
-  padding-top: 0.75rem;
+  padding-top: 1rem;
 
   .column {
     flex: 1;
@@ -109,7 +109,12 @@ export default translate(styled(AddressInfo)`
 
     label {
       grid-column:  1;
+      padding-right: 0.5rem;
       text-align: right;
+
+      .help.circle.icon {
+        display: none;
+      }
     }
 
     .result {

--- a/packages/ui-app/src/AddressInfo.tsx
+++ b/packages/ui-app/src/AddressInfo.tsx
@@ -1,0 +1,119 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { BareProps, I18nProps } from './types';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import translate from './translate';
+import CryptoType from './CryptoType';
+import Available from './Available';
+import Balance from './Balance';
+import Bonded from './Bonded';
+import Label from './Label';
+import Nonce from './Nonce';
+import Unlocking from './Unlocking';
+
+type Props = BareProps & I18nProps & {
+  children?: React.ReactNode,
+  value: string,
+  withBalance?: boolean,
+  withExtended?: boolean
+};
+
+class AddressInfo extends React.PureComponent<Props> {
+  render () {
+    const { children, className, t, value, withBalance = true, withExtended } = this.props;
+
+    return (
+      <div className={className}>
+        {withBalance && (
+          <div className='column'>
+            <Label
+              help={t('overall amount of funds (be they vested, available for transfer or locked)')}
+              label={t('total')}
+            />
+            <Balance
+              className='result'
+              params={value}
+            />
+            <Label
+              help={t('funds that that can be transfered or bonded')}
+              label={t('available')}
+            />
+            <Available
+              className='result'
+              params={value}
+            />
+            <Label
+              help={t('funds bonded for validating or nominating. They are locked and cannot be transfered')}
+              label={t('bonded')}
+            />
+            <Bonded
+              className='result'
+              params={value}
+            />
+            <Label
+              help={t('the funds that are being unlocked or available for withdrawal')}
+              label={t('locked')}
+            />
+            <Unlocking
+              className='accounts--Account-balances-unlocking'
+              params={value}
+            />
+          </div>
+        )}
+        {withExtended && (
+          <div className='column'>
+            <Label
+              help={t('number of transactions made from this account')}
+              label={t('transactions')}
+            />
+            <Nonce
+              className='result'
+              params={value}
+            />
+            <Label
+              help={t('cryptographic curve chosen for this account upon creation')}
+              label={t('crypto type')}
+            />
+            <CryptoType
+              accountId={value}
+              className='result'
+            />
+          </div>
+        )}
+        {children && (
+          <div className='column'>
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default translate(styled(AddressInfo)`
+  align-items: flex-start;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  padding-top: 0.75rem;
+
+  .column {
+    flex: 1;
+    display: grid;
+    opacity: 1;
+
+    label {
+      grid-column:  1;
+      text-align: right;
+    }
+
+    .result {
+      grid-column:  2;
+    }
+  }
+`);

--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -11,7 +11,7 @@ import translate from './translate';
 
 class AddressRow extends AddressSummary {
   render () {
-    const { className, style, identIconSize = 64, isInline, value } = this.props;
+    const { className, style, identIconSize = 64, isInline, value, withIndex = false } = this.props;
 
     return (
       <div
@@ -20,16 +20,21 @@ class AddressRow extends AddressSummary {
       >
         <div className='ui--AddressRow-base'>
           {this.renderIcon('ui--AddressRow-icon', identIconSize)}
+          {this.renderButtons()}
           <div className='ui--AddressRow-details'>
             <div className='ui--AddressSummary-data'>
               {this.renderName()}
               {this.renderAddress()}
+              {this.renderAccountIndex(withIndex)}
             </div>
             <div className='ui--AddressSummary-balances'>
+              {this.renderAvailable()}
               {this.renderBalance()}
               {this.renderBonded()}
               {this.renderNonce()}
+              {this.renderUnlocking()}
             </div>
+            {this.renderTags()}
           </div>
         </div>
         {this.renderChildren()}

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -55,6 +55,7 @@ type State = {
 };
 
 const DEFAULT_ADDR = '5'.padEnd(16, 'x');
+const ICON_SIZE = 64;
 
 class AddressSummary extends React.PureComponent<Props, State> {
   state: State;
@@ -287,7 +288,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderIcon (className: string = 'ui--AddressSummary-icon', size?: number) {
-    const { identIconSize = 96, withIcon = true } = this.props;
+    const { identIconSize = ICON_SIZE, withIcon = true } = this.props;
     const { address } = this.state;
 
     if (!withIcon) {

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -368,7 +368,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
         >
           {
             !tags.length
-              ? (isEditable ? <span>add tags</span> : undefined)
+              ? (isEditable ? <span className='addTags'>add tags</span> : undefined)
               : tags.map((tag) => {
                 return (
                   <Label key={tag} size='tiny' color='grey'>

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -236,7 +236,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
       <BalanceDisplay
         balance={balance}
         className='ui--AddressSummary-balance'
-        label={t('balance ')}
+        label={t('total ')}
         params={address}
       />
     );

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -395,6 +395,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
       <UnlockingDisplay
         className='ui--AddressSummary-available'
         label={t('unlock ')}
+        labelRedeem={t('redeem ')}
         params={address}
       />
     );

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -428,7 +428,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
         whenEdited: Date.now()
       });
 
-      this.toggleNameEditor();
+      this.setState({ isEditingName: false });
     }
   }
 
@@ -444,7 +444,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
         whenEdited: Date.now()
       });
 
-      this.toggleTagsEditor();
+      this.setState({ isEditingTags: false });
     }
   }
 

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -8,10 +8,10 @@ import { I18nProps } from './types';
 import BN from 'bn.js';
 import { Label } from 'semantic-ui-react';
 import React from 'react';
-import BaseIdentityIcon from '@polkadot/ui-identicon';
-import { Button, Input, InputTags } from '@polkadot/ui-app';
-import keyring from '@polkadot/ui-keyring';
 import { withCalls } from '@polkadot/ui-api';
+import { Button, Input, InputTags } from '@polkadot/ui-app';
+import BaseIdentityIcon from '@polkadot/ui-identicon';
+import keyring from '@polkadot/ui-keyring';
 
 import AvailableDisplay from './Available';
 import BalanceDisplay from './Balance';
@@ -384,7 +384,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderUnlocking () {
-    const { withUnlocking } = this.props;
+    const { withUnlocking, t } = this.props;
     const { address } = this.state;
 
     if (!withUnlocking || !address) {
@@ -394,6 +394,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
     return (
       <UnlockingDisplay
         className='ui--AddressSummary-available'
+        label={t('unlock ')}
         params={address}
       />
     );

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -225,7 +225,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderBalance () {
-    const { accounts_idAndIndex = [], balance, t, value, withBalance = true } = this.props;
+    const { balance, t, withBalance = true } = this.props;
     const { address } = this.state;
 
     if (!withBalance || !address) {
@@ -243,7 +243,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderBonded () {
-    const { accounts_idAndIndex = [], bonded, t, value, withBonded } = this.props;
+    const { bonded, t, withBonded } = this.props;
     const { address } = this.state;
 
     if (!withBonded || !address) {

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -27,10 +27,12 @@ export type Props = I18nProps & {
   accounts_idAndIndex?: [AccountId?, AccountIndex?],
   balance?: BN | Array<BN>,
   bonded?: BN | Array<BN>,
+  buttons?: React.ReactNode,
   children?: React.ReactNode,
   defaultName?: string,
   extraInfo?: React.ReactNode,
   identIconSize?: number,
+  isChildrenAbs?: boolean,
   isEditable?: boolean,
   isInline?: boolean,
   isShort?: boolean,
@@ -83,7 +85,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { accounts_idAndIndex = [], className, isInline, style } = this.props;
+    const { accounts_idAndIndex = [], className, isInline, style, withIndex = true } = this.props;
     const [accountId, accountIndex] = accounts_idAndIndex;
     const isValid = accountId || accountIndex;
 
@@ -94,10 +96,11 @@ class AddressSummary extends React.PureComponent<Props, State> {
       >
         <div className='ui--AddressSummary-base'>
           {this.renderIcon()}
+          {this.renderButtons()}
           <div className='ui--AddressSummary-data'>
             {this.renderName()}
             {this.renderAddress()}
-            {this.renderAccountIndex()}
+            {this.renderAccountIndex(withIndex)}
           </div>
           <div className='ui--AddressSummary-balances'>
             {this.renderAvailable()}
@@ -158,6 +161,14 @@ class AddressSummary extends React.PureComponent<Props, State> {
     );
   }
 
+  protected renderButtons () {
+    const { buttons } = this.props;
+
+    return buttons
+      ? <div className='ui--AddressSummary-buttons'>{buttons}</div>
+      : null;
+  }
+
   protected renderName () {
     const { isEditable } = this.props;
     const { isEditingName, name } = this.state;
@@ -210,8 +221,8 @@ class AddressSummary extends React.PureComponent<Props, State> {
     );
   }
 
-  protected renderAccountIndex () {
-    const { accounts_idAndIndex = [], withIndex = true } = this.props;
+  protected renderAccountIndex (withIndex: boolean) {
+    const { accounts_idAndIndex = [] } = this.props;
     const [, accountIndex] = accounts_idAndIndex;
 
     if (!accountIndex || !withIndex) {
@@ -219,9 +230,9 @@ class AddressSummary extends React.PureComponent<Props, State> {
     }
 
     return (
-        <div className='ui--AddressSummary-accountIndex'>
-          {accountIndex.toString()}
-        </div>
+      <div className='ui--AddressSummary-accountIndex'>
+        {accountIndex.toString()}
+      </div>
     );
   }
 
@@ -262,14 +273,14 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderChildren () {
-    const { children } = this.props;
+    const { children, isChildrenAbs } = this.props;
 
     if (!children || (Array.isArray(children) && children.length === 0)) {
       return null;
     }
 
     return (
-      <div className='ui--AddressSummary-children'>
+      <div className={`ui--AddressSummary-children ${isChildrenAbs ? 'abs' : ''}`}>
         {children}
       </div>
     );

--- a/packages/ui-app/src/Available.tsx
+++ b/packages/ui-app/src/Available.tsx
@@ -11,7 +11,7 @@ import { Available } from '@polkadot/ui-reactive';
 import { classes } from './util';
 
 export type Props = BareProps & {
-  label?: string,
+  label?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null
 };
 

--- a/packages/ui-app/src/Button/Button.tsx
+++ b/packages/ui-app/src/Button/Button.tsx
@@ -58,6 +58,7 @@ export default class Button extends React.PureComponent<ButtonProps> {
 
   click = () => {
     const { onClick } = this.props;
+
     if (onClick) {
       onClick();
     }

--- a/packages/ui-app/src/CryptoType.tsx
+++ b/packages/ui-app/src/CryptoType.tsx
@@ -26,10 +26,9 @@ export default class CryptoType extends React.PureComponent<Props> {
       : 'ed25519';
 
     return (
-      <>
-        <span className={classes('ui--CryptoType label-cryptotype', className)}>{label}</span>
-        <span className={classes('ui--CryptoType result-cryptotype', className)}>{type}</span>
-      </>
+      <div className={classes('ui--CryptoType', className)}>
+        {label}{type}
+      </div>
     );
   }
 }

--- a/packages/ui-app/src/Dropdown.tsx
+++ b/packages/ui-app/src/Dropdown.tsx
@@ -82,7 +82,7 @@ export default class Dropdown<Option> extends React.PureComponent<Props<Option>>
         options={options}
         placeholder={placeholder}
         renderLabel={renderLabel}
-        search={!!onSearch || allowAdd}
+        search={onSearch || allowAdd}
         searchInput={searchInput}
         selection
         value={

--- a/packages/ui-app/src/Label.tsx
+++ b/packages/ui-app/src/Label.tsx
@@ -1,0 +1,31 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { BareProps } from './types';
+
+import React from 'react';
+
+import LabelHelp from './LabelHelp';
+
+type Props = BareProps & {
+  help?: React.ReactNode,
+  label?: React.ReactNode,
+  withEllipsis?: boolean
+};
+
+export default class Label extends React.PureComponent<Props> {
+  render () {
+    const { className, help, label, withEllipsis } = this.props;
+
+    return (
+      <label className={className}>
+        {
+          withEllipsis
+            ? <div className='withEllipsis'>{label}</div>
+            : label
+        }{help && <LabelHelp help={help} />}
+      </label>
+    );
+  }
+}

--- a/packages/ui-app/src/LabelHelp.tsx
+++ b/packages/ui-app/src/LabelHelp.tsx
@@ -1,0 +1,65 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { BareProps } from './types';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import Icon from './Icon';
+import { classes } from './util';
+import Tooltip from './Tooltip';
+
+type Props = BareProps & {
+  help: React.ReactNode
+};
+
+type State = {
+  tooltipOpen: boolean
+};
+
+const Wrapper = styled.div`
+  cursor: help;
+  display: inline-block;
+  line-height: 1rem;
+  margin: 0 0 0 0.25rem;
+`;
+
+export default class Labelled extends React.PureComponent<Props, State> {
+  state: State = {
+    tooltipOpen: false
+  };
+
+  render () {
+    const { className, help, style } = this.props;
+    const { tooltipOpen } = this.state;
+
+    return (
+      <Wrapper
+        className={classes('ui--LabelHelp', className)}
+        style={style}
+      >
+        <Icon
+          name='help circle'
+          data-tip
+          data-for='controlled-trigger'
+          onMouseOver={this.toggleTooltip}
+          onMouseOut={this.toggleTooltip}
+        />
+        {tooltipOpen && (
+          <Tooltip
+            text={help}
+            trigger='controlled-trigger'
+          />
+        )}
+      </Wrapper>
+    );
+  }
+
+  private toggleTooltip = () => {
+    this.setState(({ tooltipOpen }) => ({
+      tooltipOpen: !tooltipOpen
+    }));
+  }
+}

--- a/packages/ui-app/src/LabelHelp.tsx
+++ b/packages/ui-app/src/LabelHelp.tsx
@@ -26,7 +26,7 @@ const Wrapper = styled.div`
   margin: 0 0 0 0.25rem;
 `;
 
-export default class Labelled extends React.PureComponent<Props, State> {
+export default class LabelHelp extends React.PureComponent<Props, State> {
   state: State = {
     tooltipOpen: false
   };

--- a/packages/ui-app/src/Labelled.tsx
+++ b/packages/ui-app/src/Labelled.tsx
@@ -7,10 +7,9 @@ import { BareProps } from './types';
 import React from 'react';
 import styled from 'styled-components';
 
-import Icon from './Icon';
+import LabelHelp from './LabelHelp';
 import media from './media';
 import { classes } from './util';
-import Tooltip from './Tooltip';
 
 type Props = BareProps & {
   help?: React.ReactNode,
@@ -20,10 +19,6 @@ type Props = BareProps & {
   children: React.ReactNode,
   withLabel?: boolean,
   withEllipsis?: boolean
-};
-
-type State = {
-  tooltipOpen: boolean
 };
 
 const defaultLabel: any = (// node?
@@ -44,12 +39,6 @@ const Wrapper = styled.div`
     padding-right: 0.5rem;
     position: relative;
     text-align: left;
-
-    i.icon.help {
-      margin: 0 0 0 0.25rem;
-      line-height: 1rem;
-      cursor: help;
-    }
   }
 
   &.label-small {
@@ -87,16 +76,9 @@ const Wrapper = styled.div`
   `}
 `;
 
-export default class Labelled extends React.PureComponent<Props, State> {
-  constructor (props: Props) {
-    super(props);
-    this.state = {
-      tooltipOpen: false
-    };
-  }
-
+export default class Labelled extends React.PureComponent<Props> {
   render () {
-    const { className, children, isSmall, isHidden, style, withLabel = true } = this.props;
+    const { className, children, help, isSmall, isHidden, label = defaultLabel, style, withEllipsis, withLabel = true } = this.props;
 
     if (isHidden) {
       return null;
@@ -111,44 +93,17 @@ export default class Labelled extends React.PureComponent<Props, State> {
         className={classes('ui--Labelled', isSmall ? 'label-small' : '', className)}
         style={style}
       >
-        {this.renderLabel()}
+        <label>
+          {
+            withEllipsis
+              ? <div className='withEllipsis'>{label}</div>
+              : label
+          }{help && <LabelHelp help={help} />}
+        </label>
         <div className='ui--Labelled-content'>
           {children}
         </div>
       </Wrapper>
     );
-  }
-
-  private renderLabel () {
-    const { help, label = defaultLabel, withEllipsis } = this.props;
-    const { tooltipOpen } = this.state;
-    const displayLabel = withEllipsis
-      ? <div className='withEllipsis'>{label}</div>
-      : label;
-
-    return help
-      ? <label className='with-help' >
-          {displayLabel}
-          <Icon
-            name='help circle'
-            data-tip
-            data-for='controlled-trigger'
-            onMouseOver={this.toggleTooltip}
-            onMouseOut={this.toggleTooltip}
-          />
-          {tooltipOpen && (
-            <Tooltip
-              text={help}
-              trigger='controlled-trigger'
-            />
-          )}
-        </label>
-      : <label>{displayLabel}</label>;
-  }
-
-  private toggleTooltip = () => {
-    this.setState(({ tooltipOpen }) => ({
-      tooltipOpen: !tooltipOpen
-    }));
   }
 }

--- a/packages/ui-app/src/TxButton.tsx
+++ b/packages/ui-app/src/TxButton.tsx
@@ -31,6 +31,7 @@ type Props = ApiProps & {
   extrinsic?: IExtrinsic | SubmittableExtrinsic,
   icon?: string,
   iconSize?: Button$Sizes,
+  isBasic?: boolean,
   isDisabled?: boolean,
   isNegative?: boolean,
   isPrimary?: boolean,
@@ -59,7 +60,7 @@ class TxButtonInner extends React.PureComponent<InnerProps> {
   } as State;
 
   render () {
-    const { accountId, className, icon, iconSize , isDisabled, isNegative, isPrimary, isUnsigned, label } = this.props;
+    const { accountId, className, icon, iconSize , isBasic, isDisabled, isNegative, isPrimary, isUnsigned, label } = this.props;
     const { isSending } = this.state;
     const needsAccount = isUnsigned
       ? false
@@ -69,10 +70,11 @@ class TxButtonInner extends React.PureComponent<InnerProps> {
       <Button
         className={className}
         icon={icon}
+        isBasic={isBasic}
         isDisabled={isSending || isDisabled || needsAccount}
         isLoading={isSending}
         isNegative={isNegative}
-        isPrimary={isUndefined(isPrimary) ? !isNegative : isPrimary}
+        isPrimary={isUndefined(isPrimary) ? (!isNegative && !isBasic) : isPrimary}
         label={label}
         onClick={this.send}
         size={iconSize}

--- a/packages/ui-app/src/Unlocking.tsx
+++ b/packages/ui-app/src/Unlocking.tsx
@@ -13,16 +13,18 @@ import { classes } from './util';
 
 export type Props = BareProps & {
   bonded?: BN | Array<BN>,
+  label?: string,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
   withLabel?: boolean
 };
 
 export default class UnlockingDisplay extends React.PureComponent<Props> {
   render () {
-    const { params, className, style } = this.props;
+    const { params, className, label, style } = this.props;
     return (
       <Unlocking
         className={classes('ui--Unlocking', className)}
+        label={label}
         params={params}
         style={style}
       />

--- a/packages/ui-app/src/Unlocking.tsx
+++ b/packages/ui-app/src/Unlocking.tsx
@@ -13,18 +13,20 @@ import { classes } from './util';
 
 export type Props = BareProps & {
   bonded?: BN | Array<BN>,
-  label?: string,
+  label?: React.ReactNode,
+  labelRedeem?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
   withLabel?: boolean
 };
 
 export default class UnlockingDisplay extends React.PureComponent<Props> {
   render () {
-    const { params, className, label, style } = this.props;
+    const { params, className, label, labelRedeem, style } = this.props;
     return (
       <Unlocking
         className={classes('ui--Unlocking', className)}
         label={label}
+        labelRedeem={labelRedeem}
         params={params}
         style={style}
       />

--- a/packages/ui-app/src/index.tsx
+++ b/packages/ui-app/src/index.tsx
@@ -34,6 +34,8 @@ export { default as InputNumber } from './InputNumber';
 export { default as InputRpc } from './InputRpc';
 export { default as InputStorage } from './InputStorage';
 export { default as InputTags } from './InputTags';
+export { default as Label } from './Label';
+export { default as LabelHelp } from './LabelHelp';
 export { default as Labelled } from './Labelled';
 export { default as Menu } from './Menu';
 export { default as Modal } from './Modal';

--- a/packages/ui-app/src/index.tsx
+++ b/packages/ui-app/src/index.tsx
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+export { default as AddressInfo } from './AddressInfo';
 export { default as AddressMini } from './AddressMini';
 export { default as AddressRow } from './AddressRow';
 export { default as AddressSummary } from './AddressSummary';

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -94,11 +94,15 @@ article {
     margin: 0;
     padding: 0;
   }
-  
+
   &:not(:hover) {
     .ui.button {
       background: #eee !important;
       color: #555 !important;
+    }
+
+    .ui.button.circular {
+      visibility: hidden;
     }
   }
 }

--- a/packages/ui-app/src/styles/app.css
+++ b/packages/ui-app/src/styles/app.css
@@ -38,7 +38,7 @@ label {
   font-family: sans-serif;
   font-size: 1rem;
   font-weight: 100;
-  margin: 0.25rem;
+  /* margin: 0.25rem; */
 }
 
 /*
@@ -101,6 +101,7 @@ article {
       color: #555 !important;
     }
 
+    i.help.circle.icon,
     .ui.button.circular {
       visibility: hidden;
     }

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -92,6 +92,7 @@ header .ui--Button-Group {
 }
 
 .ui--AddressSummary {
+  position: relative;
   padding: 0 1em;
   white-space: nowrap
 }
@@ -124,6 +125,26 @@ button.ui.icon.withDrawUnbonded {
   }
 }
 
+.ui--AddressSummary-tags.editable {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  > span {
+    border: 1px #00000052 solid;
+    border-radius: .5em;
+    border-style: dashed;
+    color: grey;
+    font-size: x-small;
+    padding: .1em 0.3em 0.1em 0.3em;
+    margin-top: .2em;
+  }
+
+  > div.label {
+    margin-top:.3em
+  }
+}
+
 .ui--AddressSummary-name.editable > button.ui.icon.editButton,
 .ui--AddressSummary-tags.editable > button.ui.icon.editButton {
   padding: 0em .3em .3em .3em;
@@ -134,26 +155,6 @@ button.ui.icon.withDrawUnbonded {
   position: relative;
   right: -2.3em;
   z-index: 1;
-}
-
-.ui--AddressSummary-tags.editable {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.ui--AddressSummary-tags.editable > span {
-  border: 1px #00000052 solid;
-  border-radius: .5em;
-  border-style: dashed;
-  color: grey;
-  font-size: x-small;
-  padding: .1em 0.3em 0.1em 0.3em;
-  margin-top: .2em;
-}
-
-.ui--AddressSummary-tags.editable > div.label {
-  margin-top:.3em
 }
 
 .ui--AddressSummary-base {
@@ -168,6 +169,8 @@ button.ui.icon.withDrawUnbonded {
 }
 
 .ui--AddressRow {
+  position: relative;
+
   &.inline {
     display: flex;
 
@@ -196,8 +199,18 @@ button.ui.icon.withDrawUnbonded {
   }
 
   .ui--AddressSummary-balances>span {
-      text-align: left;
+    text-align: left;
   }
+
+  .ui--AddressSummary-tags.editable {
+    justify-content: left;
+  }
+}
+
+.ui--AddressSummary-buttons {
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .ui--AddressSummary .rx--updated {
@@ -269,7 +282,7 @@ button.ui.icon.withDrawUnbonded {
 .ui--AddressSummary-accountId,
 .ui--AddressSummary-accountIndex {
   font-family: monospace;
-  font-size: 1.5em;
+  font-size: 1.25em;
   padding: 0;
 }
 

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -228,33 +228,6 @@ button.ui.icon.withDrawUnbonded {
   display: grid;
 }
 
-.label-available,
-.label-balance,
-.label-bonded,
-.label-cryptotype,
-.label-locked,
-.label-nonce,
-.label-redeemable {
-  grid-column:  1;
-  text-align: right;
-  opacity: 0.7;
-}
-
-.result-available,
-.result-balance,
-.result-bonded,
-.result-locked,
-.result-redeemable {
-  grid-column:  2;
-  text-align: left;
-}
-
-.result-nonce,
-.result-cryptotype {
-  text-align: left;
-  opacity: 0.7;
-}
-
 .ui--AddressMini-balances .ui--Bonded.result-bonded,
 .ui--AddressMini-balances .ui--Bonded {
   font-size: .75rem;

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -209,8 +209,8 @@ button.ui.icon.withDrawUnbonded {
 
 .ui--AddressSummary-buttons {
   position: absolute;
-  right: 0;
-  top: 0;
+  right: -0.75rem;
+  top: -0.5rem;
 }
 
 .ui--AddressSummary .rx--updated {

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -131,6 +131,7 @@ button.ui.icon.withDrawUnbonded {
   margin-left: -2em;
   position: relative;
   right: -2.3em;
+  z-index: 1;
 }
 
 .ui--AddressSummary-tags.editable {
@@ -267,11 +268,14 @@ button.ui.icon.withDrawUnbonded {
   white-space: nowrap;
 
   .ui--AddressSummary-name {
-    width: 15rem;
+    box-sizing: border-box;
     margin: 0 auto;
+    padding: 0 1rem;
     overflow: hidden;
     text-overflow: ellipsis;
     text-transform: uppercase;
+    white-space: normal;
+    width: 17rem;
   }
 }
 

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -189,6 +189,10 @@ button.ui.icon.withDrawUnbonded {
       margin: 0;
       text-align: left;
     }
+
+    .ui--AddressSummary-name {
+      padding: 0;
+    }
   }
 
   .ui--AddressSummary-balances>span {

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -112,14 +112,16 @@ button.ui.icon.withDrawUnbonded {
   margin-left: .3em
 }
 
-.overview--Account:hover  button.ui.icon.editButton,
-.overview--Account:hover  button.ui.icon.editButton {
-  visibility: visible;
+.overview--Account:hover {
+  .button.ui.icon.editButton, .addTags {
+    visibility: visible;
+  }
 }
 
-.overview--Account button.ui.icon.editButton,
-.overview--Account button.ui.icon.editButton {
-  visibility: hidden;
+.overview--Account {
+  .button.ui.icon.editButton, .addTags {
+    visibility: hidden;
+  }
 }
 
 .ui--AddressSummary-name.editable > button.ui.icon.editButton,
@@ -141,13 +143,13 @@ button.ui.icon.withDrawUnbonded {
 }
 
 .ui--AddressSummary-tags.editable > span {
-    border: 1px #00000052 solid;
-    border-radius: .5em;
-    border-style: dashed;
-    color: grey;
-    font-size: x-small;
-    padding: .1em 0.3em 0.1em 0.3em;
-    margin-top: .2em;
+  border: 1px #00000052 solid;
+  border-radius: .5em;
+  border-style: dashed;
+  color: grey;
+  font-size: x-small;
+  padding: .1em 0.3em 0.1em 0.3em;
+  margin-top: .2em;
 }
 
 .ui--AddressSummary-tags.editable > div.label {
@@ -260,6 +262,10 @@ button.ui.icon.withDrawUnbonded {
 .ui--AddressSummary-balance.rx--updated,
 .ui--AddressSummary-nonce.rx--updated {
   opacity: 1;
+}
+
+.ui--AddressSummary .ui--AddressSummary-data {
+  margin-top: 0.5rem;
 }
 
 .ui--AddressSummary-data {

--- a/packages/ui-reactive/src/AccountIndex.tsx
+++ b/packages/ui-reactive/src/AccountIndex.tsx
@@ -10,7 +10,7 @@ import { withCalls } from '@polkadot/ui-api';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   params?: string,
   accounts_idAndIndex?: [AccountId?, AccountIndex?]
 };

--- a/packages/ui-reactive/src/Available.tsx
+++ b/packages/ui-reactive/src/Available.tsx
@@ -13,7 +13,7 @@ import { withCalls } from '@polkadot/ui-api';
 type Props = BareProps & CallProps & {
   balances_all?: DerivedBalances,
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null
 };
 

--- a/packages/ui-reactive/src/Available.tsx
+++ b/packages/ui-reactive/src/Available.tsx
@@ -22,18 +22,13 @@ export class AvailableDisplay extends React.PureComponent<Props> {
     const { balances_all, children, className, label = '' } = this.props;
 
     return (
-      <>
-        <span className={`${className} label-available`}>
-        {label}
-        </span>
-        <span className={`${className} result-available`}>
-          {
-            balances_all ?
-            formatBalance(balances_all.availableBalance) :
-            '0'
-          }
-        </span>{children}
-      </>
+      <div className={className}>
+        {label}{
+          balances_all ?
+          formatBalance(balances_all.availableBalance) :
+          '0'
+        }{children}
+      </div>
     );
   }
 }

--- a/packages/ui-reactive/src/Available.tsx
+++ b/packages/ui-reactive/src/Available.tsx
@@ -23,10 +23,10 @@ export class AvailableDisplay extends React.PureComponent<Props> {
 
     return (
       <>
-        <span className={className + ' label-available'}>
+        <span className={`${className} label-available`}>
         {label}
         </span>
-        <span className={className + ' result-available'}>
+        <span className={`${className} result-available`}>
           {
             balances_all ?
             formatBalance(balances_all.availableBalance) :

--- a/packages/ui-reactive/src/Balance.tsx
+++ b/packages/ui-reactive/src/Balance.tsx
@@ -23,17 +23,13 @@ export class BalanceDisplay extends React.PureComponent<Props> {
     const { children, className, label = '', balances_all } = this.props;
 
     return (
-      <>
-        <span className={`${className} label-balance`}>
-        {label}
-        </span>
-        <span className={`${className} result-balance`}>
-          {balances_all
+      <div className={className}>
+        {label}{
+          balances_all
             ? formatBalance(balances_all.freeBalance)
             : '0'
-          }
-        </span>{children}
-      </>
+          }{children}
+      </div>
     );
   }
 }

--- a/packages/ui-reactive/src/Balance.tsx
+++ b/packages/ui-reactive/src/Balance.tsx
@@ -13,7 +13,7 @@ import { formatBalance } from '@polkadot/util';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
   balances_all?: DerivedBalances
 };

--- a/packages/ui-reactive/src/Balance.tsx
+++ b/packages/ui-reactive/src/Balance.tsx
@@ -24,14 +24,10 @@ export class BalanceDisplay extends React.PureComponent<Props> {
 
     return (
       <>
-        <span
-          className={`${className} label-balance`}
-        >
+        <span className={`${className} label-balance`}>
         {label}
         </span>
-        <span
-          className={`${className} result-balance`}
-        >
+        <span className={`${className} result-balance`}>
           {balances_all
             ? formatBalance(balances_all.freeBalance)
             : '0'

--- a/packages/ui-reactive/src/BestFinalized.tsx
+++ b/packages/ui-reactive/src/BestFinalized.tsx
@@ -11,7 +11,7 @@ import { formatNumber } from '@polkadot/util';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   chain_bestNumberFinalized?: BlockNumber
 };
 

--- a/packages/ui-reactive/src/BestNumber.tsx
+++ b/packages/ui-reactive/src/BestNumber.tsx
@@ -11,7 +11,7 @@ import { formatNumber } from '@polkadot/util';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   chain_bestNumber?: BlockNumber
 };
 

--- a/packages/ui-reactive/src/Bonded.tsx
+++ b/packages/ui-reactive/src/Bonded.tsx
@@ -13,7 +13,7 @@ import { formatBalance } from '@polkadot/util';
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
-  label?: string,
+  label?: React.ReactNode,
   staking_ledger?: StakingLedger | null
 };
 

--- a/packages/ui-reactive/src/Bonded.tsx
+++ b/packages/ui-reactive/src/Bonded.tsx
@@ -2,10 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AccountId, AccountIndex, Address, Option, StakingLedger } from '@polkadot/types';
 import { BareProps, CallProps } from '@polkadot/ui-api/types';
 
 import React from 'react';
+import { AccountId, AccountIndex, Address, StakingLedger } from '@polkadot/types';
 
 import { withCalls } from '@polkadot/ui-api';
 import { formatBalance } from '@polkadot/util';
@@ -14,33 +14,21 @@ type Props = BareProps & CallProps & {
   children?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
   label?: string,
-  staking_ledger?: Option<StakingLedger>
+  staking_ledger?: StakingLedger | null
 };
 
 export class BondedDisplay extends React.PureComponent<Props> {
   render () {
     const { children, className, label = '', staking_ledger } = this.props;
 
-    if (!staking_ledger || staking_ledger.isNone) {
-      return null;
-    }
-
-    const { active: bonded } = staking_ledger.unwrap();
-
     return (
-      <>
-        <span className={className + ' label-bonded'}>
-          {label}
-        </span>
-        <span className={className + ' result-bonded'}>
-          {
-            bonded
-              ? formatBalance(bonded)
-              : '0'
-          }
-        </span>
-        {children}
-      </>
+      <div className={className}>
+        {label}{
+          staking_ledger
+            ? formatBalance(staking_ledger.active)
+            : '0'
+        }{children}
+      </div>
     );
   }
 }
@@ -52,5 +40,9 @@ export default withCalls<Props>(
     transform: (value) =>
       value.unwrapOr(null)
   }],
-  ['query.staking.ledger', { paramName: 'controllerId' }]
+  ['query.staking.ledger', {
+    paramName: 'controllerId',
+    transform: (value) =>
+      value.unwrapOr(null)
+  }]
 )(BondedDisplay);

--- a/packages/ui-reactive/src/Chain.tsx
+++ b/packages/ui-reactive/src/Chain.tsx
@@ -10,7 +10,7 @@ import { withCalls } from '@polkadot/ui-api';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   system_chain?: Text
 };
 

--- a/packages/ui-reactive/src/NodeName.tsx
+++ b/packages/ui-reactive/src/NodeName.tsx
@@ -10,7 +10,7 @@ import { withCalls } from '@polkadot/ui-api';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   system_name?: Text
 };
 

--- a/packages/ui-reactive/src/NodeVersion.tsx
+++ b/packages/ui-reactive/src/NodeVersion.tsx
@@ -10,7 +10,7 @@ import { withCalls } from '@polkadot/ui-api';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   system_version?: Text
 };
 

--- a/packages/ui-reactive/src/Nonce.tsx
+++ b/packages/ui-reactive/src/Nonce.tsx
@@ -23,18 +23,13 @@ export class Nonce extends React.PureComponent<Props> {
     const { children, className, label = '', system_accountNonce } = this.props;
 
     return (
-      <>
-        <span className={className + ' label-nonce'}>
-          {label}
-        </span>
-        <span className={className + ' result-nonce'}>
-          {
-            system_accountNonce
-              ? formatNumber(system_accountNonce)
-              : '0'
-          }
-        </span>{children}
-      </>
+      <div className={className}>
+        {label}{
+          system_accountNonce
+            ? formatNumber(system_accountNonce)
+            : '0'
+        }{children}
+      </div>
     );
   }
 }

--- a/packages/ui-reactive/src/Nonce.tsx
+++ b/packages/ui-reactive/src/Nonce.tsx
@@ -13,7 +13,7 @@ import { withCalls } from '@polkadot/ui-api';
 type Props = BareProps & CallProps & {
   callOnResult?: (accountNonce: BN) => void,
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   params?: string,
   system_accountNonce?: Index
 };

--- a/packages/ui-reactive/src/TimeNow.tsx
+++ b/packages/ui-reactive/src/TimeNow.tsx
@@ -12,7 +12,7 @@ import Elapsed from './Elapsed';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   timestamp_now?: Moment
 };
 

--- a/packages/ui-reactive/src/TimePeriod.tsx
+++ b/packages/ui-reactive/src/TimePeriod.tsx
@@ -11,7 +11,7 @@ import { formatNumber } from '@polkadot/util';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   timestamp_blockPeriod?: Moment | Option<Moment>, // support for previous
   timestamp_minimumPeriod?: Moment // support for new version
 };

--- a/packages/ui-reactive/src/TotalIssuance.tsx
+++ b/packages/ui-reactive/src/TotalIssuance.tsx
@@ -11,7 +11,7 @@ import { formatBalance } from '@polkadot/util';
 
 type Props = BareProps & CallProps & {
   children?: React.ReactNode,
-  label?: string,
+  label?: React.ReactNode,
   balances_totalIssuance?: Balance
 };
 

--- a/packages/ui-reactive/src/Unlocking.tsx
+++ b/packages/ui-reactive/src/Unlocking.tsx
@@ -111,7 +111,7 @@ export class UnlockingDisplay extends React.PureComponent<Props, State> {
 
     return result && result.length
       ? result
-      : <>{label}0</>;
+      : null;
   }
 
   private renderUnlockableSum () {

--- a/packages/ui-reactive/src/Unlocking.tsx
+++ b/packages/ui-reactive/src/Unlocking.tsx
@@ -16,7 +16,7 @@ import { withCalls } from '@polkadot/ui-api';
 type Props = BareProps & CallProps & I18nProps & {
   chain_bestNumber?: BN,
   controllerId?: AccountId,
-  label?: string,
+  label?: React.ReactNode,
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null,
   remainingLabel?: string,
   staking_ledger?: StakingLedger,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,10 +1859,10 @@
     typescript "^3.4.5"
     vuepress "^1.0.0-alpha.47"
 
-"@polkadot/extension-dapp@^0.1.1-beta.4":
-  version "0.1.1-beta.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.1.1-beta.4.tgz#9ef6c7da1a0bc76519de9926b59a4ac66267b62a"
-  integrity sha512-LMNnwRKSZ/D6e7sQcCbVOYEx88TiJqrQaEwV6nNmg5YB+ep2iIag7wJRelhLrnmx2O8693INjjNiWxtGi4VJBQ==
+"@polkadot/extension-dapp@^0.1.1-beta.5":
+  version "0.1.1-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.1.1-beta.5.tgz#a5d9a19136077bc6b74dd64dc3cc5207710aab7d"
+  integrity sha512-8EWP48bWmFPe4lapIH25xSALciKVgxw9QGz/DtttpLI7GQYnNWrVPykFDkZhRLwU13Hl5mXXnDl86hyg8R1XpA==
 
 "@polkadot/extrinsics@^0.80.0-beta.2":
   version "0.80.0-beta.2"
@@ -1955,20 +1955,20 @@
     "@polkadot/keyring" "^0.91.1"
     "@polkadot/util" "^0.91.1"
 
-"@polkadot/ui-assets@^0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.39.1.tgz#25c4f7a101afc84365b75ab36ba3cd24d70b31b4"
-  integrity sha512-vNEhEPBJHYPhgEwgRMKRKHxfCiOGdWqkfaz46qoS4XTYzw+iKWnnqraqG95VFuYTKwxC+0+H8raUsVc64umBqA==
+"@polkadot/ui-assets@^0.40.0-beta.0":
+  version "0.40.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.40.0-beta.0.tgz#5bb2d4b62ece63a414395f9f185c1df065f9e4da"
+  integrity sha512-nBX3Er8whlQb7linMY49nDHKYZcQ086bBErW72yc9fehi8NUaaQNSKx5TK8Trx65zFkHpPuOAmm6+Fb/FQLLUw==
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-"@polkadot/ui-identicon@^0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.39.1.tgz#c0080a180940d23810d8b757785dee2e1ac451a1"
-  integrity sha512-mioETuDdfomLCGIF59SLflqgVsuUGczL414+VzlpMQbeo80Xq+UZkHBUZA47IGcUWokWzNuYvw6unFfXg/08Fw==
+"@polkadot/ui-identicon@^0.40.0-beta.0":
+  version "0.40.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.40.0-beta.0.tgz#2cbd2dd534df1540c38dd9c5ebaf64fd074458d3"
+  integrity sha512-tm7DY42SDUAmM+bC0S24UhiKqRNGmX9DTR3TWAXY9p35IOVM8TPGqyQj4gO4P2kSJ4rsKUjwSiGIfgB7Tp809w==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/ui-settings" "^0.39.1"
+    "@polkadot/ui-settings" "^0.40.0-beta.0"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.0.0"
@@ -1976,20 +1976,20 @@
     react-copy-to-clipboard "^5.0.1"
     styled-components "^4.2.0"
 
-"@polkadot/ui-keyring@^0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.39.1.tgz#8c0d2093bba67f5a3c350a20e4c6eda4acecf13f"
-  integrity sha512-+RBd6x9M6JGLNiDlx44fB4+e+5jAif5wn/4aYYWsVSHV+dmQNBl7TbNRWtAn6c3+GN3C+aJudWBLWbtFOafRrA==
+"@polkadot/ui-keyring@^0.40.0-beta.0":
+  version "0.40.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.40.0-beta.0.tgz#2dc121dbeb8dc3c661b80dd34ebf6683f9fb678a"
+  integrity sha512-DXanoWuwjczFYPnoXitl9BslvUXxa9dgzU9ICrk9KS3V5a7xRZmGyOOG25jHWKAaSMQSsxAFqpRu6IuJubcbbA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/store" "^2.0.1"
     store "^2.0.12"
     styled-components "^4.2.0"
 
-"@polkadot/ui-settings@^0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.39.1.tgz#174b076b282b3becf6cdcab70be8965cecedf710"
-  integrity sha512-HjtxJiRCVH0eQ4HH+d24J/XFNtwaAbTskKPRMN+qptLZWghqFrXi4F6JWIBzdTKdSnzvgjQckHr41rYkbrb8oQ==
+"@polkadot/ui-settings@^0.40.0-beta.0":
+  version "0.40.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.40.0-beta.0.tgz#64a5d6949b5a3fd68c32eddd4a831a86653dbc68"
+  integrity sha512-8ykesU9AyJMKDRXDEr9axJchHyxcS5aQ4vr4GBhGiHGJGfbjTwcJIC4jykWNPt8VefLygROIhuA60Rbucd1Yrw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/store" "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,20 +1955,20 @@
     "@polkadot/keyring" "^0.91.1"
     "@polkadot/util" "^0.91.1"
 
-"@polkadot/ui-assets@^0.40.0-beta.0":
-  version "0.40.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.40.0-beta.0.tgz#5bb2d4b62ece63a414395f9f185c1df065f9e4da"
-  integrity sha512-nBX3Er8whlQb7linMY49nDHKYZcQ086bBErW72yc9fehi8NUaaQNSKx5TK8Trx65zFkHpPuOAmm6+Fb/FQLLUw==
+"@polkadot/ui-assets@^0.40.0-beta.1":
+  version "0.40.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.40.0-beta.1.tgz#1b263138646cb1b701d8db526a9fdbd00a653e0d"
+  integrity sha512-0JlqxhBoDPl0nZPvAx/WxIc0jbpiuex8a2/fkcLcuT7N5WVQLu9Eb2W8CS7z5WFPG6pJwnKCQ2usbRDJ13Dhdg==
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-"@polkadot/ui-identicon@^0.40.0-beta.0":
-  version "0.40.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.40.0-beta.0.tgz#2cbd2dd534df1540c38dd9c5ebaf64fd074458d3"
-  integrity sha512-tm7DY42SDUAmM+bC0S24UhiKqRNGmX9DTR3TWAXY9p35IOVM8TPGqyQj4gO4P2kSJ4rsKUjwSiGIfgB7Tp809w==
+"@polkadot/ui-identicon@^0.40.0-beta.1":
+  version "0.40.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.40.0-beta.1.tgz#890a6f6dd4f20efa44bca805872bca4227bd6220"
+  integrity sha512-uvC+jWz+tv8NBEMeUxu5M4HGCoL1uzbKRKq9XqZevJMLpbAnmqa50/NT6HdNdYEyHNM7HM0rb/XSCcxnatzL0g==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/ui-settings" "^0.40.0-beta.0"
+    "@polkadot/ui-settings" "^0.40.0-beta.1"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.0.0"
@@ -1976,20 +1976,20 @@
     react-copy-to-clipboard "^5.0.1"
     styled-components "^4.2.0"
 
-"@polkadot/ui-keyring@^0.40.0-beta.0":
-  version "0.40.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.40.0-beta.0.tgz#2dc121dbeb8dc3c661b80dd34ebf6683f9fb678a"
-  integrity sha512-DXanoWuwjczFYPnoXitl9BslvUXxa9dgzU9ICrk9KS3V5a7xRZmGyOOG25jHWKAaSMQSsxAFqpRu6IuJubcbbA==
+"@polkadot/ui-keyring@^0.40.0-beta.1":
+  version "0.40.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.40.0-beta.1.tgz#0c59bf99668e4518b6b00ffa9b4781afc06a723e"
+  integrity sha512-T0vnRTKOHAFwqN1e5lQ8Gx2MWb2CMopR/hnuKJTBOsDUMGgS7rxWvnWgACdAGeVnD9/C+05aKt6NVY9ADqeGCw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/store" "^2.0.1"
     store "^2.0.12"
     styled-components "^4.2.0"
 
-"@polkadot/ui-settings@^0.40.0-beta.0":
-  version "0.40.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.40.0-beta.0.tgz#64a5d6949b5a3fd68c32eddd4a831a86653dbc68"
-  integrity sha512-8ykesU9AyJMKDRXDEr9axJchHyxcS5aQ4vr4GBhGiHGJGfbjTwcJIC4jykWNPt8VefLygROIhuA60Rbucd1Yrw==
+"@polkadot/ui-settings@^0.40.0-beta.1":
+  version "0.40.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.40.0-beta.1.tgz#793c17942acabd958fb7b7e3fee2ba6807397a71"
+  integrity sha512-Vq35tiBICI1WeLgAFmY8mNry1PV53wQBIy2RbPH3DrfvFG8D7QeFeJ9yY2P79l+CoyKyvU8Uly08QhxXIfOeXw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/store" "^2.0.1"


### PR DESCRIPTION
Sprawled completely out of control -

- fixed max calculations to not kill RPC (both modal & transfer app)
- fixed nonce display in extrinsics (cased by the point below)
- reworked ui-reactive to original form (just simple wrappable classes)
- add `Label` & `LabelHelp` components (see PR closed below)
- Hide/show all clickables on card non-hover to make things cleaner
- Fix onSearch bug in `AddressInput` (was not working)
- Adjusted `AddressRow` layout... swapped to it everywhere for cards
- Added `AddressInfo` for the grid-y balance display (staking & accounts)
- ... show available balances on transfer
- Pull in and closes https://github.com/polkadot-js/apps/pull/1198 (Labels completely reworked)
- Part of  https://github.com/polkadot-js/apps/issues/1208

Only "part of" since probably need to be a bit less cowboy and only remove the transfer app when we can deposit into an address anywhere. The first thing that will happen is that in the "hide universe" (without it everywhere), is, well, questions since people will get confused.

... so, boiling the frog slowly