### PR TITLE
Cater for empty unlockings and margin on icon

### DIFF
--- a/packages/ui-app/src/styles/components.css
+++ b/packages/ui-app/src/styles/components.css
@@ -137,6 +137,10 @@ button.ui.icon.iconButton {
   right: -2.3em  !important;
 }
 
+.ui--Unlocking i.info.circle.icon {
+  margin-left: .3em;
+}
+
 .editable {
   cursor: pointer;
 }

--- a/packages/ui-reactive/src/Unlocking.tsx
+++ b/packages/ui-reactive/src/Unlocking.tsx
@@ -111,7 +111,7 @@ export class UnlockingDisplay extends React.PureComponent<Props, State> {
 
     return result && result.length
       ? result
-      : null;
+      : <>{label}0</>;
   }
 
   private renderUnlockableSum () {


### PR DESCRIPTION
- closes https://github.com/polkadot-js/apps/issues/1214
- adds a margin left for (i) icon on locked

![image](https://user-images.githubusercontent.com/33178835/58408549-54dc6a80-806e-11e9-839c-c05e2ec5de66.png)
