### PR TITLE
Fix AddressMini padding on staking

### DIFF
--- a/packages/app-staking/src/index.css
+++ b/packages/app-staking/src/index.css
@@ -21,6 +21,7 @@
 }
 
 .staking--Address-info {
+  margin-right: 0.5rem;
   text-align: right;
 
   .staking--label {


### PR DESCRIPTION
- Caused by https://github.com/polkadot-js/apps/pull/1284

Screenshot show current vs adjusted:

<img width="612" alt="Polkadot:Substrate Portal 2019-06-07 09-24-42" src="https://user-images.githubusercontent.com/1424473/59087852-3005b400-8906-11e9-90e0-8399e0ae1d23.png">
