### PR TITLE
Swap AddressSummary for AddressRow

### DIFF
--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -117,7 +117,9 @@ class Creator extends TxComponent<Props, State> {
 
     return (
       <div className='accounts--Creator'>
+        {this.renderModal()}
         <div className='ui--grid'>
+          {this.renderInput()}
           <AddressRow
             className='shrink'
             defaultName={name}
@@ -127,9 +129,7 @@ class Creator extends TxComponent<Props, State> {
                 : ''
             }
           />
-          {this.renderInput()}
         </div>
-        {this.renderButtons()}
       </div>
     );
   }
@@ -255,7 +255,7 @@ class Creator extends TxComponent<Props, State> {
             }
           </div>
         </details>
-        {this.renderModal()}
+        {this.renderButtons()}
       </div>
     );
   }

--- a/packages/app-accounts/src/Creator.tsx
+++ b/packages/app-accounts/src/Creator.tsx
@@ -12,7 +12,7 @@ import FileSaver from 'file-saver';
 import React from 'react';
 import { DEV_PHRASE } from '@polkadot/keyring/defaults';
 import { withApi, withMulti } from '@polkadot/ui-api';
-import { AddressSummary, AddressRow, Button, Dropdown, Input, InputTags, Labelled, Modal, Password, TxComponent } from '@polkadot/ui-app';
+import { AddressRow, Button, Dropdown, Input, InputTags, Labelled, Modal, Password, TxComponent } from '@polkadot/ui-app';
 import { InputAddress } from '@polkadot/ui-app/InputAddress';
 import keyring from '@polkadot/ui-keyring';
 import uiSettings from '@polkadot/ui-settings';
@@ -113,19 +113,19 @@ class Creator extends TxComponent<Props, State> {
   }
 
   render () {
-    const { address, isSeedValid } = this.state;
+    const { address, name, isSeedValid } = this.state;
 
     return (
       <div className='accounts--Creator'>
         <div className='ui--grid'>
-          <AddressSummary
+          <AddressRow
             className='shrink'
+            defaultName={name}
             value={
               isSeedValid
                 ? address
                 : ''
             }
-            withBonded
           />
           {this.renderInput()}
         </div>

--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -35,12 +35,12 @@ class Restore extends TxComponent<Props, State> {
   };
 
   render () {
-    const { t } = this.props;
-    const { address, isFileValid, isPassValid } = this.state;
+    const { address, isFileValid } = this.state;
 
     return (
       <div className='accounts--Restore'>
         <div className='ui--grid'>
+          {this.renderInput()}
           <AddressRow
             className='shrink'
             value={
@@ -49,17 +49,7 @@ class Restore extends TxComponent<Props, State> {
                 : null
               }
           />
-          {this.renderInput()}
         </div>
-        <Button.Group>
-        <Button
-          isDisabled={!isFileValid || !isPassValid}
-          isPrimary
-          onClick={this.onSave}
-          label={t('Restore')}
-          ref={this.button}
-        />
-      </Button.Group>
       </div>
     );
   }
@@ -94,6 +84,15 @@ class Restore extends TxComponent<Props, State> {
             value={password}
           />
         </div>
+        <Button.Group>
+          <Button
+            isDisabled={!isFileValid || !isPassValid}
+            isPrimary
+            onClick={this.onSave}
+            label={t('Restore')}
+            ref={this.button}
+          />
+      </Button.Group>
       </div>
     );
   }

--- a/packages/app-accounts/src/Restore.tsx
+++ b/packages/app-accounts/src/Restore.tsx
@@ -8,7 +8,7 @@ import { ActionStatus } from '@polkadot/ui-app/Status/types';
 import { ComponentProps } from './types';
 
 import React from 'react';
-import { AddressSummary, Button, InputFile, Password, TxComponent } from '@polkadot/ui-app';
+import { AddressRow, Button, InputFile, Password, TxComponent } from '@polkadot/ui-app';
 import { InputAddress } from '@polkadot/ui-app/InputAddress';
 import { isHex, isObject, u8aToString } from '@polkadot/util';
 import keyring from '@polkadot/ui-keyring';
@@ -41,7 +41,7 @@ class Restore extends TxComponent<Props, State> {
     return (
       <div className='accounts--Restore'>
         <div className='ui--grid'>
-          <AddressSummary
+          <AddressRow
             className='shrink'
             value={
               isFileValid && address

--- a/packages/app-address-book/src/Creator.tsx
+++ b/packages/app-address-book/src/Creator.tsx
@@ -7,7 +7,7 @@ import { ComponentProps } from './types';
 
 import React from 'react';
 
-import { AddressSummary, Button, Input, InputTags, TxComponent } from '@polkadot/ui-app';
+import { AddressRow, Button, Input, InputTags, TxComponent } from '@polkadot/ui-app';
 import { ActionStatus } from '@polkadot/ui-app/Status/types';
 import { InputAddress } from '@polkadot/ui-app/InputAddress';
 import keyring from '@polkadot/ui-keyring';
@@ -36,15 +36,15 @@ class Creator extends TxComponent<Props, State> {
   }
 
   render () {
-    const { address } = this.state;
+    const { address, name } = this.state;
 
     return (
       <div className='address-book--Creator'>
         <div className='ui--grid'>
-          <AddressSummary
+          <AddressRow
             className='shrink'
+            defaultName={name}
             value={address}
-            withBonded
           />
           {this.renderInput()}
         </div>

--- a/packages/app-address-book/src/Creator.tsx
+++ b/packages/app-address-book/src/Creator.tsx
@@ -41,14 +41,13 @@ class Creator extends TxComponent<Props, State> {
     return (
       <div className='address-book--Creator'>
         <div className='ui--grid'>
+          {this.renderInput()}
           <AddressRow
             className='shrink'
             defaultName={name}
             value={address}
           />
-          {this.renderInput()}
         </div>
-        {this.renderButtons()}
       </div>
     );
   }
@@ -112,6 +111,7 @@ class Creator extends TxComponent<Props, State> {
             value={tags}
           />
         </div>
+        {this.renderButtons()}
       </div>
     );
   }

--- a/packages/app-address-book/src/Editor.tsx
+++ b/packages/app-address-book/src/Editor.tsx
@@ -7,7 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import { ComponentProps } from './types';
 
 import React from 'react';
-import { AddressSummary, Button, Input, InputAddress, InputTags, TxComponent } from '@polkadot/ui-app';
+import { AddressRow, Button, Input, InputAddress, InputTags, TxComponent } from '@polkadot/ui-app';
 import { ActionStatus } from '@polkadot/ui-app/Status/types';
 import keyring from '@polkadot/ui-keyring';
 
@@ -92,7 +92,7 @@ class Editor extends TxComponent<Props, State> {
 
     return (
       <div className='ui--grid'>
-        <AddressSummary
+        <AddressRow
           className='shrink'
           value={address || ''}
           withBonded

--- a/packages/app-address-book/src/Editor.tsx
+++ b/packages/app-address-book/src/Editor.tsx
@@ -44,7 +44,6 @@ class Editor extends TxComponent<Props, State> {
           currentAddress={current}
         />
         {this.renderData()}
-        {this.renderButtons()}
       </div>
     );
   }
@@ -92,11 +91,6 @@ class Editor extends TxComponent<Props, State> {
 
     return (
       <div className='ui--grid'>
-        <AddressRow
-          className='shrink'
-          value={address || ''}
-          withBonded
-        />
         <div className='grow'>
           <div className='ui--row'>
             <InputAddress
@@ -128,7 +122,12 @@ class Editor extends TxComponent<Props, State> {
               value={tags}
             />
           </div>
+          {this.renderButtons()}
         </div>
+        <AddressRow
+          className='shrink'
+          value={address || ''}
+        />
       </div>
     );
   }

--- a/packages/app-transfer/src/Transfer.tsx
+++ b/packages/app-transfer/src/Transfer.tsx
@@ -10,7 +10,7 @@ import BN from 'bn.js';
 import React from 'react';
 import styled from 'styled-components';
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
-import { AddressSummary, Button, InputAddress, InputBalance, TxButton, TxComponent } from '@polkadot/ui-app';
+import { AddressRow, Button, InputAddress, InputBalance, TxButton, TxComponent } from '@polkadot/ui-app';
 import { withApi, withCalls, withMulti } from '@polkadot/ui-api';
 import keyring from '@polkadot/ui-keyring';
 import Checks, { calcSignatureLength } from '@polkadot/ui-signer/Checks';
@@ -37,6 +37,7 @@ const ZERO = new BN(0);
 const Wrapper = styled.div`
   .transfer--Transfer-address {
     flex: 0 1;
+    padding: 1.5rem 0;
 
     .ui--AddressSummary {
       text-align: center;
@@ -46,6 +47,7 @@ const Wrapper = styled.div`
   .transfer--Transfer-data {
     flex: 1 1;
     min-width: 0;
+    padding: 0 1rem;
   }
 
   .transfer--Transfer-info {
@@ -146,8 +148,9 @@ class Transfer extends TxComponent<Props, State> {
 
     return (
       <div className={`transfer--Transfer-address ui--media-${media}`}>
-        <AddressSummary
+        <AddressRow
           value={accountId}
+          withAvailable
         />
       </div>
     );

--- a/packages/ui-app/src/AddressInfo.tsx
+++ b/packages/ui-app/src/AddressInfo.tsx
@@ -100,7 +100,6 @@ export default translate(styled(AddressInfo)`
   display: flex;
   flex: 1;
   justify-content: center;
-  padding-top: 1rem;
 
   .column {
     flex: 1;

--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -26,6 +26,7 @@ class AddressRow extends AddressSummary {
               {this.renderAddress()}
             </div>
             <div className='ui--AddressSummary-balances'>
+              {this.renderAvailable()}
               {this.renderBalance()}
               {this.renderBonded()}
               {this.renderNonce()}

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -64,6 +64,10 @@ class AddressSummary extends React.PureComponent<Props, State> {
     this.state = this.createState();
   }
 
+  static defaultProps = {
+    defaultName: '<unknown>'
+  };
+
   static getDerivedStateFromProps ({ accounts_idAndIndex = [], defaultName, value }: Props): State | null {
     const [_accountId] = accounts_idAndIndex;
     const accountId = _accountId || value;
@@ -224,7 +228,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderBalance () {
-    const { accounts_idAndIndex = [], balance, t, value, withBalance = true } = this.props;
+    const { accounts_idAndIndex = [], balance, t, value, withBalance } = this.props;
     const [_accountId] = accounts_idAndIndex;
     const accountId = _accountId || value;
 
@@ -315,7 +319,7 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderNonce () {
-    const { accounts_idAndIndex = [], t, value, withNonce = true } = this.props;
+    const { accounts_idAndIndex = [], t, value, withNonce } = this.props;
     const [_accountId] = accounts_idAndIndex;
     const accountId = _accountId || value;
 

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -80,12 +80,22 @@ class AddressSummary extends React.PureComponent<Props, State> {
       : DEFAULT_ADDR;
     const name = getAddrName(address, false, defaultName) || '';
     const tags = getAddrTags(address);
+    const state = { tags } as State;
+    let hasChanged = false;
 
-    if (address === prevState.address) {
-      return null;
+    if (address !== prevState.address) {
+      state.address = address;
+      hasChanged = true;
     }
 
-    return { address, name, tags } as State;
+    if (name !== prevState.name) {
+      state.name = name;
+      hasChanged = true;
+    }
+
+    return hasChanged
+      ? state
+      : null;
   }
 
   render () {

--- a/packages/ui-app/src/AddressSummary.tsx
+++ b/packages/ui-app/src/AddressSummary.tsx
@@ -32,7 +32,6 @@ export type Props = I18nProps & {
   defaultName?: string,
   extraInfo?: React.ReactNode,
   identIconSize?: number,
-  isChildrenAbs?: boolean,
   isEditable?: boolean,
   isInline?: boolean,
   isShort?: boolean,
@@ -287,14 +286,14 @@ class AddressSummary extends React.PureComponent<Props, State> {
   }
 
   protected renderChildren () {
-    const { children, isChildrenAbs } = this.props;
+    const { children } = this.props;
 
     if (!children || (Array.isArray(children) && children.length === 0)) {
       return null;
     }
 
     return (
-      <div className={`ui--AddressSummary-children ${isChildrenAbs ? 'abs' : ''}`}>
+      <div className='ui--AddressSummary-children'>
         {children}
       </div>
     );

--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -184,6 +184,10 @@ button.ui.icon.iconButton {
   vertical-align: top;
 }
 
+.grow+.ui--AddressRow {
+  padding: 1rem 0 0 1rem;
+}
+
 .ui--AddressRow {
   position: relative;
 
@@ -197,6 +201,7 @@ button.ui.icon.iconButton {
 
   .ui--AddressSummary-children {
     display: block;
+    padding-top: 1rem;
   }
 
   .ui--AddressRow-details {


### PR DESCRIPTION
- As mentioned in https://github.com/polkadot-js/apps/pull/1210/#issuecomment-496079805
- Next step would be to remove Summary altogether and pull the styles into AddressRow (finally making it clean)