### PR TITLE
Disable react-hot-loader

### DIFF
--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -6,7 +6,7 @@ import { BareProps } from '@polkadot/ui-app/types';
 import { SideBarTransition, SIDEBAR_TRANSITION_DURATION, SIDEBAR_MENU_THRESHOLD } from './constants';
 
 import React from 'react';
-import { hot } from 'react-hot-loader/root';
+// import { hot } from 'react-hot-loader/root';
 import store from 'store';
 import { ThemeProvider } from 'styled-components';
 import Signer from '@polkadot/ui-signer';
@@ -176,4 +176,4 @@ class Apps extends React.Component<Props, State> {
   }
 }
 
-export default hot(Apps);
+export default Apps; // hot(Apps);


### PR DESCRIPTION
A trial. Atm, at least with chrome, we are being our own worst nightmare in development.

1. Each save re-compiles with the webpack-plugin-serve
2. VSCode jumps in trying to validate the TypeScript (which was problematic <3.5)
3. Hot reloader reloads the page, however do bear in mind that we have a WASM leak in Chrome

The end result, at least for me, it that -

1. Hot reload doesn't always seem to work (css is mostly fine, anything bigger and it doesn't)
2. So refresh is anyway in the order of the day (especially after a lot of changes)

At least for my workflow, all that happens at it that i need to continue looking at Chrome Helper at >100% CPU for most of the time

... so, this is a trial to see if things get better without a major impact elsewhere on productivity