### PR TITLE
Fix AddressRow cut

### DIFF
--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -422,6 +422,7 @@ export default withMulti(
       font-size: 1.25em;
       padding: 0;
       margin-bottom: 0.25rem;
+      white-space: nowrap;
     }
 
     .ui--AddressRow-accountIndex {
@@ -462,7 +463,6 @@ export default withMulti(
       flex: 1;
       margin-right: 1rem;
       padding: 0.25rem 0 0;
-      white-space: nowrap;
 
       * {
         vertical-align: middle;

--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -462,6 +462,7 @@ export default withMulti(
       flex: 1;
       margin-right: 1rem;
       padding: 0.25rem 0 0;
+      white-space: nowrap;
 
       * {
         vertical-align: middle;


### PR DESCRIPTION
There's no such thing as a too small PR.
Fixes that (visible in modals):
![image](https://user-images.githubusercontent.com/33178835/58979417-532d4800-87ce-11e9-8d2b-538662a89308.png)