### PR TITLE
Staking compatibility with v2

### DIFF
--- a/packages/app-staking/src/Actions/Account/index.tsx
+++ b/packages/app-staking/src/Actions/Account/index.tsx
@@ -30,7 +30,7 @@ type Props = ApiProps & I18nProps & {
   recentlyOffline: RecentlyOfflineMap,
   balances_all?: DerivedBalances,
   staking_info?: DerivedStaking,
-  stashOptions: Array<KeyringSectionOption>
+  stashOptions: KeyringSectionOption[]
 };
 
 type State = {
@@ -47,7 +47,7 @@ type State = {
   isStashValidating: boolean,
   isUnbondOpen: boolean,
   isValidateOpen: boolean,
-  nominees?: Array<string>,
+  nominees?: string[],
   sessionId: string | null,
   stakers?: Exposure,
   stakingLedger?: StakingLedger,

--- a/packages/app-staking/src/Actions/Accounts.tsx
+++ b/packages/app-staking/src/Actions/Accounts.tsx
@@ -89,9 +89,9 @@ class Accounts extends React.PureComponent<Props,State> {
   }
 
   private getStashOptions (): Array<KeyringSectionOption> {
-    const { stashes } = this.props;
+    const { allStashes } = this.props;
 
-    return stashes.map((stashId) =>
+    return allStashes.map((stashId) =>
       createOption(stashId, getAddressName(stashId, 'account'))
     );
   }

--- a/packages/app-staking/src/Actions/Accounts.tsx
+++ b/packages/app-staking/src/Actions/Accounts.tsx
@@ -19,7 +19,7 @@ import StartStaking from './NewStake';
 import translate from '../translate';
 
 type Props = I18nProps & ComponentProps & ApiProps & {
-  myControllers?: Array<string>
+  myControllers?: string[]
 };
 
 type State = {
@@ -73,7 +73,7 @@ class Accounts extends React.PureComponent<Props,State> {
 
   private getMyStashes () {
     const { myControllers, allAccounts } = this.props;
-    const result: Array<string> = [];
+    const result: string[] = [];
 
     if (!myControllers) {
       return null;
@@ -88,7 +88,7 @@ class Accounts extends React.PureComponent<Props,State> {
     return result;
   }
 
-  private getStashOptions (): Array<KeyringSectionOption> {
+  private getStashOptions (): KeyringSectionOption[] {
     const { allStashes } = this.props;
 
     return allStashes.map((stashId) =>

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -17,7 +17,7 @@ import { formatBalance } from '@polkadot/util';
 import translate from '../translate';
 
 type Props = I18nProps & {
-  address: string,
+  address: string, // controller (v1) or stash (v2)
   balances: DerivedBalancesMap,
   className?: string,
   defaultName: string,
@@ -29,7 +29,7 @@ type Props = I18nProps & {
 };
 
 type State = {
-  controllerId: string,
+  controllerId: string | null,
   stashActive: string | null,
   stashTotal: string | null,
   sessionId: string | null,
@@ -45,7 +45,7 @@ class Address extends React.PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      controllerId: props.address,
+      controllerId: null,
       sessionId: null,
       stashActive: null,
       stashId: null,
@@ -60,7 +60,8 @@ class Address extends React.PureComponent<Props, State> {
     }
 
     const { controllerId, nextSessionId, stakers, stashId, stakingLedger } = staking_info;
-
+    console.log('controller',controllerId && controllerId.toString());
+    console.log('stash',stashId && stashId.toString());
     return {
       controllerId: controllerId && controllerId.toString(),
       sessionId: nextSessionId && nextSessionId.toString(),
@@ -96,7 +97,7 @@ class Address extends React.PureComponent<Props, State> {
         className={className}
         defaultName={defaultName}
         iconInfo={this.renderOffline()}
-        key={stashId || controllerId}
+        key={stashId || controllerId || undefined}
         value={stashId}
         withBalance={{ bonded }}
       >

--- a/packages/app-staking/src/Overview/Address.tsx
+++ b/packages/app-staking/src/Overview/Address.tsx
@@ -60,8 +60,7 @@ class Address extends React.PureComponent<Props, State> {
     }
 
     const { controllerId, nextSessionId, stakers, stashId, stakingLedger } = staking_info;
-    console.log('controller',controllerId && controllerId.toString());
-    console.log('stash',stashId && stashId.toString());
+
     return {
       controllerId: controllerId && controllerId.toString(),
       sessionId: nextSessionId && nextSessionId.toString(),

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -14,7 +14,7 @@ import Address from './Address';
 
 type Props = I18nProps & {
   balances?: DerivedBalancesMap,
-  current: Array<string>,
+  currentValidatorsControllersV1OrStashesV2: Array<string>,
   lastAuthor?: string,
   lastBlock: string,
   next: Array<string>,
@@ -48,7 +48,7 @@ class CurrentList extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { current, next, t } = this.props;
+    const { currentValidatorsControllersV1OrStashesV2, next, t } = this.props;
     const { filter, filterOptions } = this.state;
     return (
       <div>
@@ -65,7 +65,7 @@ class CurrentList extends React.PureComponent<Props, State> {
             emptyText={t('No addresses found')}
             headerText={t('validators')}
           >
-            {this.renderColumn(current, t('validator (stash)'))}
+            {this.renderColumn(currentValidatorsControllersV1OrStashesV2, t('validator (stash)'))}
           </Column>
           <Column
             emptyText={t('No addresses found')}

--- a/packages/app-staking/src/Overview/CurrentList.tsx
+++ b/packages/app-staking/src/Overview/CurrentList.tsx
@@ -14,16 +14,16 @@ import Address from './Address';
 
 type Props = I18nProps & {
   balances?: DerivedBalancesMap,
-  currentValidatorsControllersV1OrStashesV2: Array<string>,
+  currentValidatorsControllersV1OrStashesV2: string[],
   lastAuthor?: string,
   lastBlock: string,
-  next: Array<string>,
+  next: string[],
   recentlyOffline: RecentlyOfflineMap
 };
 
 type State = {
   filter: ValidatorFilter,
-  filterOptions: Array<{ text: React.ReactNode, value: ValidatorFilter }>
+  filterOptions: { text: React.ReactNode, value: ValidatorFilter }[]
 };
 
 class CurrentList extends React.PureComponent<Props, State> {
@@ -78,7 +78,7 @@ class CurrentList extends React.PureComponent<Props, State> {
     );
   }
 
-  private renderColumn (addresses: Array<string>, defaultName: string) {
+  private renderColumn (addresses: string[], defaultName: string) {
     const { balances, lastAuthor, lastBlock, recentlyOffline } = this.props;
     const { filter } = this.state;
 

--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -15,11 +15,11 @@ import translate from '../translate';
 
 type Props = I18nProps & {
   className?: string,
-  allControllers: Array<string>,
+  allControllers: string[],
   lastAuthor?: string,
   lastBlock: string,
   staking_validatorCount?: BN,
-  currentValidatorsControllersV1OrStashesV2: Array<string>
+  currentValidatorsControllersV1OrStashesV2: string[]
 };
 
 class Summary extends React.PureComponent<Props> {

--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -2,7 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-// import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
 
 import BN from 'bn.js';

--- a/packages/app-staking/src/Overview/Summary.tsx
+++ b/packages/app-staking/src/Overview/Summary.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { DerivedBalancesMap } from '@polkadot/api-derive/types';
+// import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { I18nProps } from '@polkadot/ui-app/types';
 
 import BN from 'bn.js';
@@ -15,20 +15,19 @@ import { withCalls, withMulti } from '@polkadot/ui-api';
 import translate from '../translate';
 
 type Props = I18nProps & {
-  balances: DerivedBalancesMap,
   className?: string,
-  controllers: Array<string>,
+  allControllers: Array<string>,
   lastAuthor?: string,
   lastBlock: string,
   staking_validatorCount?: BN,
-  validators: Array<string>
+  currentValidatorsControllersV1OrStashesV2: Array<string>
 };
 
 class Summary extends React.PureComponent<Props> {
   render () {
-    const { className, controllers, lastAuthor, lastBlock, style, t, staking_validatorCount, validators } = this.props;
-    const waiting = controllers.length > validators.length
-      ? (controllers.length - validators.length)
+    const { className, allControllers, lastAuthor, lastBlock, style, t, staking_validatorCount, currentValidatorsControllersV1OrStashesV2 } = this.props;
+    const waiting = allControllers.length > currentValidatorsControllersV1OrStashesV2.length
+      ? (allControllers.length - currentValidatorsControllersV1OrStashesV2.length)
       : 0;
 
     return (
@@ -38,7 +37,7 @@ class Summary extends React.PureComponent<Props> {
       >
         <section>
           <CardSummary label={t('validators')}>
-            {validators.length}/{staking_validatorCount ? staking_validatorCount.toString() : '-'}
+            {currentValidatorsControllersV1OrStashesV2.length}/{staking_validatorCount ? staking_validatorCount.toString() : '-'}
           </CardSummary>
           <CardSummary label={t('waiting')}>
             {waiting}

--- a/packages/app-staking/src/Overview/index.tsx
+++ b/packages/app-staking/src/Overview/index.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Balance } from '@polkadot/types';
+// import { Balance } from '@polkadot/types';
 import { BareProps } from '@polkadot/ui-app/types';
 import { ComponentProps } from '../types';
 
@@ -13,22 +13,29 @@ import { formatNumber } from '@polkadot/util';
 
 import CurrentList from './CurrentList';
 import Summary from './Summary';
+import { withApi, api } from '@polkadot/ui-api';
+import { ApiProps } from '@polkadot/ui-api/types';
 
-type Props = BareProps & ComponentProps & {
+type Props = ApiProps & BareProps & ComponentProps & {
   chain_subscribeNewHead?: HeaderExtended
 };
 
-const ZERO = new Balance(0);
-
 class Overview extends React.PureComponent<Props> {
   render () {
-    const { balances, chain_subscribeNewHead, controllers, recentlyOffline, validators } = this.props;
-    const nextSorted = this.sortByBalance(
-      controllers.filter((address) =>
-        !validators.includes(address)
-      )
-    );
-    const validatorsSorted = this.sortByBalance(validators);
+    const { chain_subscribeNewHead, allControllers, allStashes, recentlyOffline, currentValidatorsControllersV1OrStashesV2 } = this.props;
+    let nextSorted: Array<string>;
+
+    if (Object.keys(api.consts).length) {
+      // this is a V2 node currentValidatorsControllersV1OrStashesV2 is a list of stashes
+      nextSorted = allStashes.filter((address) =>
+        !currentValidatorsControllersV1OrStashesV2.includes(address)
+      );
+    } else {
+      // this is a V1 node currentValidatorsControllersV1OrStashesV2 is a list of controllers
+      nextSorted = allControllers.filter((address) =>
+        !currentValidatorsControllersV1OrStashesV2.includes(address)
+      );
+    }
 
     let lastBlock: string = '—';
     let lastAuthor: string | undefined;
@@ -41,15 +48,13 @@ class Overview extends React.PureComponent<Props> {
     return (
       <div className='staking--Overview'>
         <Summary
-          balances={balances}
-          controllers={controllers}
+          allControllers={allControllers}
           lastBlock={lastBlock}
           lastAuthor={lastAuthor}
-          validators={validators}
+          currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
         />
         <CurrentList
-          balances={balances}
-          current={validatorsSorted}
+          currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
           lastBlock={lastBlock}
           lastAuthor={lastAuthor}
           next={nextSorted}
@@ -58,25 +63,11 @@ class Overview extends React.PureComponent<Props> {
       </div>
     );
   }
-
-  private sortByBalance (list: Array<string>): Array<string> {
-    const { balances } = this.props;
-
-    if (!balances) {
-      return [];
-    }
-
-    return list.sort((a, b) => {
-      const balanceA = balances[a] || { freeBalance: ZERO };
-      const balanceB = balances[b] || { freeBalance: ZERO };
-
-      return balanceB.freeBalance.cmp(balanceA.freeBalance);
-    });
-  }
 }
 
 export default withMulti(
   Overview,
+  withApi,
   withCalls<Props>(
     'derive.chain.subscribeNewHead'
   )

--- a/packages/app-staking/src/Overview/index.tsx
+++ b/packages/app-staking/src/Overview/index.tsx
@@ -12,7 +12,7 @@ import { formatNumber } from '@polkadot/util';
 
 import CurrentList from './CurrentList';
 import Summary from './Summary';
-import { withApi, api } from '@polkadot/ui-api';
+import { withApi } from '@polkadot/ui-api';
 import { ApiProps } from '@polkadot/ui-api/types';
 
 type Props = ApiProps & BareProps & ComponentProps & {
@@ -21,10 +21,10 @@ type Props = ApiProps & BareProps & ComponentProps & {
 
 class Overview extends React.PureComponent<Props> {
   render () {
-    const { chain_subscribeNewHead, allControllers, allStashes, recentlyOffline, currentValidatorsControllersV1OrStashesV2 } = this.props;
+    const { chain_subscribeNewHead, allControllers, allStashes, recentlyOffline, currentValidatorsControllersV1OrStashesV2, isSubstrateV2 } = this.props;
     let nextSorted: string[];
 
-    if (Object.keys(api.consts).length) {
+    if (isSubstrateV2) {
       // this is a V2 node currentValidatorsControllersV1OrStashesV2 is a list of stashes
       nextSorted = allStashes.filter((address) =>
         !currentValidatorsControllersV1OrStashesV2.includes(address)

--- a/packages/app-staking/src/Overview/index.tsx
+++ b/packages/app-staking/src/Overview/index.tsx
@@ -22,7 +22,7 @@ type Props = ApiProps & BareProps & ComponentProps & {
 class Overview extends React.PureComponent<Props> {
   render () {
     const { chain_subscribeNewHead, allControllers, allStashes, recentlyOffline, currentValidatorsControllersV1OrStashesV2 } = this.props;
-    let nextSorted: Array<string>;
+    let nextSorted: string[];
 
     if (Object.keys(api.consts).length) {
       // this is a V2 node currentValidatorsControllersV1OrStashesV2 is a list of stashes

--- a/packages/app-staking/src/Overview/index.tsx
+++ b/packages/app-staking/src/Overview/index.tsx
@@ -2,7 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-// import { Balance } from '@polkadot/types';
 import { BareProps } from '@polkadot/ui-app/types';
 import { ComponentProps } from '../types';
 
@@ -49,9 +48,9 @@ class Overview extends React.PureComponent<Props> {
       <div className='staking--Overview'>
         <Summary
           allControllers={allControllers}
+          currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
           lastBlock={lastBlock}
           lastAuthor={lastAuthor}
-          currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
         />
         <CurrentList
           currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -24,17 +24,17 @@ import translate from './translate';
 
 type Props = AppProps & ApiProps & I18nProps & {
   allAccounts?: SubjectInfo,
-  allStashesAndControllers?: [Array<AccountId>, Array<Option<AccountId>>],
-  currentValidatorsControllersV1OrStashesV2?: Array<AccountId>,
+  allStashesAndControllers?: [AccountId[], Option<AccountId>[]],
+  currentValidatorsControllersV1OrStashesV2?: AccountId[],
   staking_recentlyOffline?: RecentlyOffline
 };
 
 type State = {
-  allControllers: Array<string>,
-  allStashes: Array<string>,
-  currentValidatorsControllersV1OrStashesV2: Array<string>,
+  allControllers: string[],
+  allStashes: string[],
+  currentValidatorsControllersV1OrStashesV2: string[],
   recentlyOffline: RecentlyOfflineMap,
-  tabs: Array<TabItem>
+  tabs: TabItem[]
 };
 
 class App extends React.PureComponent<Props, State> {

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -24,17 +24,17 @@ import translate from './translate';
 
 type Props = AppProps & ApiProps & I18nProps & {
   allAccounts?: SubjectInfo,
-  currentValidatorsControllersV1OrStashesV2?: Array<AccountId>,
   allStashesAndControllers?: [Array<AccountId>, Array<Option<AccountId>>],
+  currentValidatorsControllersV1OrStashesV2?: Array<AccountId>,
   staking_recentlyOffline?: RecentlyOffline
 };
 
 type State = {
   allControllers: Array<string>,
-  recentlyOffline: RecentlyOfflineMap,
   allStashes: Array<string>,
-  tabs: Array<TabItem>,
-  currentValidatorsControllersV1OrStashesV2: Array<string>
+  currentValidatorsControllersV1OrStashesV2: Array<string>,
+  recentlyOffline: RecentlyOfflineMap,
+  tabs: Array<TabItem>
 };
 
 class App extends React.PureComponent<Props, State> {
@@ -47,8 +47,9 @@ class App extends React.PureComponent<Props, State> {
 
     this.state = {
       allControllers: [],
-      recentlyOffline: {},
       allStashes: [],
+      currentValidatorsControllersV1OrStashesV2: [],
+      recentlyOffline: {},
       tabs: [
         {
           isRoot: true,
@@ -59,8 +60,7 @@ class App extends React.PureComponent<Props, State> {
           name: 'actions',
           text: t('Account actions')
         }
-      ],
-      currentValidatorsControllersV1OrStashesV2: []
+      ]
     };
   }
 
@@ -129,9 +129,9 @@ class App extends React.PureComponent<Props, State> {
         <Component
           allAccounts={allAccounts}
           allControllers={allControllers}
-          recentlyOffline={recentlyOffline}
           allStashes={allStashes}
           currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
+          recentlyOffline={recentlyOffline}
         />
       );
     };

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -2,7 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { DerivedBalancesMap } from '@polkadot/api-derive/types';
 import { AppProps, I18nProps } from '@polkadot/ui-app/types';
 import { ApiProps } from '@polkadot/ui-api/types';
 import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
@@ -25,18 +24,17 @@ import translate from './translate';
 
 type Props = AppProps & ApiProps & I18nProps & {
   allAccounts?: SubjectInfo,
-  balances?: DerivedBalancesMap,
-  session_validators?: Array<AccountId>,
-  staking_controllers?: [Array<AccountId>, Array<Option<AccountId>>],
+  currentValidatorsControllersV1OrStashesV2?: Array<AccountId>,
+  allStashesAndControllers?: [Array<AccountId>, Array<Option<AccountId>>],
   staking_recentlyOffline?: RecentlyOffline
 };
 
 type State = {
-  controllers: Array<string>,
+  allControllers: Array<string>,
   recentlyOffline: RecentlyOfflineMap,
-  stashes: Array<string>,
+  allStashes: Array<string>,
   tabs: Array<TabItem>,
-  validators: Array<string>
+  currentValidatorsControllersV1OrStashesV2: Array<string>
 };
 
 class App extends React.PureComponent<Props, State> {
@@ -48,9 +46,9 @@ class App extends React.PureComponent<Props, State> {
     const { t } = props;
 
     this.state = {
-      controllers: [],
+      allControllers: [],
       recentlyOffline: {},
-      stashes: [],
+      allStashes: [],
       tabs: [
         {
           isRoot: true,
@@ -62,17 +60,17 @@ class App extends React.PureComponent<Props, State> {
           text: t('Account actions')
         }
       ],
-      validators: []
+      currentValidatorsControllersV1OrStashesV2: []
     };
   }
 
-  static getDerivedStateFromProps ({ staking_controllers = [[], []], session_validators = [], staking_recentlyOffline = [] }: Props): State {
+  static getDerivedStateFromProps ({ allStashesAndControllers = [[], []], currentValidatorsControllersV1OrStashesV2 = [], staking_recentlyOffline = [] }: Props): State {
     return {
-      controllers: staking_controllers[1].filter((optId) => optId.isSome).map((accountId) =>
+      allControllers: allStashesAndControllers[1].filter((optId) => optId.isSome).map((accountId) =>
         accountId.unwrap().toString()
       ),
-      stashes: staking_controllers[0].map((accountId) => accountId.toString()),
-      validators: session_validators.map((authorityId) =>
+      allStashes: allStashesAndControllers[0].map((accountId) => accountId.toString()),
+      currentValidatorsControllersV1OrStashesV2: currentValidatorsControllersV1OrStashesV2.map((authorityId) =>
         authorityId.toString()
       ),
       recentlyOffline: staking_recentlyOffline.reduce(
@@ -120,8 +118,8 @@ class App extends React.PureComponent<Props, State> {
 
   private renderComponent (Component: React.ComponentType<ComponentProps>) {
     return (): React.ReactNode => {
-      const { controllers, recentlyOffline, stashes, validators } = this.state;
-      const { balances = {}, allAccounts } = this.props;
+      const { allControllers, recentlyOffline, allStashes, currentValidatorsControllersV1OrStashesV2 } = this.state;
+      const { allAccounts } = this.props;
 
       if (!allAccounts) {
         return null;
@@ -130,11 +128,10 @@ class App extends React.PureComponent<Props, State> {
       return (
         <Component
           allAccounts={allAccounts}
-          balances={balances}
-          controllers={controllers}
+          allControllers={allControllers}
           recentlyOffline={recentlyOffline}
-          stashes={stashes}
-          validators={validators}
+          allStashes={allStashes}
+          currentValidatorsControllersV1OrStashesV2={currentValidatorsControllersV1OrStashesV2}
         />
       );
     };
@@ -145,8 +142,8 @@ export default withMulti(
   App,
   translate,
   withCalls<Props>(
-    'derive.staking.controllers',
-    'query.session.validators',
+    ['derive.staking.controllers', { propName: 'allStashesAndControllers' }],
+    ['query.session.validators', { propName: 'currentValidatorsControllersV1OrStashesV2' }],
     'query.staking.recentlyOffline'
   ),
   withObservable(accountObservable.subject, { propName: 'allAccounts' })

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -9,14 +9,14 @@ import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 
 export type Nominators = {
   // stash account and who is being nominated
-  [index: string]: Array<string>
+  [index: string]: string[]
 };
 
 export type ComponentProps = {
   allAccounts?: SubjectInfo,
-  allControllers: Array<string>,
-  allStashes: Array<string>,
-  currentValidatorsControllersV1OrStashesV2: Array<string>,
+  allControllers: string[],
+  allStashes: string[],
+  currentValidatorsControllersV1OrStashesV2: string[],
   recentlyOffline: RecentlyOfflineMap
 };
 
@@ -26,10 +26,10 @@ export type CalculateBalanceProps = {
   system_accountNonce?: BN
 };
 
-export type RecentlyOffline = Array<[AccountId, BlockNumber, BN]>;
+export type RecentlyOffline = [AccountId, BlockNumber, BN][];
 
 export type RecentlyOfflineMap = {
-  [s: string]: Array<OfflineStatus>
+  [s: string]: OfflineStatus[]
 };
 
 export interface OfflineStatus {

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -15,9 +15,9 @@ export type Nominators = {
 export type ComponentProps = {
   allAccounts?: SubjectInfo,
   allControllers: Array<string>,
-  recentlyOffline: RecentlyOfflineMap,
   allStashes: Array<string>,
-  currentValidatorsControllersV1OrStashesV2: Array<string>
+  currentValidatorsControllersV1OrStashesV2: Array<string>,
+  recentlyOffline: RecentlyOfflineMap
 };
 
 export type CalculateBalanceProps = {

--- a/packages/app-staking/src/types.ts
+++ b/packages/app-staking/src/types.ts
@@ -4,7 +4,7 @@
 
 import { AccountId, BlockNumber } from '@polkadot/types';
 import BN from 'bn.js';
-import { DerivedFees, DerivedBalances, DerivedBalancesMap } from '@polkadot/api-derive/types';
+import { DerivedFees, DerivedBalances } from '@polkadot/api-derive/types';
 import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 
 export type Nominators = {
@@ -14,11 +14,10 @@ export type Nominators = {
 
 export type ComponentProps = {
   allAccounts?: SubjectInfo,
-  balances?: DerivedBalancesMap,
-  controllers: Array<string>,
+  allControllers: Array<string>,
   recentlyOffline: RecentlyOfflineMap,
-  stashes: Array<string>,
-  validators: Array<string>
+  allStashes: Array<string>,
+  currentValidatorsControllersV1OrStashesV2: Array<string>
 };
 
 export type CalculateBalanceProps = {

--- a/packages/ui-api/src/Api.tsx
+++ b/packages/ui-api/src/Api.tsx
@@ -59,10 +59,11 @@ export default class Api extends React.PureComponent<Props, State> {
     api = new ApiPromise({ provider, signer });
 
     this.state = {
+      api,
       isApiConnected: false,
       isApiReady: false,
+      isSubstrateV2: true,
       isWaitingInjected: isWeb3Injected,
-      api,
       setApiUrl
     } as State;
   }
@@ -138,18 +139,20 @@ export default class Api extends React.PureComponent<Props, State> {
       (api.tx.system && api.tx.system.setCode) || // 2.x
       (api.tx.consensus && api.tx.consensus.setCode) || // 1.x
       apiDefaultTx; // other
+    const isSubstrateV2 = !!Object.keys(api.consts).length;
 
     this.setState({
-      isApiReady: true,
       apiDefaultTx,
       apiDefaultTxSudo,
       chain,
-      isDevelopment
+      isApiReady: true,
+      isDevelopment,
+      isSubstrateV2
     });
   }
 
   render () {
-    const { api, apiDefaultTx, apiDefaultTxSudo, chain, isApiConnected, isApiReady, isDevelopment, isWaitingInjected, setApiUrl } = this.state;
+    const { api, apiDefaultTx, apiDefaultTxSudo, chain, isApiConnected, isApiReady, isDevelopment, isSubstrateV2, isWaitingInjected, setApiUrl } = this.state;
 
     return (
       <ApiContext.Provider
@@ -161,6 +164,7 @@ export default class Api extends React.PureComponent<Props, State> {
           isApiConnected,
           isApiReady: isApiReady && !!chain,
           isDevelopment,
+          isSubstrateV2,
           isWaitingInjected,
           setApiUrl
         }}

--- a/packages/ui-api/src/types.ts
+++ b/packages/ui-api/src/types.ts
@@ -23,6 +23,7 @@ export type ApiProps = {
   isApiConnected: boolean,
   isApiReady: boolean,
   isDevelopment: boolean,
+  isSubstrateV2: boolean,
   isWaitingInjected: boolean,
   setApiUrl: (url?: string) => void
 };


### PR DESCRIPTION
- one part of https://github.com/polkadot-js/apps/issues/1378 the rest should be sorted with `derive.staking.info` (https://github.com/polkadot-js/api/issues/1113)
- cleaning the balance props that was carried around and never used
- a lot of renaming to make things clearer (IMHO), e.g `stashes` --> `allStashes` (includes the ones currently **not** selected in the validator set) or the monster `currentValidatorsControllersV1OrStashesV2` that represents either the stash (v2) or the controllers (v1) from the validators currently in the validator set. lmk if you think about something better.
- working well on Alex, and almost nothing is shown on v2 (because of the derive)