### PR TITLE
Adjust AddressRow-buttons right margin

### DIFF
--- a/packages/ui-app/src/AddressRow.tsx
+++ b/packages/ui-app/src/AddressRow.tsx
@@ -450,7 +450,7 @@ export default withMulti(
 
     .ui--AddressRow-buttons {
       flex: 0;
-      margin: -0.75rem -0.75rem 0 0;
+      margin: -0.75rem -1.25rem 0 0;
       white-space: nowrap;
     }
 


### PR DESCRIPTION
First item fixed, second one the old version. Just make stuff consistent.

![image](https://user-images.githubusercontent.com/1424473/59048581-6d2a6180-8886-11e9-911a-0c22878cd400.png)
