### PR TITLE
Method: don't use globals

### DIFF
--- a/packages/app-democracy/src/Overview/Item.tsx
+++ b/packages/app-democracy/src/Overview/Item.tsx
@@ -10,11 +10,13 @@ import styled from 'styled-components';
 import { Method, Proposal } from '@polkadot/types';
 import { Call, Card } from '@polkadot/ui-app';
 import { styles as rowStyles } from '@polkadot/ui-app/Row';
+import { withMulti, withApi } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { formatNumber } from '@polkadot/util';
 
 import translate from '../translate';
 
-type Props = I18nProps & {
+type Props = I18nProps & ApiProps & {
   children?: React.ReactNode,
   proposal: Proposal,
   proposalExtra?: React.ReactNode,
@@ -23,8 +25,8 @@ type Props = I18nProps & {
 
 class Item extends React.PureComponent<Props> {
   render () {
-    const { children, className, idNumber, proposal, proposalExtra } = this.props;
-    const { meta, method, section } = Method.findFunction(proposal.callIndex);
+    const { api, children, className, idNumber, proposal, proposalExtra } = this.props;
+    const { meta, method, section } = Method.findByCallIndex(proposal.callIndex, api.runtimeMetadata);
 
     return (
       <Card className={className}>
@@ -52,22 +54,26 @@ class Item extends React.PureComponent<Props> {
   }
 }
 
-export default translate(styled(Item as React.ComponentClass<Props>)`
-  ${rowStyles}
+export default withMulti(
+  styled(Item as React.ComponentClass<Props>)`
+    ${rowStyles}
 
-  .democracy--Item-extrinsic {
-    margin-top: 1rem;
+    .democracy--Item-extrinsic {
+      margin-top: 1rem;
 
-    .ui--Params-Content {
-      padding-left: 0;
+      .ui--Params-Content {
+        padding-left: 0;
+      }
     }
-  }
 
-  .democracy--Item-header {
-    margin-bottom: 1rem;
-  }
+    .democracy--Item-header {
+      margin-bottom: 1rem;
+    }
 
-  .democracy--Item-buttons {
+    .democracy--Item-buttons {
 
-  }
-`);
+    }
+  `,
+  translate,
+  withApi
+);

--- a/packages/app-explorer/src/BlockInfo/Extrinsics.tsx
+++ b/packages/app-explorer/src/BlockInfo/Extrinsics.tsx
@@ -8,11 +8,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { AddressMini, Call, Column, LinkPolkascan } from '@polkadot/ui-app';
 import { formatNumber } from '@polkadot/util';
+import { withApi, withMulti } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { Extrinsic, Method } from '@polkadot/types';
 
 import translate from '../translate';
 
-type Props = I18nProps & {
+type Props = I18nProps & ApiProps & {
   label?: React.ReactNode,
   value?: Array<Extrinsic> | null
 };
@@ -47,7 +49,8 @@ class Extrinsics extends React.PureComponent<Props> {
 
   // FIXME This is _very_ similar to what we have in democracy/Item
   private renderExtrinsic = (extrinsic: Extrinsic, index: number) => {
-    const { meta, method, section } = Method.findFunction(extrinsic.callIndex);
+    const { api } = this.props;
+    const { meta, method, section } = Method.findByCallIndex(extrinsic.callIndex, api.runtimeMetadaa);
 
     return (
       <article key={`extrinsic:${index}`}>
@@ -98,18 +101,22 @@ class Extrinsics extends React.PureComponent<Props> {
   }
 }
 
-export default translate(styled(Extrinsics)`
-  .explorer--BlockByHash-header {
-    position: absolute;
-    top: 0.25rem;
-    right: 0.75rem;
-  }
+export default withMulti(
+  styled(Extrinsics)`
+    .explorer--BlockByHash-header {
+      position: absolute;
+      top: 0.25rem;
+      right: 0.75rem;
+    }
 
-  .explorer--BlockByHash-nonce {
-    font-size: .75rem;
-    margin-right: 2.25rem;
-    margin-top: -1rem;
-    opacity: 0.45;
-    text-align: right;
-  }
-`);
+    .explorer--BlockByHash-nonce {
+      font-size: .75rem;
+      margin-right: 2.25rem;
+      margin-top: -1rem;
+      opacity: 0.45;
+      text-align: right;
+    }
+  `,
+  translate,
+  withApi
+);

--- a/packages/app-extrinsics/src/Selection.tsx
+++ b/packages/app-extrinsics/src/Selection.tsx
@@ -10,8 +10,8 @@ import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 
 import React from 'react';
 import { Method } from '@polkadot/types';
-import { Button, Extrinsic, InputAddress, Labelled, TxButton, TxComponent } from '@polkadot/ui-app';
 import { withApi, withMulti } from '@polkadot/ui-api';
+import { Button, Extrinsic, InputAddress, Labelled, TxButton, TxComponent } from '@polkadot/ui-app';
 import { Nonce } from '@polkadot/ui-reactive';
 
 import Balance from './Balance';
@@ -135,7 +135,7 @@ class Selection extends TxComponent<Props, State> {
       return null;
     }
 
-    const fn = Method.findFunction(method.callIndex);
+    const fn = Method.findByCallIndex(method.callIndex, api.runtimeMetadata);
 
     return api.tx[fn.section][fn.method](...method.args);
   }

--- a/packages/ui-app/src/Status/index.tsx
+++ b/packages/ui-app/src/Status/index.tsx
@@ -8,13 +8,15 @@ import { QueueStatus, QueueTx, QueueTx$Status } from './types';
 import React from 'react';
 import styled from 'styled-components';
 import { Method } from '@polkadot/types';
+import { withApi, withMulti } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 
 import AddressMini from '../AddressMini';
 import Icon from '../Icon';
 import { classes } from '../util';
 import translate from '../translate';
 
-type Props = I18nProps & {
+type Props = I18nProps & ApiProps & {
   stqueue?: Array<QueueStatus>,
   txqueue?: Array<QueueTx>
 };
@@ -141,10 +143,11 @@ class Status extends React.PureComponent<Props> {
   }
 
   private renderItem = ({ id, extrinsic, error, removeItem, rpc, status }: QueueTx) => {
+    let { api } = this.props;
     let { method, section } = rpc;
 
     if (extrinsic) {
-      const found = Method.findFunction(extrinsic.callIndex);
+      const found = Method.findByCallIndex(extrinsic.callIndex, api.runtimeMetadata);
 
       if (found.section !== 'unknown') {
         method = found.method;
@@ -225,4 +228,8 @@ class Status extends React.PureComponent<Props> {
   }
 }
 
-export default translate(Status);
+export default withMulti(
+  Status,
+  translate,
+  withApi
+);

--- a/packages/ui-app/src/Status/index.tsx
+++ b/packages/ui-app/src/Status/index.tsx
@@ -149,7 +149,7 @@ class Status extends React.PureComponent<Props> {
     if (extrinsic) {
       const found = Method.findByCallIndex(extrinsic.callIndex, api.runtimeMetadata);
 
-      if (found.section !== 'unknown') {
+      if (found) {
         method = found.method;
         section = found.section;
       }

--- a/packages/ui-params/src/Param/Proposal.tsx
+++ b/packages/ui-params/src/Param/Proposal.tsx
@@ -6,15 +6,17 @@ import { Props } from '../types';
 
 import React from 'react';
 import { Extrinsic, Method } from '@polkadot/types';
+import { withApi } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { Call, Static } from '@polkadot/ui-app';
 import { classes } from '@polkadot/ui-app/util';
 
 import Bare from './Bare';
 import Unknown from './Unknown';
 
-export default class Proposal extends React.PureComponent<Props> {
+class Proposal extends React.PureComponent<Props & ApiProps> {
   render () {
-    const { className, defaultValue: { value }, isDisabled, label, style, withLabel } = this.props;
+    const { api, className, defaultValue: { value }, isDisabled, label, style, withLabel } = this.props;
 
     if (!isDisabled) {
       return (
@@ -23,7 +25,7 @@ export default class Proposal extends React.PureComponent<Props> {
     }
 
     const proposal = value as Extrinsic;
-    const { method, section } = Method.findFunction(proposal.callIndex);
+    const { method, section } = Method.findByCallIndex(proposal.callIndex, api.runtimeMetadata);
 
     return (
       <Bare>
@@ -40,3 +42,5 @@ export default class Proposal extends React.PureComponent<Props> {
     );
   }
 }
+
+export default withApi(Proposal);

--- a/packages/ui-signer/src/Transaction.tsx
+++ b/packages/ui-signer/src/Transaction.tsx
@@ -7,12 +7,14 @@ import { QueueTx } from '@polkadot/ui-app/Status/types';
 
 import React from 'react';
 import { Method } from '@polkadot/types';
+import { withApi, withMulti } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { Call, InputAddress, Modal } from '@polkadot/ui-app';
 
 import Checks from './Checks';
 import translate from './translate';
 
-type Props = I18nProps & {
+type Props = I18nProps & ApiProps & {
   children?: React.ReactNode,
   isSendable: boolean,
   value: QueueTx
@@ -20,13 +22,13 @@ type Props = I18nProps & {
 
 class Transaction extends React.PureComponent<Props> {
   render () {
-    const { children, value: { extrinsic } } = this.props;
+    const { api, children, value: { extrinsic } } = this.props;
 
     if (!extrinsic) {
       return null;
     }
 
-    const { meta, method, section } = Method.findFunction(extrinsic.callIndex);
+    const { meta, method, section } = Method.findByCallIndex(extrinsic.callIndex, api.runtimeMetadata);
 
     return (
       <>
@@ -84,4 +86,8 @@ class Transaction extends React.PureComponent<Props> {
   }
 }
 
-export default translate(Transaction);
+export default withMulti(
+  Transaction,
+  translate,
+  withApi
+);


### PR DESCRIPTION
Use the pure function `findByCallIndex` introduced in https://github.com/polkadot-js/api/pull/1047 instead of `findFunction` relying on injected globals.

(Need to update the dependency once the api PR is merged)