### PR TITLE
Add new snippet for api.query.balances.freeBalance.multi

### DIFF
--- a/packages/app-js/src/snippets/index.ts
+++ b/packages/app-js/src/snippets/index.ts
@@ -15,7 +15,8 @@ import {
   storageGetInfo,
   storageSystemEvents,
   storageListenToBalanceChange,
- storageRetrieveInfoOnQueryKeys
+  storageListenToMultipleBalancesChange,
+  storageRetrieveInfoOnQueryKeys
 } from './storage-examples';
 
 import { extrinsicMakeTransfer } from './extrinsics-examples';
@@ -28,6 +29,7 @@ const snippets: Array<Snippet> = [
   storageGetInfo,
   storageSystemEvents,
   storageListenToBalanceChange,
+  storageListenToMultipleBalancesChange,
   storageRetrieveInfoOnQueryKeys,
   extrinsicMakeTransfer
 ];

--- a/packages/app-js/src/snippets/storage-examples.ts
+++ b/packages/app-js/src/snippets/storage-examples.ts
@@ -85,6 +85,23 @@ api.query.balances.freeBalance(ALICE, (balance) => {
 });`
 };
 
+export const storageListenToMultipleBalancesChange: Snippet = {
+  value: 'storageListenToMultipleBalancesChange',
+  text: 'Listen to multiple balances changes',
+  label: { color: 'blue', children: 'Storage', size: 'tiny' },
+  code: `// You may leave this example running and make a transfer
+// of any value from or to Alice/Bob address in the 'Transfer' App
+const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+
+console.log('Tracking balances for:', [ALICE, BOB])
+
+// Subscribe and listen to several balance changes
+api.query.balances.freeBalance.multi([ALICE, BOB], (balance) => {
+  console.log('Change detected, new balances: ', balance)
+});`
+};
+
 export const storageRetrieveInfoOnQueryKeys: Snippet = {
   value: 'storageRetrieveInfoOnQueryKeys',
   text: 'Retrieve Info on query keys',


### PR DESCRIPTION
This PR adds a new snippet to the list:

It shows up as:
![image](https://user-images.githubusercontent.com/738724/59181787-76f2e400-8b68-11e9-941e-12330f23f3b6.png)


![image](https://user-images.githubusercontent.com/738724/59181898-a6a1ec00-8b68-11e9-8507-d0a83e0ab7b2.png)
