### PR TITLE
Default proposal/sudo for new 2.x substrate

### DIFF
--- a/packages/app-democracy/src/Propose.tsx
+++ b/packages/app-democracy/src/Propose.tsx
@@ -35,17 +35,9 @@ class Propose extends TxComponent<Props, State> {
   };
 
   render () {
-    const { api, apiDefaultTx, t } = this.props;
+    const { apiDefaultTxSudo, t } = this.props;
     const { isValid, accountId, method, value } = this.state;
     const hasValue = !!value && value.gtn(0);
-
-    const defaultExtrinsic = (() => {
-      try {
-        return api.tx.consensus.setCode;
-      } catch (error) {
-        return apiDefaultTx;
-      }
-    })();
 
     return (
       <section>
@@ -57,7 +49,7 @@ class Propose extends TxComponent<Props, State> {
           onChange={this.onChangeAccount}
         />
         <Extrinsic
-          defaultValue={defaultExtrinsic}
+          defaultValue={apiDefaultTxSudo}
           label={t('propose')}
           onChange={this.onChangeExtrinsic}
           onEnter={this.sendTx}

--- a/packages/app-extrinsics/src/Selection.tsx
+++ b/packages/app-extrinsics/src/Selection.tsx
@@ -36,16 +36,9 @@ class Selection extends TxComponent<Props, State> {
   } as State;
 
   render () {
-    const { apiDefaultTx, api, t } = this.props;
+    const { apiDefaultTxSudo, t } = this.props;
     const { isValid, isValidUnsigned, accountId } = this.state;
-    const defaultExtrinsic = (() => {
-      try {
-        return api.tx.balances.transfer;
-      } catch (error) {
-        return apiDefaultTx;
-      }
-    })();
-    const extrinsic = this.getExtrinsic() || defaultExtrinsic;
+    const extrinsic = this.getExtrinsic() || apiDefaultTxSudo;
 
     return (
       <div className='extrinsics--Selection'>
@@ -73,7 +66,7 @@ class Selection extends TxComponent<Props, State> {
         </div>
         <br></br>
         <Extrinsic
-          defaultValue={defaultExtrinsic}
+          defaultValue={apiDefaultTxSudo}
           label={t('submit the following extrinsic')}
           onChange={this.onChangeExtrinsic}
           onEnter={this.sendTx}

--- a/packages/app-sudo/src/Sudo.tsx
+++ b/packages/app-sudo/src/Sudo.tsx
@@ -29,21 +29,13 @@ class Propose extends TxComponent<Props, State> {
   };
 
   render () {
-    const { api, apiDefaultTx, isMine, sudoKey, t } = this.props;
+    const { apiDefaultTxSudo, isMine, sudoKey, t } = this.props;
     const { method, isValid } = this.state;
-
-    const defaultExtrinsic = (() => {
-      try {
-        return api.tx.consensus.setCode;
-      } catch (error) {
-        return apiDefaultTx;
-      }
-    })();
 
     return isMine ? (
         <section>
           <Extrinsic
-            defaultValue={defaultExtrinsic}
+            defaultValue={apiDefaultTxSudo}
             label={t('submit the following change')}
             onChange={this.onChangeExtrinsic}
             onEnter={this.sendTx}

--- a/packages/ui-api/src/Api.tsx
+++ b/packages/ui-api/src/Api.tsx
@@ -100,8 +100,6 @@ export default class Api extends React.PureComponent<Props, State> {
       api.rpc.system.properties() as Promise<ChainProperties | undefined>,
       api.rpc.system.chain() as Promise<any>
     ]);
-    const section = Object.keys(api.tx)[0];
-    const method = Object.keys(api.tx[section])[0];
     const chain = value
       ? value.toString()
       : null;
@@ -133,22 +131,32 @@ export default class Api extends React.PureComponent<Props, State> {
       type: 'ed25519'
     }, injectedAccounts);
 
+    const section = Object.keys(api.tx)[0];
+    const method = Object.keys(api.tx[section])[0];
+    const apiDefaultTx = api.tx[section][method];
+    const apiDefaultTxSudo =
+      (api.tx.system && api.tx.system.setCode) || // 2.x
+      (api.tx.consensus && api.tx.consensus.setCode) || // 1.x
+      apiDefaultTx; // other
+
     this.setState({
       isApiReady: true,
-      apiDefaultTx: api.tx[section][method],
+      apiDefaultTx,
+      apiDefaultTxSudo,
       chain,
       isDevelopment
     });
   }
 
   render () {
-    const { api, apiDefaultTx, chain, isApiConnected, isApiReady, isDevelopment, isWaitingInjected, setApiUrl } = this.state;
+    const { api, apiDefaultTx, apiDefaultTxSudo, chain, isApiConnected, isApiReady, isDevelopment, isWaitingInjected, setApiUrl } = this.state;
 
     return (
       <ApiContext.Provider
         value={{
           api,
           apiDefaultTx,
+          apiDefaultTxSudo,
           currentChain: chain || '<unknown>',
           isApiConnected,
           isApiReady: isApiReady && !!chain,

--- a/packages/ui-api/src/types.ts
+++ b/packages/ui-api/src/types.ts
@@ -18,6 +18,7 @@ export type BareProps = {
 export type ApiProps = {
   api: ApiPromise,
   apiDefaultTx: SubmittableExtrinsicFunction,
+  apiDefaultTxSudo: SubmittableExtrinsicFunction,
   currentChain: string,
   isApiConnected: boolean,
   isApiReady: boolean,

--- a/packages/ui-app/src/Params/Proposal.tsx
+++ b/packages/ui-app/src/Params/Proposal.tsx
@@ -15,19 +15,12 @@ type Props = ApiProps & BaseProps;
 
 class ProposalDisplay extends React.PureComponent<Props> {
   render () {
-    const { apiDefaultTx, api, className, isDisabled, isError, label, onEnter, style, withLabel } = this.props;
-    const defaultValue = (() => {
-      try {
-        return api.tx.consensus.setCode;
-      } catch (error) {
-        return apiDefaultTx;
-      }
-    })();
+    const { apiDefaultTxSudo, className, isDisabled, isError, label, onEnter, style, withLabel } = this.props;
 
     return (
       <ExtrinsicDisplay
         className={className}
-        defaultValue={defaultValue}
+        defaultValue={apiDefaultTxSudo}
         isDisabled={isDisabled}
         isError={isError}
         isPrivate


### PR DESCRIPTION
- Consensus module removed in 2.x, setCode moved to system
- support with consensus, 2.x without and fallback if neither

NOTE: Current substrate master needs additional API types (as a fall-out from the above change). Types merged in https://github.com/polkadot-js/apps/pull/1297, updates for session in https://github.com/polkadot-js/apps/pull/1298