### PR TITLE
Create Enum, Option & Struct from toRawType

### DIFF
--- a/packages/ui-params/src/Param/Enum.tsx
+++ b/packages/ui-params/src/Param/Enum.tsx
@@ -5,32 +5,26 @@
 import { Props as BaseProps, RawParam } from '../types';
 
 import React from 'react';
-import { WithTranslation } from 'react-i18next';
 import { Enum, TypeDef, createType, getTypeDef } from '@polkadot/types';
-import { Dropdown, Static } from '@polkadot/ui-app';
-import translate from '@polkadot/ui-app/translate';
+import { Dropdown } from '@polkadot/ui-app';
 
+import Params from '../';
 import getValues from '../values';
-import findComponent from './findComponent';
 import Bare from './Bare';
-import Null from './Null';
+import Static from './Static';
 
-type Props = WithTranslation & BaseProps;
+type Props = BaseProps;
 
 type State = {
-  Child: React.ComponentType<BaseProps>,
   def: TypeDef | null,
-  defValue: RawParam,
   options: Array<{ text: string, value: string }>,
   sub: Array<TypeDef>,
   type: string | null
 };
 
-class EnumParam extends React.PureComponent<Props, State> {
+export default class EnumParam extends React.PureComponent<Props, State> {
   state: State = {
-    Child: Null,
     def: null,
-    defValue: { isValid: false, value: undefined },
     options: [],
     sub: [],
     type: null
@@ -59,26 +53,13 @@ class EnumParam extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { className, defaultValue, isDisabled, isError, label, style, t, withLabel } = this.props;
+    const { className, defaultValue, isDisabled, isError, label, style, withLabel } = this.props;
 
     if (isDisabled) {
-      const value = defaultValue && defaultValue.value && defaultValue.value.toString();
-
-      return (
-        <Bare
-          className={className}
-          style={style}
-        >
-          <Static
-            className='full'
-            label={label}
-            value={value || t('empty')}
-          />
-        </Bare>
-      );
+      return <Static {...this.props} />;
     }
 
-    const { Child, def, defValue, options } = this.state;
+    const { def, options } = this.state;
     const initialValue = defaultValue && defaultValue.value
       ? defaultValue.value instanceof Enum
         ? defaultValue.value.type
@@ -91,7 +72,7 @@ class EnumParam extends React.PureComponent<Props, State> {
         style={style}
       >
         <Dropdown
-          className={'medium'}
+          className='large'
           defaultValue={initialValue}
           isDisabled={isDisabled}
           isError={isError}
@@ -102,11 +83,9 @@ class EnumParam extends React.PureComponent<Props, State> {
           withLabel={withLabel}
         />
         {def && (
-          <Child
-            defaultValue={defValue}
-            label={'1234'}
+          <Params
             onChange={this.onChangeParam}
-            type={def}
+            params={[{ name: def.name, type: def }]}
           />
         )}
       </Bare>
@@ -118,26 +97,15 @@ class EnumParam extends React.PureComponent<Props, State> {
     const def = sub.find(({ name }) => name === value);
 
     if (def) {
-      this.setState({
-        Child: findComponent(def),
-        def,
-        defValue: getValues([{ type: def }])[0]
-      });
+      this.setState({ def });
     }
   }
 
-  private onChangeParam = ({ isValid, value }: RawParam): void => {
+  private onChangeParam = ([{ isValid, value }]: Array<RawParam>): void => {
     const { onChange } = this.props;
     const { def } = this.state;
 
     if (def) {
-      console.log({
-        isValid,
-        value: {
-          [def.name as string]: value
-        }
-      });
-
       onChange && onChange({
         isValid,
         value: {
@@ -147,5 +115,3 @@ class EnumParam extends React.PureComponent<Props, State> {
     }
   }
 }
-
-export default translate(EnumParam);

--- a/packages/ui-params/src/Param/Enum.tsx
+++ b/packages/ui-params/src/Param/Enum.tsx
@@ -9,7 +9,6 @@ import { Enum, TypeDef, createType, getTypeDef } from '@polkadot/types';
 import { Dropdown } from '@polkadot/ui-app';
 
 import Params from '../';
-import getValues from '../values';
 import Bare from './Bare';
 import Static from './Static';
 
@@ -41,11 +40,9 @@ export default class EnumParam extends React.PureComponent<Props, State> {
       value: name
     }));
     const def = prevState.def || sub[0];
-    const defValue = getValues([{ type: def }])[0];
 
     return {
       def,
-      defValue,
       options,
       sub,
       type
@@ -94,11 +91,10 @@ export default class EnumParam extends React.PureComponent<Props, State> {
 
   private onChange = (value: string): void => {
     const { sub } = this.state;
-    const def = sub.find(({ name }) => name === value);
 
-    if (def) {
-      this.setState({ def });
-    }
+    this.setState({
+      def: sub.find(({ name }) => name === value) || null
+    });
   }
 
   private onChangeParam = ([{ isValid, value }]: Array<RawParam>): void => {

--- a/packages/ui-params/src/Param/Enum.tsx
+++ b/packages/ui-params/src/Param/Enum.tsx
@@ -2,25 +2,35 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Props as BaseProps } from '../types';
+import { Props as BaseProps, RawParam } from '../types';
 
 import React from 'react';
+import { WithTranslation } from 'react-i18next';
 import { Enum, TypeDef, createType, getTypeDef } from '@polkadot/types';
-import { Dropdown } from '@polkadot/ui-app';
-import { isObject } from '@polkadot/util';
+import { Dropdown, Static } from '@polkadot/ui-app';
+import translate from '@polkadot/ui-app/translate';
 
+import getValues from '../values';
+import findComponent from './findComponent';
 import Bare from './Bare';
+import Null from './Null';
 
-type Props = BaseProps;
+type Props = WithTranslation & BaseProps;
 
 type State = {
+  Child: React.ComponentType<BaseProps>,
+  def: TypeDef | null,
+  defValue: RawParam,
   options: Array<{ text: string, value: string }>,
   sub: Array<TypeDef>,
   type: string | null
 };
 
-export default class EnumParam extends React.PureComponent<Props, State> {
+class EnumParam extends React.PureComponent<Props, State> {
   state: State = {
+    Child: Null,
+    def: null,
+    defValue: { isValid: false, value: undefined },
     options: [],
     sub: [],
     type: null
@@ -36,22 +46,44 @@ export default class EnumParam extends React.PureComponent<Props, State> {
       text: name,
       value: name
     }));
+    const def = prevState.def || sub[0];
+    const defValue = getValues([{ type: def }])[0];
 
     return {
+      def,
+      defValue,
       options,
       sub,
       type
-    };
+    } as State;
   }
 
   render () {
-    const { className, defaultValue: { value }, isDisabled, isError, label, style, withLabel } = this.props;
-    const { options } = this.state;
-    const defaultValue = value && isObject(value)
-      ? value instanceof Enum
-        ? value.type
-        : Object.keys(value)[0]
-      : value;
+    const { className, defaultValue, isDisabled, isError, label, style, t, withLabel } = this.props;
+
+    if (isDisabled) {
+      const value = defaultValue && defaultValue.value && defaultValue.value.toString();
+
+      return (
+        <Bare
+          className={className}
+          style={style}
+        >
+          <Static
+            className='full'
+            label={label}
+            value={value || t('empty')}
+          />
+        </Bare>
+      );
+    }
+
+    const { Child, def, defValue, options } = this.state;
+    const initialValue = defaultValue && defaultValue.value
+      ? defaultValue.value instanceof Enum
+        ? defaultValue.value.type
+        : Object.keys(defaultValue.value)[0]
+      : defaultValue;
 
     return (
       <Bare
@@ -59,8 +91,8 @@ export default class EnumParam extends React.PureComponent<Props, State> {
         style={style}
       >
         <Dropdown
-          className={isDisabled ? 'full' : 'medium'}
-          defaultValue={defaultValue}
+          className={'medium'}
+          defaultValue={initialValue}
           isDisabled={isDisabled}
           isError={isError}
           label={label}
@@ -69,20 +101,51 @@ export default class EnumParam extends React.PureComponent<Props, State> {
           withEllipsis
           withLabel={withLabel}
         />
+        {def && (
+          <Child
+            defaultValue={defValue}
+            label={'1234'}
+            onChange={this.onChangeParam}
+            type={def}
+          />
+        )}
       </Bare>
     );
   }
 
   private onChange = (value: string): void => {
-    const { onChange } = this.props;
     const { sub } = this.state;
     const def = sub.find(({ name }) => name === value);
 
-    if (def && onChange) {
-      onChange({
-        isValid: true,
-        value: { [value]: createType(def.type) }
+    if (def) {
+      this.setState({
+        Child: findComponent(def),
+        def,
+        defValue: getValues([{ type: def }])[0]
+      });
+    }
+  }
+
+  private onChangeParam = ({ isValid, value }: RawParam): void => {
+    const { onChange } = this.props;
+    const { def } = this.state;
+
+    if (def) {
+      console.log({
+        isValid,
+        value: {
+          [def.name as string]: value
+        }
+      });
+
+      onChange && onChange({
+        isValid,
+        value: {
+          [def.name as string]: value
+        }
       });
     }
   }
 }
+
+export default translate(EnumParam);

--- a/packages/ui-params/src/Param/Enum.tsx
+++ b/packages/ui-params/src/Param/Enum.tsx
@@ -1,0 +1,88 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Props as BaseProps } from '../types';
+
+import React from 'react';
+import { Enum, TypeDef, createType, getTypeDef } from '@polkadot/types';
+import { Dropdown } from '@polkadot/ui-app';
+import { isObject } from '@polkadot/util';
+
+import Bare from './Bare';
+
+type Props = BaseProps;
+
+type State = {
+  options: Array<{ text: string, value: string }>,
+  sub: Array<TypeDef>,
+  type: string | null
+};
+
+export default class EnumParam extends React.PureComponent<Props, State> {
+  state: State = {
+    options: [],
+    sub: [],
+    type: null
+  };
+
+  static getDerivedStateFromProps ({ type: { type } }: Props, prevState: State) {
+    if (prevState.type === type) {
+      return null;
+    }
+
+    const sub = getTypeDef(createType(type).toRawType()).sub as Array<TypeDef>;
+    const options = sub.map(({ name }) => ({
+      text: name,
+      value: name
+    }));
+
+    return {
+      options,
+      sub,
+      type
+    };
+  }
+
+  render () {
+    const { className, defaultValue: { value }, isDisabled, isError, label, style, withLabel } = this.props;
+    const { options } = this.state;
+    const defaultValue = value && isObject(value)
+      ? value instanceof Enum
+        ? value.type
+        : Object.keys(value)[0]
+      : value;
+
+    return (
+      <Bare
+        className={className}
+        style={style}
+      >
+        <Dropdown
+          className={isDisabled ? 'full' : 'medium'}
+          defaultValue={defaultValue}
+          isDisabled={isDisabled}
+          isError={isError}
+          label={label}
+          options={options}
+          onChange={this.onChange}
+          withEllipsis
+          withLabel={withLabel}
+        />
+      </Bare>
+    );
+  }
+
+  private onChange = (value: string): void => {
+    const { onChange } = this.props;
+    const { sub } = this.state;
+    const def = sub.find(({ name }) => name === value);
+
+    if (def && onChange) {
+      onChange({
+        isValid: true,
+        value: { [value]: createType(def.type) }
+      });
+    }
+  }
+}

--- a/packages/ui-params/src/Param/Null.tsx
+++ b/packages/ui-params/src/Param/Null.tsx
@@ -7,7 +7,16 @@ import { Props } from '../types';
 import React from 'react';
 
 export default class Null extends React.PureComponent<Props> {
+  componentDidMount () {
+    const { onChange } = this.props;
+
+    onChange && onChange({
+      isValid: true,
+      value: null
+    });
+  }
+
   render () {
-    return null;
+    return 'null goes here';
   }
 }

--- a/packages/ui-params/src/Param/Null.tsx
+++ b/packages/ui-params/src/Param/Null.tsx
@@ -1,0 +1,13 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Props } from '../types';
+
+import React from 'react';
+
+export default class Null extends React.PureComponent<Props> {
+  render () {
+    return null;
+  }
+}

--- a/packages/ui-params/src/Param/Null.tsx
+++ b/packages/ui-params/src/Param/Null.tsx
@@ -17,6 +17,6 @@ export default class Null extends React.PureComponent<Props> {
   }
 
   render () {
-    return 'null goes here';
+    return null;
   }
 }

--- a/packages/ui-params/src/Param/Static.tsx
+++ b/packages/ui-params/src/Param/Static.tsx
@@ -1,0 +1,39 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { WithTranslation } from 'react-i18next';
+import { Props as BareProps, RawParam } from '../types';
+
+import React from 'react';
+import { Static } from '@polkadot/ui-app';
+import translate from '@polkadot/ui-app/translate';
+
+import Bare from './Bare';
+
+type Props = BareProps & WithTranslation & {
+  defaultValue: RawParam,
+  withLabel?: boolean
+};
+
+class StaticParam extends React.PureComponent<Props> {
+  render () {
+    const { className, defaultValue, label, style, t } = this.props;
+    const value = defaultValue && defaultValue.value && defaultValue.value.toString();
+
+    return (
+      <Bare
+        className={className}
+        style={style}
+      >
+        <Static
+          className='full'
+          label={label}
+          value={value || t('empty')}
+        />
+      </Bare>
+    );
+  }
+}
+
+export default translate(StaticParam);

--- a/packages/ui-params/src/Param/Struct.tsx
+++ b/packages/ui-params/src/Param/Struct.tsx
@@ -1,0 +1,85 @@
+// Copyright 2017-2019 @polkadot/ui-app authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Props as BaseProps, RawParam } from '../types';
+
+import React from 'react';
+import { TypeDef, createType, getTypeDef } from '@polkadot/types';
+
+import Params from '../';
+import Base from './Base';
+import Static from './Static';
+
+type Props = BaseProps;
+
+type State = {
+  defs: Array<TypeDef>,
+  type: string | null
+};
+
+export default class StructParam extends React.PureComponent<Props, State> {
+  state: State = {
+    defs: [],
+    type: null
+  };
+
+  static getDerivedStateFromProps ({ type: { type } }: Props, prevState: State) {
+    if (prevState.type === type) {
+      return null;
+    }
+
+    const defs = getTypeDef(createType(type).toRawType()).sub as Array<TypeDef>;
+
+    return {
+      defs,
+      type
+    } as State;
+  }
+
+  render () {
+    const { className, isDisabled, label, style, withLabel } = this.props;
+
+    if (isDisabled) {
+      return <Static {...this.props} />;
+    }
+
+    const { defs } = this.state;
+    const params = defs.map((type) => ({ name: type.name, type }));
+
+    return (
+      <div>
+        <Base
+          className={className}
+          label={label}
+          size='full'
+          style={style}
+          withLabel={withLabel}
+        >
+          &nbsp;
+        </Base>
+        <Params
+          onChange={this.onChangeParams}
+          params={params}
+        />
+      </div>
+    );
+  }
+
+  private onChangeParams = (values: Array<RawParam>) => {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      const { defs } = this.state;
+
+      onChange({
+        isValid: values.reduce((result, { isValid }) => result && isValid, true as boolean),
+        value: defs.reduce((value, { name }, index) => {
+          value[name as string] = values[index].value;
+
+          return value;
+        }, {} as { [index: string]: any })
+      });
+    }
+  }
+}

--- a/packages/ui-params/src/Param/Unknown.tsx
+++ b/packages/ui-params/src/Param/Unknown.tsx
@@ -2,40 +2,24 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { WithTranslation } from 'react-i18next';
 import { Props as BareProps, RawParam } from '../types';
 
 import React from 'react';
-import { Static } from '@polkadot/ui-app';
-import translate from '@polkadot/ui-app/translate';
 
-import Bare from './Bare';
 import BaseBytes from './BaseBytes';
+import Static from './Static';
 
-type Props = BareProps & WithTranslation & {
+type Props = BareProps & {
   defaultValue: RawParam,
   withLabel?: boolean
 };
 
-class Unknown extends React.PureComponent<Props> {
+export default class Unknown extends React.PureComponent<Props> {
   render () {
-    const { className, defaultValue, isDisabled, isError, label, name, onChange, onEnter, style, t, type } = this.props;
+    const { className, defaultValue, isDisabled, isError, label, name, onChange, onEnter, style, type } = this.props;
 
     if (isDisabled) {
-      const value = defaultValue && defaultValue.value && defaultValue.value.toString();
-
-      return (
-        <Bare
-          className={className}
-          style={style}
-        >
-          <Static
-            className='full'
-            label={label}
-            value={value || t('empty')}
-          />
-        </Bare>
-      );
+      return <Static {...this.props} />;
     }
 
     return (
@@ -57,5 +41,3 @@ class Unknown extends React.PureComponent<Props> {
     );
   }
 }
-
-export default translate(Unknown);

--- a/packages/ui-params/src/Param/findComponent.ts
+++ b/packages/ui-params/src/Param/findComponent.ts
@@ -20,6 +20,7 @@ import Proposal from './Proposal';
 import KeyValue from './KeyValue';
 import KeyValueArray from './KeyValueArray';
 import Null from './Null';
+import Struct from './Struct';
 import Text from './Text';
 import Tuple from './Tuple';
 import Unknown from './Unknown';
@@ -47,6 +48,7 @@ const components: ComponentMap = ([
   { c: Null, t: ['Null'] },
   { c: Proposal, t: ['Proposal'] },
   { c: Text, t: ['String', 'Text'] },
+  { c: Struct, t: ['Struct'] },
   { c: Tuple, t: ['Tuple'] },
   { c: Vector, t: ['Vector'] },
   { c: Vote, t: ['Vote'] },
@@ -71,7 +73,7 @@ export default function findComponent (def: TypeDef, overrides: ComponentMap = {
         return 'Enum';
 
       case TypeDefInfo.Struct:
-        return 'Unknown';
+        return 'Struct';
 
       case TypeDefInfo.Tuple:
         return 'Tuple';

--- a/packages/ui-params/src/Param/findComponent.ts
+++ b/packages/ui-params/src/Param/findComponent.ts
@@ -2,8 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { TypeDef, TypeDefInfo, UInt, createType } from '@polkadot/types';
 import { Props, ComponentMap } from '../types';
+
+import BN from 'bn.js';
+import { TypeDef, TypeDefInfo, createType, getTypeDef } from '@polkadot/types';
 
 import Account from './Account';
 import Amount from './Amount';
@@ -11,11 +13,13 @@ import Balance from './Balance';
 import Bool from './Bool';
 import Bytes from './Bytes';
 import Code from './Code';
+import Enum from './Enum';
 import Hash from './Hash';
 import Moment from './Moment';
 import Proposal from './Proposal';
 import KeyValue from './KeyValue';
 import KeyValueArray from './KeyValueArray';
+import Null from './Null';
 import Text from './Text';
 import Tuple from './Tuple';
 import Unknown from './Unknown';
@@ -35,10 +39,12 @@ const components: ComponentMap = ([
   { c: Bool, t: ['bool'] },
   { c: Bytes, t: ['Bytes'] },
   { c: Code, t: ['Code'] },
+  { c: Enum, t: ['Enum'] },
   { c: Hash, t: ['CodeHash', 'Hash', 'SeedOf', 'Signature'] },
   { c: KeyValue, t: ['KeyValue'] },
   { c: KeyValueArray, t: ['Vec<KeyValue>'] },
   { c: Moment, t: ['Moment', 'MomentOf'] },
+  { c: Null, t: ['Null'] },
   { c: Proposal, t: ['Proposal'] },
   { c: Text, t: ['String', 'Text'] },
   { c: Tuple, t: ['Tuple'] },
@@ -59,6 +65,9 @@ export default function findComponent (def: TypeDef, overrides: ComponentMap = {
       case TypeDefInfo.Compact:
         return (sub as TypeDef).type;
 
+      case TypeDefInfo.Enum:
+        return 'Enum';
+
       case TypeDefInfo.Tuple:
         return 'Tuple';
 
@@ -78,9 +87,14 @@ export default function findComponent (def: TypeDef, overrides: ComponentMap = {
     try {
       const instance = createType(type);
 
-      if (instance instanceof UInt) {
+      if (instance instanceof BN) {
         return Amount;
       }
+
+      const raw = instance.toRawType();
+      const def = getTypeDef(raw);
+
+      return findComponent(def, overrides);
     } catch (error) {
       // console.error(error.message);
     }

--- a/packages/ui-params/src/Params.css
+++ b/packages/ui-params/src/Params.css
@@ -17,6 +17,10 @@
 .ui--Params-Content {
   box-sizing: border-box;
   padding: 0 0 0 1.75rem;
+
+  label .withEllipsis {
+    white-space: normal;
+  }
 }
 
 .ui--Param-text {

--- a/packages/ui-params/src/initValue.ts
+++ b/packages/ui-params/src/initValue.ts
@@ -17,8 +17,6 @@ function fromType (type: string): RawParam$Value | Array<RawParam$Value> {
   const raw = instance.toRawType();
   const def = getTypeDef(raw);
 
-  console.log('destructured', raw, def);
-
   if (def.info === TypeDefInfo.Enum) {
     const sdef = (def.sub as Array<TypeDef>)[0];
 
@@ -38,6 +36,8 @@ export default function getInitValue (def: TypeDef): RawParam$Value | Array<RawP
   } else if (def.info === TypeDefInfo.Struct) {
     console.error(`Unable to determine default type from Struct ${JSON.stringify(def)}`);
     return void 0;
+  } else if (def.info === TypeDefInfo.Option) {
+    return getInitValue(def.sub as TypeDef);
   }
 
   const type = def.info === TypeDefInfo.Compact

--- a/packages/ui-params/src/initValue.ts
+++ b/packages/ui-params/src/initValue.ts
@@ -15,8 +15,13 @@ export default function getInitValue (def: TypeDef): RawParam$Value | Array<RawP
       ? def.sub.map((def) => getInitValue(def))
       : [];
   } else if (def.info === TypeDefInfo.Struct) {
-    console.warn('Unable to determine default for Struct', def);
-    return void 0;
+    return Array.isArray(def.sub)
+      ? def.sub.reduce((result, def) => {
+        result[def.name as string] = getInitValue(def);
+
+        return result;
+      }, {} as { [index: string]: RawParam$Value | Array<RawParam$Value> })
+      : {};
   } else if (def.info === TypeDefInfo.Enum) {
     return Array.isArray(def.sub)
       ? { [def.sub[0].name as string]: getInitValue(def.sub[0]) }


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/546
- This uses deep object inspection via `toRawType` to build up the inputs for Enum, Struct & Option

Currently with Enums:

![image](https://user-images.githubusercontent.com/1424473/58904870-b3f24d00-8708-11e9-92fa-b7bc6a0777ca.png)

With this in place:

![image](https://user-images.githubusercontent.com/1424473/58904910-d5533900-8708-11e9-9c7a-4af6eb22ef68.png)

As a bonus, it also allows Option<Type> with proper inputs - however here there is no "None", it is always "Some":

![image](https://user-images.githubusercontent.com/1424473/58933994-56dab380-8769-11e9-9a30-b6d151734967.png)

For structs, the old bytes input is gone:

<img width="689" alt="Polkadot:Substrate Portal 2019-06-05 08-42-20" src="https://user-images.githubusercontent.com/1424473/58935718-4e38ac00-876e-11e9-9a5e-074b26328a47.png">
<img width="915" alt="Polkadot:Substrate Portal 2019-06-05 08-42-39" src="https://user-images.githubusercontent.com/1424473/58935739-5395f680-876e-11e9-8dfa-166f8264c7fb.png">
