### PR TITLE
Display extrinsic meta documentation on hover

### DIFF
--- a/packages/app-storage/src/Selection/Modules.tsx
+++ b/packages/app-storage/src/Selection/Modules.tsx
@@ -46,7 +46,7 @@ class Modules extends TxComponent<Props, State> {
 
   render () {
     const { t } = this.props;
-    const { isValid, key: { method, section }, params } = this.state;
+    const { isValid, key: { method, section, meta }, params } = this.state;
 
     return (
       <section className='storage--actionrow'>
@@ -55,6 +55,11 @@ class Modules extends TxComponent<Props, State> {
             defaultValue={this.defaultValue}
             label={t('selected state query')}
             onChange={this.onChangeKey}
+            help={
+              t(meta && meta.documentation
+                ? meta.documentation.join(' ') : ''
+              )
+            }
           />
           <Params
             key={`${section}.${method}:params` /* force re-render on change */}

--- a/packages/app-storage/src/Selection/Modules.tsx
+++ b/packages/app-storage/src/Selection/Modules.tsx
@@ -56,9 +56,8 @@ class Modules extends TxComponent<Props, State> {
             label={t('selected state query')}
             onChange={this.onChangeKey}
             help={
-              t(meta && meta.documentation
-                ? meta.documentation.join(' ') : ''
-              )
+              meta && meta.documentation
+              && meta.documentation.join(' ')
             }
           />
           <Params

--- a/packages/ui-app/src/Extrinsic.tsx
+++ b/packages/ui-app/src/Extrinsic.tsx
@@ -63,8 +63,7 @@ class ExtrinsicDisplay extends React.PureComponent<Props, State> {
           withLabel={withLabel}
           help={
             meta && meta.documentation
-              ? meta.documentation.join(' ')
-              : ''
+            && meta.documentation.join(' ')
           }
         />
         <Params

--- a/packages/ui-app/src/Extrinsic.tsx
+++ b/packages/ui-app/src/Extrinsic.tsx
@@ -49,7 +49,7 @@ class ExtrinsicDisplay extends React.PureComponent<Props, State> {
 
   render () {
     const { defaultValue, isDisabled, isError, isPrivate, label, onEnter, withLabel } = this.props;
-    const { methodfn: { method, section }, params } = this.state;
+    const { methodfn: { method, section, meta }, params } = this.state;
 
     return (
       <div className='extrinsics--Extrinsic'>
@@ -61,6 +61,11 @@ class ExtrinsicDisplay extends React.PureComponent<Props, State> {
           label={label}
           onChange={this.onChangeMethod}
           withLabel={withLabel}
+          help={
+            meta && meta.documentation
+              ? meta.documentation.join(' ')
+              : ''
+          }
         />
         <Params
           key={`${section}.${method}:params` /* force re-render on change */}


### PR DESCRIPTION
Resolves #969 

---

### Extrinsic

![Screenshot from 2019-05-31 00-31-37 (1) (1)](https://user-images.githubusercontent.com/17903466/58659432-8d1acc00-8340-11e9-976e-6bd52f69c069.png)

![Screenshot from 2019-05-31 14-22-56 (1)](https://user-images.githubusercontent.com/17903466/58694050-c2aace00-83af-11e9-85e6-2679a600a063.png)

---

### Chain State
![Screenshot from 2019-05-31 00-40-49 (1)](https://user-images.githubusercontent.com/17903466/58657883-dd902a80-833c-11e9-9ce9-1d69b211e8e2.png)

---