### PR TITLE
Hide search and filter on small screens

### DIFF
--- a/packages/ui-app/src/FilterOverlay.tsx
+++ b/packages/ui-app/src/FilterOverlay.tsx
@@ -14,23 +14,29 @@ type Props = BareProps & {
 };
 
 const Wrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  position: absolute;
-  right: 5rem;
-  top: 0.4rem;
-
-  > div {
-    max-width: 35rem !important;
-  }
+  display:none;
 
   .ui--Labelled label {
     display: none;
   }
 
   ${media.DESKTOP`
+    display: flex;
+    justify-content: flex-end;
+    position: absolute;
+    right: 5rem;
+    top: 0.4rem;
+
+    > div {
+      max-width: 35rem !important;
+    }
+
     .ui--Labelled label {
       display: flex;
+    }
+    
+    .ui.selection.dropdown{
+      white-space: nowrap;
     }
   `}
 `;

--- a/packages/ui-app/src/FilterOverlay.tsx
+++ b/packages/ui-app/src/FilterOverlay.tsx
@@ -34,8 +34,8 @@ const Wrapper = styled.div`
     .ui--Labelled label {
       display: flex;
     }
-    
-    .ui.selection.dropdown{
+
+    .ui.selection.dropdown {
       white-space: nowrap;
     }
   `}


### PR DESCRIPTION
closes https://github.com/polkadot-js/apps/issues/1249

The no-wrap fixes this problem on FF
![image](https://user-images.githubusercontent.com/33178835/58704443-52e71400-83ac-11e9-92ea-32571c9f07d8.png)
