### PR TITLE
Filter modules (query & storage) without methods

### DIFF
--- a/packages/ui-app/src/InputExtrinsic/options/method.tsx
+++ b/packages/ui-app/src/InputExtrinsic/options/method.tsx
@@ -10,7 +10,7 @@ import ApiPromise from '@polkadot/api/promise';
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
   const section = api.tx[sectionName];
 
-  if (!section) {
+  if (!section || Object.keys(section).length === 0) {
     return [];
   }
 

--- a/packages/ui-app/src/InputExtrinsic/options/section.ts
+++ b/packages/ui-app/src/InputExtrinsic/options/section.ts
@@ -10,6 +10,7 @@ export default function createOptions (api: ApiPromise): DropdownOptions {
   return Object
     .keys(api.tx)
     .sort()
+    .filter((name) => Object.keys(api.tx[name]).length)
     .map((name) => ({
       text: name,
       value: name

--- a/packages/ui-app/src/InputStorage/options/key.tsx
+++ b/packages/ui-app/src/InputStorage/options/key.tsx
@@ -11,7 +11,7 @@ import ApiPromise from '@polkadot/api/promise';
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
   const section = api.query[sectionName];
 
-  if (!section) {
+  if (!section || Object.keys(section).length === 0) {
     return [];
   }
 

--- a/packages/ui-app/src/InputStorage/options/section.ts
+++ b/packages/ui-app/src/InputStorage/options/section.ts
@@ -10,6 +10,7 @@ export default function createOptions (api: ApiPromise): DropdownOptions {
   return Object
     .keys(api.query)
     .sort()
+    .filter((name) => Object.keys(api.query[name]).length)
     .map((name) => ({
       text: name,
       value: name


### PR DESCRIPTION
There is currently a crash in indices - the section calls are `[]` in the metadata, so it has an index, however there are no items for the dropdown. 

TL;DR There are valid reasons why the metadata returns `[]` instead of `null` of calls, however we assume for non-`null` that we always have methods inside the section. This is not the case.