### PR TITLE
Add wrong password indication

### DIFF
--- a/packages/ui-signer/src/Modal.tsx
+++ b/packages/ui-signer/src/Modal.tsx
@@ -177,7 +177,9 @@ class Signer extends React.PureComponent<Props, State> {
           value={currentItem.accountId}
           tabIndex={1}
         />
-        <PasswordCheck unlockError= {unlockError} />
+        <PasswordCheck
+          unlockError={unlockError}
+        />
       </>
     );
   }

--- a/packages/ui-signer/src/Modal.tsx
+++ b/packages/ui-signer/src/Modal.tsx
@@ -19,9 +19,10 @@ import keyring from '@polkadot/ui-keyring';
 import { assert, isFunction } from '@polkadot/util';
 import { format } from '@polkadot/util/logger';
 
+import PasswordCheck from './PasswordCheck';
 import Transaction from './Transaction';
-import Unlock from './Unlock';
 import translate from './translate';
+import Unlock from './Unlock';
 
 type BaseProps = BareProps & {
   queue: Array<QueueTx>,
@@ -167,14 +168,17 @@ class Signer extends React.PureComponent<Props, State> {
     }
 
     return (
-      <Unlock
-        autoFocus
-        error={unlockError || undefined}
-        onChange={this.onChangePassword}
-        password={password}
-        value={currentItem.accountId}
-        tabIndex={1}
-      />
+      <>
+        <Unlock
+          autoFocus
+          error={unlockError || undefined}
+          onChange={this.onChangePassword}
+          password={password}
+          value={currentItem.accountId}
+          tabIndex={1}
+        />
+        <PasswordCheck unlockError= {unlockError} />
+      </>
     );
   }
 

--- a/packages/ui-signer/src/PasswordCheck.tsx
+++ b/packages/ui-signer/src/PasswordCheck.tsx
@@ -11,8 +11,8 @@ import { withMulti } from '@polkadot/ui-api';
 import translate from './translate';
 
 type Props = I18nProps & {
+  className?: string,
   unlockError?: string | null
-  className: string
 };
 
 function PasswordCheck (props: Props) {

--- a/packages/ui-signer/src/PasswordCheck.tsx
+++ b/packages/ui-signer/src/PasswordCheck.tsx
@@ -6,22 +6,27 @@ import { I18nProps } from '@polkadot/ui-app/types';
 
 import React from 'react';
 import styled from 'styled-components';
+import { withMulti } from '@polkadot/ui-api';
 
 import translate from './translate';
 
 type Props = I18nProps & {
   unlockError?: string | null
+  className: string
 };
 
-const Wrapper = styled.div`
-    margin-left: 15em;
-    color: #9f3a38;
-`;
-
 function PasswordCheck (props: Props) {
-  const { unlockError, t } = props;
+  const { className, unlockError, t } = props;
 
-  return unlockError ? <Wrapper>{t('wrong password')}</Wrapper> : null;
+  return unlockError
+  ? <div className={className}>{t('wrong password')}</div>
+  : null;
 }
 
-export default translate(PasswordCheck);
+export default withMulti(
+  styled(PasswordCheck)`
+    margin-left: 15em;
+    color: #9f3a38;
+  `,
+  translate
+);

--- a/packages/ui-signer/src/PasswordCheck.tsx
+++ b/packages/ui-signer/src/PasswordCheck.tsx
@@ -1,0 +1,27 @@
+// Copyright 2017-2019 @polkadot/ui-signer authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { I18nProps } from '@polkadot/ui-app/types';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import translate from './translate';
+
+type Props = I18nProps & {
+  unlockError?: string | null
+};
+
+const Wrapper = styled.div`
+    margin-left: 15em;
+    color: #9f3a38;
+`;
+
+function PasswordCheck (props: Props) {
+  const { unlockError, t } = props;
+
+  return unlockError ? <Wrapper>{t('wrong password')}</Wrapper> : null;
+}
+
+export default translate(PasswordCheck);


### PR DESCRIPTION
- closes #1363

I didn't want to use the bells and whistles from a class, however I couldn't manage the have the styled component work with `withMulti`.
```js
export default withMulti(
  styled(PasswordCheck)`
    margin-left: 15em;
    color: #9f3a38;
  `,
  translate
);
```
The style wasn't taken into account.. any hint welcome

This is how it looks:
![image](https://user-images.githubusercontent.com/33178835/60746795-4f354700-9f81-11e9-8288-c0a80875762a.png)

