### PR TITLE
Bump deps (change use as required)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "packages/*"
   ],
   "resolutions": {
-    "@polkadot/api": "^0.81.0-beta.14",
+    "@polkadot/api": "^0.81.0-beta.15",
     "@polkadot/keyring": "^0.93.0-beta.5",
-    "@polkadot/types": "^0.81.0-beta.14",
+    "@polkadot/types": "^0.81.0-beta.15",
     "@polkadot/util": "^0.93.0-beta.5",
     "@polkadot/util-crypto": "^0.93.0-beta.5",
     "babel-core": "^7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "packages/*"
   ],
   "resolutions": {
-    "@polkadot/api": "^0.81.0-beta.11",
-    "@polkadot/keyring": "^0.93.0-beta.3",
-    "@polkadot/types": "^0.81.0-beta.11",
-    "@polkadot/util": "^0.93.0-beta.3",
-    "@polkadot/util-crypto": "^0.93.0-beta.3",
+    "@polkadot/api": "^0.81.0-beta.14",
+    "@polkadot/keyring": "^0.93.0-beta.5",
+    "@polkadot/types": "^0.81.0-beta.14",
+    "@polkadot/util": "^0.93.0-beta.5",
+    "@polkadot/util-crypto": "^0.93.0-beta.5",
     "babel-core": "^7.0.0-bridge.0",
     "typescript": "^3.5.1"
   },

--- a/packages/app-accounts/src/Account.tsx
+++ b/packages/app-accounts/src/Account.tsx
@@ -35,7 +35,7 @@ class Account extends React.PureComponent<Props> {
 
     this.state = {
       isBackupOpen: false,
-      isEditable: !(keyring.getAccount(props.address).getMeta().isInjected),
+      isEditable: !(keyring.getAccount(props.address).meta.isInjected),
       isForgetOpen: false,
       isPasswordOpen: false,
       isTransferOpen: false

--- a/packages/app-accounts/src/modals/ChangePass.tsx
+++ b/packages/app-accounts/src/modals/ChangePass.tsx
@@ -125,7 +125,7 @@ class ChangePass extends TxComponent<Props, State> {
       }
 
       try {
-        if (!account.isLocked()) {
+        if (!account.isLocked) {
           account.lock();
         }
 

--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -84,7 +84,7 @@ function rawValidate (seed: string): boolean {
 function addressFromSeed (phrase: string, derivePath: string, pairType: KeypairType): string {
   return keyring
     .createFromUri(`${phrase.trim()}${derivePath}`, {}, pairType)
-    .address();
+    .address;
 }
 
 class Create extends React.PureComponent<Props, State> {
@@ -416,14 +416,15 @@ class Create extends React.PureComponent<Props, State> {
     try {
       const { json, pair } = keyring.addUri(`${seed}${derivePath}`, password, { name, tags }, pairType);
       const blob = new Blob([JSON.stringify(json)], { type: 'application/json; charset=utf-8' });
+      const { address } = pair;
 
-      FileSaver.saveAs(blob, `${pair.address()}.json`);
+      FileSaver.saveAs(blob, `${address}.json`);
 
-      status.account = pair.address();
+      status.account = address;
       status.status = pair ? 'success' : 'error';
       status.message = t('created account');
 
-      InputAddress.setLastValue('account', pair.address());
+      InputAddress.setLastValue('account', address);
     } catch (error) {
       status.status = 'error';
       status.message = error.message;

--- a/packages/app-accounts/src/modals/Import.tsx
+++ b/packages/app-accounts/src/modals/Import.tsx
@@ -145,12 +145,13 @@ class Import extends TxComponent<Props, State> {
 
     try {
       const pair = keyring.restoreAccount(json, password);
+      const { address } = pair;
 
       status.status = pair ? 'success' : 'error';
-      status.account = pair.address();
+      status.account = address;
       status.message = t('account restored');
 
-      InputAddress.setLastValue('account', pair.address());
+      InputAddress.setLastValue('account', address);
     } catch (error) {
       this.setState({ isPassValid: false });
 

--- a/packages/app-address-book/src/Address.tsx
+++ b/packages/app-address-book/src/Address.tsx
@@ -78,7 +78,7 @@ class Address extends React.PureComponent<Props, State> {
     if (isForgetOpen) {
       modals.push(
         <Forget
-          address={current.address()}
+          address={current.address}
           onForget={this.onForget}
           key='modal-forget-account'
           mode='address'

--- a/packages/app-address-book/src/modals/Create.tsx
+++ b/packages/app-address-book/src/modals/Create.tsx
@@ -145,7 +145,7 @@ class Create extends React.PureComponent<Props, State> {
 
             if (old.isValid) {
               if (!allowEdit) {
-                name = old.getMeta().name || name;
+                name = old.meta.name || name;
               }
 
               isAddressExisting = true;

--- a/packages/app-contracts/src/Params.tsx
+++ b/packages/app-contracts/src/Params.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { ContractABIArgs } from '@polkadot/types/ContractAbi';
+import { ContractABIFn$Arg } from '@polkadot/types/ContractAbi';
 import { RawParams } from '@polkadot/ui-params/types';
 
 import React from 'react';
@@ -11,7 +11,7 @@ import { getTypeDef, TypeDef } from '@polkadot/types';
 
 type Props = {
   isDisabled?: boolean,
-  params?: ContractABIArgs,
+  params?: Array<ContractABIFn$Arg>,
   onChange: (values: Array<any>) => void,
   onEnter?: () => void
 };

--- a/packages/app-staking/src/Actions/Accounts.tsx
+++ b/packages/app-staking/src/Actions/Accounts.tsx
@@ -56,18 +56,14 @@ class Accounts extends React.PureComponent<Props,State> {
         }
       >
         {this.renderNewStake()}
-        {accounts.map((account, index) => {
-          const address = account.address();
-
-          return (
-            <Account
-              accountId={address}
-              key={index}
-              recentlyOffline={recentlyOffline}
-              stashOptions={stashOptions}
-            />
-          );
-        })}
+        {accounts.map(({ address }, index) => (
+          <Account
+            accountId={address}
+            key={index}
+            recentlyOffline={recentlyOffline}
+            stashOptions={stashOptions}
+          />
+        ))}
       </Wrapper>
     );
   }

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -155,9 +155,7 @@ class Address extends React.PureComponent<Props, State> {
 
   private iNominated () {
     const nominators = this.getNominators();
-    const myAddresses = keyring.getAccounts().map((acc) =>
-      acc.address()
-    );
+    const myAddresses = keyring.getAccounts().map(({ address }) => address);
 
     return nominators.some(([who]) =>
       myAddresses.includes(who.toString())

--- a/packages/app-toolbox/src/Sign.tsx
+++ b/packages/app-toolbox/src/Sign.tsx
@@ -67,7 +67,7 @@ class Sign extends React.PureComponent<Props, State> {
       data: '',
       isHexData: false,
       isLocked: currentPair
-        ? currentPair.isLocked()
+        ? currentPair.isLocked
         : false,
       isUnlockVisible: false,
       signature: ''
@@ -203,7 +203,7 @@ class Sign extends React.PureComponent<Props, State> {
     this.setState(
       (prevState: State): State => {
         const { currentPair = prevState.currentPair, data = prevState.data, isHexData = prevState.isHexData, isUnlockVisible = prevState.isUnlockVisible } = newState;
-        const isLocked = !currentPair || currentPair.isLocked();
+        const isLocked = !currentPair || currentPair.isLocked;
         let signature = '';
 
         if (!isLocked && currentPair) {

--- a/packages/app-toolbox/src/Unlock.tsx
+++ b/packages/app-toolbox/src/Unlock.tsx
@@ -30,9 +30,7 @@ class Unlock extends TxComponent<Props, State> {
 
   static getDerivedStateFromProps ({ pair }: Props): State {
     return {
-      address: pair
-        ? pair.address()
-        : ''
+      address: (pair && pair.address) || ''
     } as State;
   }
 
@@ -111,7 +109,7 @@ class Unlock extends TxComponent<Props, State> {
   private unlockAccount (password?: string): string | null {
     const { pair } = this.props;
 
-    if (!pair || !pair.isLocked()) {
+    if (!pair || !pair.isLocked) {
       return null;
     }
 

--- a/packages/app-toolbox/src/Verify.tsx
+++ b/packages/app-toolbox/src/Verify.tsx
@@ -44,7 +44,7 @@ class Verify extends React.PureComponent<Props, State> {
     const pairs = keyring.getPairs();
     const currentPair = pairs[0];
     const currentPublicKey = currentPair
-      ? currentPair.publicKey()
+      ? currentPair.publicKey
       : null;
 
     this.state = {

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-app": "^0.34.0-beta.11",
-    "@polkadot/ui-assets": "^0.41.0-beta.5",
+    "@polkadot/ui-assets": "^0.41.0-beta.6",
     "@polkadot/ui-signer": "^0.34.0-beta.11"
   }
 }

--- a/packages/ui-api/package.json
+++ b/packages/ui-api/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-reactive#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/api": "^0.81.0-beta.11",
-    "@polkadot/extension-dapp": "^0.1.1-beta.26",
+    "@polkadot/api": "^0.81.0-beta.14",
+    "@polkadot/extension-dapp": "^0.1.1-beta.27",
     "rxjs-compat": "^6.4.0"
   }
 }

--- a/packages/ui-api/package.json
+++ b/packages/ui-api/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-reactive#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/api": "^0.81.0-beta.14",
+    "@polkadot/api": "^0.81.0-beta.15",
     "@polkadot/extension-dapp": "^0.1.1-beta.27",
     "rxjs-compat": "^6.4.0"
   }

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/ui-api": "^0.34.0-beta.11",
-    "@polkadot/ui-identicon": "^0.41.0-beta.5",
-    "@polkadot/ui-keyring": "^0.41.0-beta.5",
+    "@polkadot/ui-identicon": "^0.41.0-beta.6",
+    "@polkadot/ui-keyring": "^0.41.0-beta.6",
     "@polkadot/ui-reactive": "^0.34.0-beta.11",
-    "@polkadot/ui-settings": "^0.41.0-beta.5",
+    "@polkadot/ui-settings": "^0.41.0-beta.6",
     "@types/chart.js": "^2.7.53",
     "@types/classnames": "^2.2.7",
     "@types/i18next": "^12.1.0",

--- a/packages/ui-app/src/CryptoType.tsx
+++ b/packages/ui-app/src/CryptoType.tsx
@@ -26,7 +26,7 @@ export default class CryptoType extends React.PureComponent<Props> {
         : null;
 
       if (current) {
-        type = current.getMeta().isInjected
+        type = current.meta.isInjected
           ? 'injected'
           : current.type;
       }

--- a/packages/ui-app/src/InputAddress.tsx
+++ b/packages/ui-app/src/InputAddress.tsx
@@ -71,10 +71,10 @@ const createOption = (address: string) => {
   let name: string | undefined;
 
   try {
-    name = keyring.getAccount(address).getMeta().name;
+    name = keyring.getAccount(address).meta.name;
   } catch (error) {
     try {
-      const meta = keyring.getAddress(address).getMeta();
+      const meta = keyring.getAddress(address).meta;
 
       name = meta.name;
       isRecent = meta.isRecent;

--- a/packages/ui-app/src/util/getAddressName.ts
+++ b/packages/ui-app/src/util/getAddressName.ts
@@ -15,8 +15,8 @@ export default function getAddressName (address: string, type: KeyringItemType |
     // all-ok, we have empty fallbacks
   }
 
-  const name = pair && pair.isValid()
-    ? pair.getMeta().name
+  const name = pair && pair.isValid
+    ? pair.meta.name
     : defaultName;
 
   return !name && withShort

--- a/packages/ui-app/src/util/getAddressTags.ts
+++ b/packages/ui-app/src/util/getAddressTags.ts
@@ -14,5 +14,5 @@ export default function getAddressTags (address: string, type: KeyringItemType |
     // all-ok, we have empty fallbacks
   }
 
-  return (pair && pair.isValid() && pair.getMeta().tags) || [];
+  return (pair && pair.isValid && pair.meta.tags) || [];
 }

--- a/packages/ui-app/src/util/getContractAbi.ts
+++ b/packages/ui-app/src/util/getContractAbi.ts
@@ -16,10 +16,8 @@ export default function getContractAbi (address: string): ContractAbi | null {
 
   return (
     pair &&
-    pair.isValid() &&
-    pair.getMeta().contract &&
-    new ContractAbi(
-      JSON.parse(pair.getMeta().contract!.abi)
-    )
+    pair.isValid &&
+    pair.meta.contract &&
+    new ContractAbi(JSON.parse(pair.meta.contract.abi))
   ) || null;
 }

--- a/packages/ui-signer/src/Modal.tsx
+++ b/packages/ui-signer/src/Modal.tsx
@@ -191,7 +191,7 @@ class Signer extends React.PureComponent<Props, State> {
 
     const pair = keyring.getPair(publicKey);
 
-    if (!pair.isLocked() || pair.getMeta().isInjected) {
+    if (!pair.isLocked || pair.meta.isInjected) {
       return null;
     }
 
@@ -321,9 +321,8 @@ class Signer extends React.PureComponent<Props, State> {
 
     if (pair) {
       // set the signer
-      if (pair.getMeta().isInjected) {
-        const source = pair.getMeta().source;
-        const address = pair.address();
+      if (pair.meta.isInjected) {
+        const { address, meta: { source } } = pair;
         const injected = await web3FromSource(source);
 
         assert(injected, `Unable to find a signer for ${address}`);

--- a/packages/ui-signer/src/Unlock.tsx
+++ b/packages/ui-signer/src/Unlock.tsx
@@ -40,8 +40,7 @@ class Unlock extends React.PureComponent<Props, State> {
       return null;
     }
 
-    const isLocked = pair.isLocked();
-    const isInjected = pair.getMeta().isInjected || false;
+    const { isLocked, meta: { isInjected = false } } = pair;
 
     return {
       isError: !!error,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,30 +1842,30 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@polkadot/api-derive@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.81.0-beta.11.tgz#832263162a163ce148341112e32df458ae0f7077"
-  integrity sha512-NlH4CkdQhCmndjH1S0hhxoBHJk75C7B3wJbCyXciUyfDe0SU8HS4lfp1B9m138mYuit6jASDjcN+SU77HlWa8g==
+"@polkadot/api-derive@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.81.0-beta.14.tgz#125c11337aa24e1ba290ba09e316aa676eddf4b8"
+  integrity sha512-y8I94P/Y95UN7ixO8Ho3fcOFN+zlTBg39G+uRg3dxEm7pPcU2eT8UMl/l1uS66Xc/hCezBp7ze+ur7MBKHTgNw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/api" "^0.81.0-beta.11"
-    "@polkadot/types" "^0.81.0-beta.11"
+    "@polkadot/api" "^0.81.0-beta.14"
+    "@polkadot/types" "^0.81.0-beta.14"
     "@types/memoizee" "^0.4.2"
     memoizee "^0.4.14"
 
-"@polkadot/api@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.81.0-beta.11.tgz#f4a8876d02acc58914a57ab5154127fb52a3cdfa"
-  integrity sha512-2Ls8K0nVbwBvnX8iIw9XuKq/x34NUXzA3yytckKQ6L0P/eXD7pl8tVkGCH+tyDntGeUcorIDvk4DtPJL7npgqA==
+"@polkadot/api@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.81.0-beta.14.tgz#233223a7cdac1c4853c43ec8973f6545d5ea159b"
+  integrity sha512-2z7W06UHJHggIlQwKyGUvz/ZbaXBoE5wA/ChgBI63vSn7qA+EWzCn4swAZlO9tcIm9DSgtAGHSrUGn6i3wHDAw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/api-derive" "^0.81.0-beta.11"
-    "@polkadot/extrinsics" "^0.81.0-beta.11"
-    "@polkadot/rpc-provider" "^0.81.0-beta.11"
-    "@polkadot/rpc-rx" "^0.81.0-beta.11"
-    "@polkadot/storage" "^0.81.0-beta.11"
-    "@polkadot/types" "^0.81.0-beta.11"
-    "@polkadot/util-crypto" "^0.93.0-beta.3"
+    "@polkadot/api-derive" "^0.81.0-beta.14"
+    "@polkadot/extrinsics" "^0.81.0-beta.14"
+    "@polkadot/rpc-provider" "^0.81.0-beta.14"
+    "@polkadot/rpc-rx" "^0.81.0-beta.14"
+    "@polkadot/storage" "^0.81.0-beta.14"
+    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/util-crypto" "^0.93.0-beta.5"
 
 "@polkadot/dev-react@^0.30.0-beta.13":
   version "0.30.0-beta.13"
@@ -1940,85 +1940,85 @@
     typescript "^3.5.1"
     vuepress "^1.0.1"
 
-"@polkadot/extension-dapp@^0.1.1-beta.26":
-  version "0.1.1-beta.26"
-  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.1.1-beta.26.tgz#405573c69962968bc9280162cc91e42c6f347dfd"
-  integrity sha512-1e81AhUz9lUNgpyl+3zCdJyF+4P77YvLxvWIYS3S7k0usZlZsH48n9r6BpQqBquhFARCMO7kX1/JIBw5WW5bMQ==
+"@polkadot/extension-dapp@^0.1.1-beta.27":
+  version "0.1.1-beta.27"
+  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.1.1-beta.27.tgz#0373f2c8ee75011619258cd52e1f068b001d9931"
+  integrity sha512-2bZYVRnXIa9Q0fMJFBCRDFtwCEULs5tVvjJmHCMBx5yUjjwqAK4g+Iednr9L2qs3Ru1XO/MVrJ0ofxRVYMfjGw==
 
-"@polkadot/extrinsics@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.81.0-beta.11.tgz#bfa7ac6b8524318bde20d80aa4c2dd0f4c4fb150"
-  integrity sha512-J8NzGq0yjcJhRqFCMKw5+crULLdR4aX/HVcEqW4rtBFRlyD6wBP0ykTMyWza+NEvmh7BqjCHjPZkfJfBW1ShIw==
+"@polkadot/extrinsics@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.81.0-beta.14.tgz#a8c7ecc78b4b6b5497b9c1e540aff1019ad8404a"
+  integrity sha512-x2oCTraJLSckecB+gBJGn4kt+Bht+ObY9NlDD/KOpEYJj/n/nEnTYBi5mI3r0tJBnb1svpOV0uaGjp1TZSdkpg==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/types" "^0.81.0-beta.11"
-    "@polkadot/util" "^0.93.0-beta.3"
+    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/util" "^0.93.0-beta.5"
 
-"@polkadot/jsonrpc@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.81.0-beta.11.tgz#92934f08fba6a266fac5f6139780d26226c92edc"
-  integrity sha512-Fui1DxoBXTCgDsie/D4frbS5E27hIL4cvzIHmHudgwoqep+dHJ/iF2XG9MGopBKNalnAfvV/WFWAmU96N/18Dw==
+"@polkadot/jsonrpc@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.81.0-beta.14.tgz#f6853f2c06345d0cad02d5adeaae2c1b5385d159"
+  integrity sha512-xiVtq6BlyW0MCJlTqdcx1u6wBn7siDhLey+ZQKTIL6xLmsHkzniucyJ5KoD5ocMord1PhT9b4T0pQc+6mFhYGQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-"@polkadot/keyring@^0.93.0-beta.3":
-  version "0.93.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.93.0-beta.3.tgz#3d980c6546e4b7f49b83a621621412f1d322db1b"
-  integrity sha512-mjU1mycuIOdXgbwDVlVwnojaBxtfraoiKvilG14EvG5bCMEQoGU3jUdOTXQs7v1bhrjmrXFMfixaZlco394Gow==
+"@polkadot/keyring@^0.93.0-beta.5":
+  version "0.93.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.93.0-beta.5.tgz#581cedb279ce718026a5d901065293d4193dfbe9"
+  integrity sha512-NHNVyn1DmpD6yN06caHdkmrrhQIh/bvs87DlnsjsGA2PccQFH+UO315Qa3eNmueZorCzyIKTsOYBpY1lwehqSw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.0-beta.3"
-    "@polkadot/util-crypto" "^0.93.0-beta.3"
+    "@polkadot/util" "^0.93.0-beta.5"
+    "@polkadot/util-crypto" "^0.93.0-beta.5"
     "@types/bs58" "^4.0.0"
     bs58 "^4.0.1"
 
-"@polkadot/rpc-core@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.81.0-beta.11.tgz#c68909b986bb4eefe566ff8620939c38d6ddcb30"
-  integrity sha512-DqjroMP6D4GG6vsYNEvh5sqr6qlcnd3cUXV3RCtC149SAJ2bUmJxhxhignVjWpcDXeqvHslshVlYl49srMRAHA==
+"@polkadot/rpc-core@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.81.0-beta.14.tgz#52210c139e3aba0b1086298300c691310327189a"
+  integrity sha512-YKEL0NMjmscju1SwYDNw05mVdE8B3blmBNwGSHe/mNQ4FBqt1XUvOEPOF7uinFEyRcTBL6WdKWepNWCfFTnfAQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/jsonrpc" "^0.81.0-beta.11"
-    "@polkadot/rpc-provider" "^0.81.0-beta.11"
-    "@polkadot/types" "^0.81.0-beta.11"
-    "@polkadot/util" "^0.93.0-beta.3"
+    "@polkadot/jsonrpc" "^0.81.0-beta.14"
+    "@polkadot/rpc-provider" "^0.81.0-beta.14"
+    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/util" "^0.93.0-beta.5"
 
-"@polkadot/rpc-provider@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.81.0-beta.11.tgz#c46ca99efdd47c0009d64cadd22745ac64cf3034"
-  integrity sha512-xenZMYQIIJxZu5j1LO2IafZBQiEjTmgkegJ6H8EFAzq5K9wnhQbr0oH6q4HZemmzt/Fz5AT/H+5SBexMqgmb3A==
+"@polkadot/rpc-provider@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.81.0-beta.14.tgz#521d0084ecbd4cc538ecdcfb42d4c64180708665"
+  integrity sha512-KcVy39rfaX1iB5WfN4UzZcEJ+sW6adL5vD4ytlTbUqyzXott2c4AAfv+HBXa7JKkcUdVEZ/i28y6mP/3Qkkyqw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/storage" "^0.81.0-beta.11"
-    "@polkadot/util" "^0.93.0-beta.3"
-    "@polkadot/util-crypto" "^0.93.0-beta.3"
+    "@polkadot/storage" "^0.81.0-beta.14"
+    "@polkadot/util" "^0.93.0-beta.5"
+    "@polkadot/util-crypto" "^0.93.0-beta.5"
     "@types/nock" "^10.0.3"
     eventemitter3 "^3.1.0"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.28"
 
-"@polkadot/rpc-rx@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.81.0-beta.11.tgz#59052a2c2f6b40d2b36999abee04dd029aa065be"
-  integrity sha512-BH4Fqszg3OjOnkWClfG0V+1QXuXBOpIu1FcmD1VB1AUkrrn0mRldRuTig3s1YKlyu3vtP4srSXFPxBOZet6LvQ==
+"@polkadot/rpc-rx@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.81.0-beta.14.tgz#ee14b1cd89bb8fa38936650436fd19701e3fca79"
+  integrity sha512-DFqqDGw4m/unF1TNlI52A951Grr4vBZhscuYSVaO+xcGw6Z43l/FmKAV797rAMtoAkgxeaHlX6Xoulc8IdkHkQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/rpc-core" "^0.81.0-beta.11"
-    "@polkadot/rpc-provider" "^0.81.0-beta.11"
+    "@polkadot/rpc-core" "^0.81.0-beta.14"
+    "@polkadot/rpc-provider" "^0.81.0-beta.14"
     "@types/memoizee" "^0.4.2"
     "@types/rx" "^4.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.2"
 
-"@polkadot/storage@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.81.0-beta.11.tgz#dff59886a00c71889a9ff21046018bd00bcf0275"
-  integrity sha512-r5wPCFTt4GTDYClOYQ6L0gny/ayCYIBCIoIsypWl97r4UyRyHqfYQcftkjgAHVOMMKm97mu2RVFEQgWL1DsiIA==
+"@polkadot/storage@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.81.0-beta.14.tgz#7580de9a04223e70fe017a79a65f2899e3bddf99"
+  integrity sha512-5gjIK7A+YwlU2AwOEk8wVaKXbStl8+9Fnwk4DVs4IQOQeoHS7h6gEvBmtTlJ5u7sQLdUn+PXcWGNFikOkG3EsQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/types" "^0.81.0-beta.11"
-    "@polkadot/util" "^0.93.0-beta.3"
-    "@polkadot/util-crypto" "^0.93.0-beta.3"
+    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/util" "^0.93.0-beta.5"
+    "@polkadot/util-crypto" "^0.93.0-beta.5"
 
 "@polkadot/ts@^0.1.60":
   version "0.1.60"
@@ -2027,29 +2027,29 @@
   dependencies:
     "@types/chrome" "^0.0.86"
 
-"@polkadot/types@^0.81.0-beta.11":
-  version "0.81.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.81.0-beta.11.tgz#a0730b007f7577a7ad5558d504f8ffb759ce56a8"
-  integrity sha512-v97TppKi/vInhvK7p7REqcflWDh67OVliviHcm8/WckiRbACIpMlbATGNvTjxfygyEBkwZPviAQkpGw7ZlSWPg==
+"@polkadot/types@^0.81.0-beta.14":
+  version "0.81.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.81.0-beta.14.tgz#fc0693a60ce2eef5ece72676b04bad567b74be15"
+  integrity sha512-KkmeZUgwMuO10QxzpgTGyi7nRiNoJeeAG7MtVEtRlWjUrIAhjAzdxWgy/hoYycxs7hRHCWmSiDloomde9/zF+w==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.0-beta.3"
-    "@polkadot/util-crypto" "^0.93.0-beta.3"
+    "@polkadot/util" "^0.93.0-beta.5"
+    "@polkadot/util-crypto" "^0.93.0-beta.5"
 
-"@polkadot/ui-assets@^0.41.0-beta.5":
-  version "0.41.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.41.0-beta.5.tgz#a3d284765d8773074dcbd4f151fe9d8bca08d5b2"
-  integrity sha512-lZ2N1IH2rztDbY91ml9xZfDEgFgQzXJmbGT+U6dStodd1yczgRfMcl7fQmtmXFHbUKomIymrt59UIcdo0KOxag==
+"@polkadot/ui-assets@^0.41.0-beta.6":
+  version "0.41.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.41.0-beta.6.tgz#2f1d30f0c30c64d10538250b4dff611699b4646d"
+  integrity sha512-l7EiuBtxOlULSgO2JlS1SFZvfAlI06w/AfcOa1AZ2LWxSTJpSITC+9Te3IpWztzB4VTtNkxJdHuYmLvrrr8lUg==
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-"@polkadot/ui-identicon@^0.41.0-beta.5":
-  version "0.41.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.41.0-beta.5.tgz#3abf27c8e4a7a242f2fbc00dbb96a09a13862fd3"
-  integrity sha512-FbdXyDR6jcPInnVZjUv2P21Zi2jPG2z5uXnOm09UcUQzbkjjrgc1oI9Dzb7pzcRPaDjl0zNVGK9bl4MTbMTuAA==
+"@polkadot/ui-identicon@^0.41.0-beta.6":
+  version "0.41.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.41.0-beta.6.tgz#af79a87bc790b9c92f1a7cc53e00cd2120e9edba"
+  integrity sha512-WenjHLELfZM9rUsmwoFIqzIKof0Sd/w9aSKv2cNDuWv/yMPMxAgC/qr/bf/ns2rOKbAL6ncxyCU+P78XahiIGQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/ui-settings" "^0.41.0-beta.5"
+    "@polkadot/ui-settings" "^0.41.0-beta.6"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.1.2"
@@ -2057,10 +2057,10 @@
     react-copy-to-clipboard "^5.0.1"
     styled-components "^4.3.1"
 
-"@polkadot/ui-keyring@^0.41.0-beta.5":
-  version "0.41.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.41.0-beta.5.tgz#9a8b1e95294e62ab274330ac95b593560e9ae210"
-  integrity sha512-7abYGkCcT2icdNg48S/BqdtmS+jirEO6lPqOgzrRZ5JPobQLxKZQ8aq/1zZgJS4DcY0NW5tDVtlT7MvAPk6YRQ==
+"@polkadot/ui-keyring@^0.41.0-beta.6":
+  version "0.41.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.41.0-beta.6.tgz#1eadfe137d2d662f1023b7400f4da7c58836afa9"
+  integrity sha512-yuF0KeTsrsWnmLcmQYFWACipg4ndFNPggFWvsu7LRY1j+rUOMY6kFywQ6pce2jnTy6Z7iVGn7onvkuA9D84P1g==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/mkdirp" "^0.5.2"
@@ -2070,22 +2070,22 @@
     store "^2.0.12"
     styled-components "^4.3.1"
 
-"@polkadot/ui-settings@^0.41.0-beta.5":
-  version "0.41.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.41.0-beta.5.tgz#8d22d08ca6485339d8ae29b0d162401afa236ca6"
-  integrity sha512-7L3Twpqcty8EzQyPsDkDl0MdncdHTk/T6HDl0dzBDAEEGlK1/K7wziZSaBJX4TMSz8gU+t7kpf5KJx/64EtCvg==
+"@polkadot/ui-settings@^0.41.0-beta.6":
+  version "0.41.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.41.0-beta.6.tgz#2cc9b171bac7fde633cce63387ee1e7854606264"
+  integrity sha512-cKN881bezE1+SuDrVakyq7466OuidkPBw2urcJWgNA3jgdZcvfcs/rsJ/1oEg6ZQfQ7BrQ1WsLZd1YS6PChe6g==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/store" "^2.0.2"
     store "^2.0.12"
 
-"@polkadot/util-crypto@^0.93.0-beta.3":
-  version "0.93.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.93.0-beta.3.tgz#8d590c18fa7cd72042a53d6a79332f1fcac98758"
-  integrity sha512-o6K36gz47Zuqd1e//sNmx5axGCMJrZRJMgXZQgSXPBgb423JFR3IZYZVqQx+r+k5xTqH6t9VhXfv55jE5YyFiA==
+"@polkadot/util-crypto@^0.93.0-beta.5":
+  version "0.93.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.93.0-beta.5.tgz#81a399395825b22d532d3834c12e143112564cd5"
+  integrity sha512-GntTfbZd2qfIo1GdYTHtimuDhQIiexiLaQ3/qfShAZ3BP1QiVHx6yYFngMPkEKnebx7rgowT4g0yH1ztf35WiQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.0-beta.3"
+    "@polkadot/util" "^0.93.0-beta.5"
     "@polkadot/wasm-crypto" "^0.11.1"
     "@types/bip39" "^2.4.2"
     "@types/pbkdf2" "^3.0.0"
@@ -2098,10 +2098,10 @@
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^0.93.0-beta.3":
-  version "0.93.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.93.0-beta.3.tgz#6334ab1026f743f3a4f45740091066ee8041aff7"
-  integrity sha512-rFRcT8OHXNvx+tGMeDRZOAoeGguiRVsEk5+MYXViq0sjuK+YWioWmDEN+HiiqBB2Qih0BQ+UEZ63MXqZAwH2vg==
+"@polkadot/util@^0.93.0-beta.5":
+  version "0.93.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.93.0-beta.5.tgz#c0b27459fdf4848382403b924698f1b012df8c88"
+  integrity sha512-dhJ56+5dYAAz45rdc5AqvFGI1qeQ8qTGiFbiE9S+ZXimEU/3mR1LRcq8nMx4aeZaC3blrReuAmzTxLS2c6aOsw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/bn.js" "^4.11.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,29 +1842,29 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@polkadot/api-derive@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.81.0-beta.14.tgz#125c11337aa24e1ba290ba09e316aa676eddf4b8"
-  integrity sha512-y8I94P/Y95UN7ixO8Ho3fcOFN+zlTBg39G+uRg3dxEm7pPcU2eT8UMl/l1uS66Xc/hCezBp7ze+ur7MBKHTgNw==
+"@polkadot/api-derive@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-0.81.0-beta.15.tgz#d1917b9ccea9fcdf53c5e914b8a04a97db803b28"
+  integrity sha512-7Rft0VrGKi3XcZ9Q+1GpNkpAKZ4qRScSCXO5NMA72qg/+j4bKtlTSra7qmqnT50Y1kkzGASdrFUYqKG3gWp7dA==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/api" "^0.81.0-beta.14"
-    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/api" "^0.81.0-beta.15"
+    "@polkadot/types" "^0.81.0-beta.15"
     "@types/memoizee" "^0.4.2"
     memoizee "^0.4.14"
 
-"@polkadot/api@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.81.0-beta.14.tgz#233223a7cdac1c4853c43ec8973f6545d5ea159b"
-  integrity sha512-2z7W06UHJHggIlQwKyGUvz/ZbaXBoE5wA/ChgBI63vSn7qA+EWzCn4swAZlO9tcIm9DSgtAGHSrUGn6i3wHDAw==
+"@polkadot/api@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-0.81.0-beta.15.tgz#ebceadf89468f0b803f5f34ba88d502dff54e7b5"
+  integrity sha512-s68wacOHzX6od4ih+yNyJpV6cWSPry7LGsuUC0CYFtUNJUhwXup7oi9lBkh2OyJs0ezAccyOiHdBI+QPh1Z//g==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/api-derive" "^0.81.0-beta.14"
-    "@polkadot/extrinsics" "^0.81.0-beta.14"
-    "@polkadot/rpc-provider" "^0.81.0-beta.14"
-    "@polkadot/rpc-rx" "^0.81.0-beta.14"
-    "@polkadot/storage" "^0.81.0-beta.14"
-    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/api-derive" "^0.81.0-beta.15"
+    "@polkadot/extrinsics" "^0.81.0-beta.15"
+    "@polkadot/rpc-provider" "^0.81.0-beta.15"
+    "@polkadot/rpc-rx" "^0.81.0-beta.15"
+    "@polkadot/storage" "^0.81.0-beta.15"
+    "@polkadot/types" "^0.81.0-beta.15"
     "@polkadot/util-crypto" "^0.93.0-beta.5"
 
 "@polkadot/dev-react@^0.30.0-beta.13":
@@ -1945,19 +1945,19 @@
   resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.1.1-beta.27.tgz#0373f2c8ee75011619258cd52e1f068b001d9931"
   integrity sha512-2bZYVRnXIa9Q0fMJFBCRDFtwCEULs5tVvjJmHCMBx5yUjjwqAK4g+Iednr9L2qs3Ru1XO/MVrJ0ofxRVYMfjGw==
 
-"@polkadot/extrinsics@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.81.0-beta.14.tgz#a8c7ecc78b4b6b5497b9c1e540aff1019ad8404a"
-  integrity sha512-x2oCTraJLSckecB+gBJGn4kt+Bht+ObY9NlDD/KOpEYJj/n/nEnTYBi5mI3r0tJBnb1svpOV0uaGjp1TZSdkpg==
+"@polkadot/extrinsics@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/extrinsics/-/extrinsics-0.81.0-beta.15.tgz#b6e62f06f9721db7e7f3fd67480f3bf46fc7719f"
+  integrity sha512-/OyrEyyh5NTTn7UjOX61SjnznKZdvti1btw+vUHMZU4/uhlRPf0spkazc9YJdW9idSl48eV9xpu2fLiEfkqKKg==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/types" "^0.81.0-beta.15"
     "@polkadot/util" "^0.93.0-beta.5"
 
-"@polkadot/jsonrpc@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.81.0-beta.14.tgz#f6853f2c06345d0cad02d5adeaae2c1b5385d159"
-  integrity sha512-xiVtq6BlyW0MCJlTqdcx1u6wBn7siDhLey+ZQKTIL6xLmsHkzniucyJ5KoD5ocMord1PhT9b4T0pQc+6mFhYGQ==
+"@polkadot/jsonrpc@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-0.81.0-beta.15.tgz#84ae35bdad35198c324a5249daf093d858e052f4"
+  integrity sha512-R+gKOPHIMoTGF5O3YzDHIfSZoyqFe4WB6Gx+mM6WFGi1vD1cPH/hq86kGDZQwm2PJRdLeSHhaZ8ZHUkHwThNug==
   dependencies:
     "@babel/runtime" "^7.4.5"
 
@@ -1972,24 +1972,24 @@
     "@types/bs58" "^4.0.0"
     bs58 "^4.0.1"
 
-"@polkadot/rpc-core@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.81.0-beta.14.tgz#52210c139e3aba0b1086298300c691310327189a"
-  integrity sha512-YKEL0NMjmscju1SwYDNw05mVdE8B3blmBNwGSHe/mNQ4FBqt1XUvOEPOF7uinFEyRcTBL6WdKWepNWCfFTnfAQ==
+"@polkadot/rpc-core@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-0.81.0-beta.15.tgz#74b7b913172c66c40611fc92f3aacd79deeb3524"
+  integrity sha512-wuZQYzq2ovCl7p0WV+0Q7KoFVZRxI5KGj+TJcqwq2OjFkRKRuQxtfbEcW13uLv9L22AbRhe7dH6AyOM/302umQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/jsonrpc" "^0.81.0-beta.14"
-    "@polkadot/rpc-provider" "^0.81.0-beta.14"
-    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/jsonrpc" "^0.81.0-beta.15"
+    "@polkadot/rpc-provider" "^0.81.0-beta.15"
+    "@polkadot/types" "^0.81.0-beta.15"
     "@polkadot/util" "^0.93.0-beta.5"
 
-"@polkadot/rpc-provider@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.81.0-beta.14.tgz#521d0084ecbd4cc538ecdcfb42d4c64180708665"
-  integrity sha512-KcVy39rfaX1iB5WfN4UzZcEJ+sW6adL5vD4ytlTbUqyzXott2c4AAfv+HBXa7JKkcUdVEZ/i28y6mP/3Qkkyqw==
+"@polkadot/rpc-provider@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-0.81.0-beta.15.tgz#2c3fd352d66f67cec00ca4c6551c9e2c4750978c"
+  integrity sha512-8Cj9YCI6d+2bFohFni7mP7QLK82IPFTI0ZsN59Uz46kI6QXx1vQhT2BXbvKNqc3kWQKrRoewKMISC3SdZM72Mw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/storage" "^0.81.0-beta.14"
+    "@polkadot/storage" "^0.81.0-beta.15"
     "@polkadot/util" "^0.93.0-beta.5"
     "@polkadot/util-crypto" "^0.93.0-beta.5"
     "@types/nock" "^10.0.3"
@@ -1997,26 +1997,26 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.28"
 
-"@polkadot/rpc-rx@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.81.0-beta.14.tgz#ee14b1cd89bb8fa38936650436fd19701e3fca79"
-  integrity sha512-DFqqDGw4m/unF1TNlI52A951Grr4vBZhscuYSVaO+xcGw6Z43l/FmKAV797rAMtoAkgxeaHlX6Xoulc8IdkHkQ==
+"@polkadot/rpc-rx@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-rx/-/rpc-rx-0.81.0-beta.15.tgz#16344ae9b0add420fb2dde53f42d5bbdafd61b0c"
+  integrity sha512-B6Bi3P9Bnd8jg3HfQdpbS/fEbOWkUMKrVaICyGQnQRDDsF2+G6K747rNDbJzkeqHfLb3y+Iu4dRO4WakO5ercg==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/rpc-core" "^0.81.0-beta.14"
-    "@polkadot/rpc-provider" "^0.81.0-beta.14"
+    "@polkadot/rpc-core" "^0.81.0-beta.15"
+    "@polkadot/rpc-provider" "^0.81.0-beta.15"
     "@types/memoizee" "^0.4.2"
     "@types/rx" "^4.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.2"
 
-"@polkadot/storage@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.81.0-beta.14.tgz#7580de9a04223e70fe017a79a65f2899e3bddf99"
-  integrity sha512-5gjIK7A+YwlU2AwOEk8wVaKXbStl8+9Fnwk4DVs4IQOQeoHS7h6gEvBmtTlJ5u7sQLdUn+PXcWGNFikOkG3EsQ==
+"@polkadot/storage@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/storage/-/storage-0.81.0-beta.15.tgz#aa061ba21ef56764d0b62851738a964ff97698d9"
+  integrity sha512-5kYiZB18Lq/pdYDzSvMA2DwPUxz1b8LwtsL/cwTv5Dk6qJVr4p1jFihPyzqyR7CNJlF7VQUIZ934S1X2QFpZuQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/types" "^0.81.0-beta.14"
+    "@polkadot/types" "^0.81.0-beta.15"
     "@polkadot/util" "^0.93.0-beta.5"
     "@polkadot/util-crypto" "^0.93.0-beta.5"
 
@@ -2027,10 +2027,10 @@
   dependencies:
     "@types/chrome" "^0.0.86"
 
-"@polkadot/types@^0.81.0-beta.14":
-  version "0.81.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.81.0-beta.14.tgz#fc0693a60ce2eef5ece72676b04bad567b74be15"
-  integrity sha512-KkmeZUgwMuO10QxzpgTGyi7nRiNoJeeAG7MtVEtRlWjUrIAhjAzdxWgy/hoYycxs7hRHCWmSiDloomde9/zF+w==
+"@polkadot/types@^0.81.0-beta.15":
+  version "0.81.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.81.0-beta.15.tgz#c35d3f0d0db5a0333eacc8dc98812516fd72e1b4"
+  integrity sha512-5wfk/Vpmn4MKpkrCbE/RUDCOP09gMiEzOhjeKYiMOEpWNZ+yyf5v+jzhFhYSiZpaUCHqWh4ljQ86DbyCuC2hAg==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@polkadot/util" "^0.93.0-beta.5"


### PR DESCRIPTION
Includes -
  - polkadot-js/common#419 (keyring interface)
  - https://github.com/polkadot-js/api/pull/997 (additional ABI types)
  - https://github.com/polkadot-js/api/pull/991 (substrate 2.x metadata v5)

And additions due to the above -
  - https://github.com/polkadot-js/ui/pull/146  (ui-keyring with new keyring interface)
  - https://github.com/polkadot-js/extension/pull/57 (extension-dapp with compliant injection)