### PR TITLE
Fix upload and deploy contract(s) after rename

### DIFF
--- a/packages/app-contracts/src/Codes/Upload.tsx
+++ b/packages/app-contracts/src/Codes/Upload.tsx
@@ -96,9 +96,11 @@ class Upload extends ContractModal<Props, State> {
   }
 
   private onSuccess = (result: SubmittableResult): void => {
+    const { api } = this.props;
     this.setState(({ abi, name, tags }) => {
 
-      const record = result.findRecord('contract', 'CodeStored');
+      const section = api.tx.contracts ? 'contracts' : 'contract';
+      const record = result.findRecord(section, 'CodeStored');
 
       if (record) {
         const codeHash = record.event.data[0];

--- a/packages/app-contracts/src/Deploy.tsx
+++ b/packages/app-contracts/src/Deploy.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
 import { Abi } from '@polkadot/api-contract';
-import { api, withApi, withMulti } from '@polkadot/ui-api';
+import { api as apiUi, withApi, withMulti } from '@polkadot/ui-api';
 import keyring from '@polkadot/ui-keyring';
 import { Button, Dropdown, InputBalance, TxButton } from '@polkadot/ui-app';
 import { AccountId, getTypeDef } from '@polkadot/types';
@@ -256,7 +256,7 @@ class Deploy extends ContractModal<Props, State> {
     if (record) {
       const address = record.event.data[1] as any as AccountId;
 
-      await api.isReady;
+      await apiUi.isReady;
 
       this.setState(({ abi, name, tags }) => {
         if (!abi || !name) {
@@ -267,7 +267,7 @@ class Deploy extends ContractModal<Props, State> {
           name,
           contract: {
             abi,
-            genesisHash: api.genesisHash.toHex()
+            genesisHash: apiUi.genesisHash.toHex()
           },
           tags
         });

--- a/packages/app-contracts/src/Deploy.tsx
+++ b/packages/app-contracts/src/Deploy.tsx
@@ -248,9 +248,10 @@ class Deploy extends ContractModal<Props, State> {
   }
 
   private onSuccess = async (result: SubmittableResult) => {
-    const { history } = this.props;
+    const { api, history } = this.props;
 
-    const record = result.findRecord('contract', 'Instantiated');
+    const section = api.tx.contracts ? 'contracts' : 'contract';
+    const record = result.findRecord(section, 'Instantiated');
 
     if (record) {
       const address = record.event.data[1] as any as AccountId;


### PR DESCRIPTION
In substrate, the `contract` module was renamed to `contracts`. This looks up the record on success by the correct name, should be backwards compatible.