### PR TITLE
Remove all tags on create dialogs

### DIFF
--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { DEV_PHRASE } from '@polkadot/keyring/defaults';
 import { withApi, withMulti } from '@polkadot/ui-api';
-import { AddressRow, Button, Dropdown, Input, InputTags, Labelled, Modal, Password } from '@polkadot/ui-app';
+import { AddressRow, Button, Dropdown, Input, Labelled, Modal, Password } from '@polkadot/ui-app';
 import { InputAddress } from '@polkadot/ui-app/InputAddress';
 import keyring from '@polkadot/ui-keyring';
 import uiSettings from '@polkadot/ui-settings';
@@ -151,7 +151,7 @@ class Create extends React.PureComponent<Props, State> {
 
   private renderInput () {
     const { t } = this.props;
-    const { address, deriveError, derivePath, isNameValid, isPassValid, isSeedValid, name, pairType, password, seed, seedOptions, seedType, tags } = this.state;
+    const { address, deriveError, derivePath, isNameValid, isPassValid, isSeedValid, name, pairType, password, seed, seedOptions, seedType } = this.state;
     const seedLabel = (() => {
       switch (seedType) {
         case 'bip':
@@ -204,12 +204,6 @@ class Create extends React.PureComponent<Props, State> {
             onChange={this.onChangePass}
             onEnter={this.onCommit}
             value={password}
-          />
-          <InputTags
-            help={t('Additional user-specified tags that can be used to identify the account. Tags can be used for categorization and filtering.')}
-            label={t('user-defined tags')}
-            onChange={this.onChangeTags}
-            value={tags}
           />
           <details
             className='accounts--Creator-advanced'
@@ -390,10 +384,6 @@ class Create extends React.PureComponent<Props, State> {
 
   private onChangeSeed = (seed: string): void => {
     this.nextState({ seed } as State);
-  }
-
-  private onChangeTags = (tags: Array<string>): void => {
-    this.setState({ tags });
   }
 
   private onShowWarning = (): void => {

--- a/packages/app-address-book/src/modals/Create.tsx
+++ b/packages/app-address-book/src/modals/Create.tsx
@@ -8,7 +8,7 @@ import { ModalProps } from '../types';
 
 import React from 'react';
 
-import { AddressRow, Button, Input, InputTags, Modal } from '@polkadot/ui-app';
+import { AddressRow, Button, Input, Modal } from '@polkadot/ui-app';
 import { InputAddress } from '@polkadot/ui-app/InputAddress';
 import keyring from '@polkadot/ui-keyring';
 
@@ -76,7 +76,7 @@ class Create extends React.PureComponent<Props, State> {
 
   private renderContent () {
     const { t } = this.props;
-    const { address, isAddressValid, isNameValid, name, tags } = this.state;
+    const { address, isAddressValid, isNameValid, name } = this.state;
 
     return (
       <Modal.Content>
@@ -102,12 +102,6 @@ class Create extends React.PureComponent<Props, State> {
             onChange={this.onChangeName}
             onEnter={this.onCommit}
             value={name}
-          />
-          <InputTags
-            help={t('Additional user-specified tags that can be used to identify the address. Tags can be used for categorization and filtering.')}
-            label={t('user-defined tags')}
-            onChange={this.onChangeTags}
-            value={tags}
           />
         </AddressRow>
       </Modal.Content>
@@ -177,10 +171,6 @@ class Create extends React.PureComponent<Props, State> {
 
   private onChangeName = (name: string): void => {
     this.nextState({ name } as State, true);
-  }
-
-  private onChangeTags = (tags: Array<string>): void => {
-    this.setState({ tags });
   }
 
   private onCommit = (): void => {

--- a/packages/app-contracts/src/Codes/Add.tsx
+++ b/packages/app-contracts/src/Codes/Add.tsx
@@ -53,7 +53,6 @@ class Add extends ContractModal<Props, State> {
           onChange={this.onValidateCode}
         />
         {this.renderInputName()}
-        {this.renderInputTags()}
         {this.renderInputAbi()}
       </>
     );

--- a/packages/app-contracts/src/Codes/Upload.tsx
+++ b/packages/app-contracts/src/Codes/Upload.tsx
@@ -57,7 +57,6 @@ class Upload extends ContractModal<Props, State> {
           }
         />
         {this.renderInputName()}
-        {this.renderInputTags()}
         {this.renderInputAbi()}
         {this.renderInputGas()}
       </>

--- a/packages/app-contracts/src/Contracts/Add.tsx
+++ b/packages/app-contracts/src/Contracts/Add.tsx
@@ -63,7 +63,6 @@ class Add extends ContractModal<Props, State> {
           onChange={this.onValidateAddr}
         />
         {this.renderInputName()}
-        {this.renderInputTags()}
         {this.renderInputAbi()}
       </AddressRow>
     );

--- a/packages/app-contracts/src/Deploy.tsx
+++ b/packages/app-contracts/src/Deploy.tsx
@@ -92,7 +92,6 @@ class Deploy extends ContractModal<Props, State> {
           value={codeHash}
         />
         {this.renderInputName()}
-        {this.renderInputTags()}
         {
           isAbiSupplied
             ? null

--- a/packages/app-contracts/src/Modal.tsx
+++ b/packages/app-contracts/src/Modal.tsx
@@ -7,7 +7,7 @@ import { I18nProps } from '@polkadot/ui-app/types';
 import BN from 'bn.js';
 import React from 'react';
 import { Abi } from '@polkadot/api-contract';
-import { Button, Input, InputAddress, InputNumber, InputTags, Modal, TxComponent } from '@polkadot/ui-app';
+import { Button, Input, InputAddress, InputNumber, Modal, TxComponent } from '@polkadot/ui-app';
 
 import ABI from './ABI';
 
@@ -147,21 +147,6 @@ class ContractModal<P extends ContractModalProps, S extends ContractModalState> 
     );
   }
 
-  protected renderInputTags () {
-    const { t } = this.props;
-    const { isBusy, tags } = this.state;
-
-    return (
-      <InputTags
-        help={t(`Additional user-specified tags. Tags can be used for categorization and filtering.`)}
-        isDisabled={isBusy}
-        label={t('user-defined tags')}
-        onChange={this.onChangeTags}
-        value={tags}
-      />
-    );
-  }
-
   protected renderInputGas () {
     const { t } = this.props;
     const { gasLimit, isBusy } = this.state;
@@ -226,10 +211,6 @@ class ContractModal<P extends ContractModalProps, S extends ContractModalState> 
 
   protected onChangeName = (name: string): void => {
     this.setState({ name, isNameValid: name.length !== 0 });
-  }
-
-  protected onChangeTags = (tags: Array<string>): void => {
-    this.setState({ tags });
   }
 
   protected onChangeGas = (gasLimit: BN | undefined): void => {

--- a/packages/ui-app/src/Row.tsx
+++ b/packages/ui-app/src/Row.tsx
@@ -26,8 +26,11 @@ export const styles = `
   }
 
   &.invalid {
-    filter: grayscale(100);
-    opacity: 0.5;
+    .ui--Row-accountId,
+    .ui--Row-icon {
+      filter: grayscale(100);
+      opacity: 0.5;
+    }
   }
 
   button.ui.icon.editButton {


### PR DESCRIPTION
In 99% of the cases people just want to get their work done - de-clutter. (Always available on edit)

Mentioned in https://github.com/polkadot-js/apps/issues/1332

