### PR TITLE
Add endpoint fallbacks option and handling of consts to ui-api

### DIFF
--- a/packages/app-contracts/src/Codes/ValidateCode.tsx
+++ b/packages/app-contracts/src/Codes/ValidateCode.tsx
@@ -16,7 +16,7 @@ import translate from '../translate';
 
 type Props = ApiProps & I18nProps & {
   codeHash?: string | null;
-  contract_codeStorage?: Option<PrefabWasmModule>;
+  contracts_codeStorage?: Option<PrefabWasmModule>;
   onChange: (isValid: boolean) => void;
 };
 
@@ -33,9 +33,9 @@ class ValidateCode extends React.PureComponent<Props> {
     isValid: false
   };
 
-  public static getDerivedStateFromProps ({ codeHash, contract_codeStorage, onChange }: Props): State {
+  public static getDerivedStateFromProps ({ codeHash, contracts_codeStorage, onChange }: Props): State {
     const isValidHex = !!codeHash && isHex(codeHash) && codeHash.length === 66;
-    const isStored = !!contract_codeStorage && contract_codeStorage.isSome;
+    const isStored = !!contracts_codeStorage && contracts_codeStorage.isSome;
     const isValid = isValidHex && isStored;
 
     // FIXME Really not convinced this is the correct place to do this type of callback?

--- a/packages/app-contracts/src/Codes/ValidateCode.tsx
+++ b/packages/app-contracts/src/Codes/ValidateCode.tsx
@@ -70,7 +70,6 @@ class ValidateCode extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['query.contracts.codeStorage', { paramName: 'codeHash' }], // 2.x
-    ['query.contract.codeStorage', { paramName: 'codeHash' }] // 1.x
+    ['query.contracts.codeStorage', { fallback: 'query.contract.codeStorage', paramName: 'codeHash' }]
   )(ValidateCode)
 );

--- a/packages/app-contracts/src/Codes/ValidateCode.tsx
+++ b/packages/app-contracts/src/Codes/ValidateCode.tsx
@@ -70,6 +70,6 @@ class ValidateCode extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['query.contracts.codeStorage', { fallback: 'query.contract.codeStorage', paramName: 'codeHash' }]
+    ['query.contracts.codeStorage', { fallbacks: ['query.contract.codeStorage'], paramName: 'codeHash' }]
   )(ValidateCode)
 );

--- a/packages/app-contracts/src/Contracts/ValidateAddr.tsx
+++ b/packages/app-contracts/src/Contracts/ValidateAddr.tsx
@@ -82,6 +82,6 @@ class ValidateAddr extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['query.contracts.contractInfoOf', { fallback: 'query.contract.codeStorage', paramName: 'address' }]
+    ['query.contracts.contractInfoOf', { fallback: 'query.contract.contractInfoOf', paramName: 'address' }]
   )(ValidateAddr)
 );

--- a/packages/app-contracts/src/Contracts/ValidateAddr.tsx
+++ b/packages/app-contracts/src/Contracts/ValidateAddr.tsx
@@ -82,6 +82,6 @@ class ValidateAddr extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['query.contracts.contractInfoOf', { fallback: 'query.contract.contractInfoOf', paramName: 'address' }]
+    ['query.contracts.contractInfoOf', { fallbacks: ['query.contract.contractInfoOf'], paramName: 'address' }]
   )(ValidateAddr)
 );

--- a/packages/app-contracts/src/Contracts/ValidateAddr.tsx
+++ b/packages/app-contracts/src/Contracts/ValidateAddr.tsx
@@ -82,7 +82,6 @@ class ValidateAddr extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['query.contracts.contractInfoOf', { paramName: 'address' }], // 2.x
-    ['query.contract.contractInfoOf', { paramName: 'address' }] // 1.x
+    ['query.contracts.contractInfoOf', { fallback: 'query.contract.codeStorage', paramName: 'address' }]
   )(ValidateAddr)
 );

--- a/packages/app-contracts/src/Contracts/ValidateAddr.tsx
+++ b/packages/app-contracts/src/Contracts/ValidateAddr.tsx
@@ -16,7 +16,7 @@ import translate from '../translate';
 
 type Props = ApiProps & I18nProps & {
   address?: string | null;
-  contract_contractInfoOf?: Option<ContractInfo>;
+  contracts_contractInfoOf?: Option<ContractInfo>;
   onChange: (isValid: boolean) => void;
 };
 
@@ -33,7 +33,7 @@ class ValidateAddr extends React.PureComponent<Props> {
     isValid: false
   };
 
-  public static getDerivedStateFromProps ({ address, contract_contractInfoOf, onChange }: Props): State {
+  public static getDerivedStateFromProps ({ address, contracts_contractInfoOf, onChange }: Props): State {
     let isValidAddr = false;
 
     try {
@@ -45,7 +45,7 @@ class ValidateAddr extends React.PureComponent<Props> {
     }
 
     const isStored = (
-      (!!contract_contractInfoOf && contract_contractInfoOf.isSome)
+      (!!contracts_contractInfoOf && contracts_contractInfoOf.isSome)
       // (!!contract_codeHashOf && contract_codeHashOf.isSome)
     );
     const isValid = isValidAddr && isStored;

--- a/packages/app-democracy/src/Overview/Referendum.tsx
+++ b/packages/app-democracy/src/Overview/Referendum.tsx
@@ -29,7 +29,7 @@ interface Props extends I18nProps {
   idNumber: BN;
   chain_bestNumber?: BN;
   democracy_referendumVotesFor?: DerivedReferendumVote[];
-  democracy_publicDelay?: BN;
+  democracy_enactmentPeriod: BN;
   value: ReferendumInfoExtended;
 }
 
@@ -111,13 +111,13 @@ class Referendum extends React.PureComponent<Props, State> {
   }
 
   private renderInfo (): React.ReactNode {
-    const { chain_bestNumber, democracy_publicDelay, t, value: { end, threshold } } = this.props;
+    const { chain_bestNumber, democracy_enactmentPeriod, t, value: { end, threshold } } = this.props;
 
     if (!chain_bestNumber) {
       return null;
     }
 
-    const enactBlock = (democracy_publicDelay || new BN(0)).add(end);
+    const enactBlock = (democracy_enactmentPeriod || new BN(0)).add(end);
 
     return (
       <div>
@@ -193,6 +193,6 @@ export default withMulti(
   withCalls<Props>(
     'derive.chain.bestNumber',
     ['derive.democracy.referendumVotesFor', { paramName: 'idNumber' }],
-    'query.democracy.publicDelay'
+    ['consts.democracy.enactmentPeriod', { fallback: 'query.democracy.publicDelay' }]
   )
 );

--- a/packages/app-democracy/src/Overview/Referendum.tsx
+++ b/packages/app-democracy/src/Overview/Referendum.tsx
@@ -193,6 +193,6 @@ export default withMulti(
   withCalls<Props>(
     'derive.chain.bestNumber',
     ['derive.democracy.referendumVotesFor', { paramName: 'idNumber' }],
-    ['consts.democracy.enactmentPeriod', { fallback: 'query.democracy.publicDelay' }]
+    ['consts.democracy.enactmentPeriod', { fallbacks: ['query.democracy.publicDelay'] }]
   )
 );

--- a/packages/app-democracy/src/Overview/Summary.tsx
+++ b/packages/app-democracy/src/Overview/Summary.tsx
@@ -61,7 +61,7 @@ class Summary extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    ['consts.democracy.launchPeriod', { fallback: 'query.democracy.launchPeriod' }],
+    ['consts.democracy.launchPeriod', { fallbacks: ['query.democracy.launchPeriod'] }],
     'query.democracy.nextTally',
     'query.democracy.publicPropCount',
     'query.democracy.referendumCount',

--- a/packages/app-democracy/src/Overview/Summary.tsx
+++ b/packages/app-democracy/src/Overview/Summary.tsx
@@ -17,14 +17,20 @@ interface Props extends I18nProps {
   chain_bestNumber?: BN;
   democracy_launchPeriod?: BN;
   democracy_nextTally?: BN;
-  democracy_publicDelay?: BN;
   democracy_publicPropCount?: BN;
   democracy_referendumCount?: BN;
 }
 
 class Summary extends React.PureComponent<Props> {
   public render (): React.ReactNode {
-    const { chain_bestNumber = new BN(0), democracy_launchPeriod = new BN(1), democracy_nextTally = new BN(0), democracy_publicPropCount, democracy_referendumCount = new BN(0), t } = this.props;
+    const {
+      chain_bestNumber = new BN(0),
+      democracy_launchPeriod = new BN(1),
+      democracy_nextTally = new BN(0),
+      democracy_publicPropCount,
+      democracy_referendumCount = new BN(0),
+      t
+    } = this.props;
 
     return (
       <SummaryBox>
@@ -55,7 +61,7 @@ class Summary extends React.PureComponent<Props> {
 
 export default translate(
   withCalls<Props>(
-    'query.democracy.launchPeriod',
+    ['consts.democracy.launchPeriod', { fallback: 'query.democracy.launchPeriod' }],
     'query.democracy.nextTally',
     'query.democracy.publicPropCount',
     'query.democracy.referendumCount',

--- a/packages/app-js/src/snippets/storage-examples.ts
+++ b/packages/app-js/src/snippets/storage-examples.ts
@@ -11,11 +11,12 @@ export const storageGetInfo: Snippet = {
   code: `// Get chain state information
 // Make our basic chain state/storage queries, all in one go
 
-const [minimumPeriod, validators, transferFee] = await Promise.all([
+const [minimumPeriod, validators] = await Promise.all([
   api.query.timestamp.minimumPeriod(),
-  api.query.session.validators(),
-  api.query.balances.transferFee()
+  api.query.session.validators()
 ]);
+
+const transferFee = api.consts.balances.transferFee;
 
 console.log('minimum period between blocks: ' + minimumPeriod);
 console.log('transfer fee: ', transferFee);

--- a/packages/app-js/src/snippets/storage-examples.ts
+++ b/packages/app-js/src/snippets/storage-examples.ts
@@ -11,14 +11,14 @@ export const storageGetInfo: Snippet = {
   code: `// Get chain state information
 // Make our basic chain state/storage queries, all in one go
 
-const [minimumPeriod, validators] = await Promise.all([
-  api.query.timestamp.minimumPeriod(),
+const [blockPeriod, validators] = await Promise.all([
+  api.query.timestamp.blockPeriod(),
   api.query.session.validators()
 ]);
 
 const transferFee = api.consts.balances.transferFee;
 
-console.log('minimum period between blocks: ' + minimumPeriod);
+console.log('The block period: ' + blockPeriod);
 console.log('transfer fee: ', transferFee);
 
 if (validators && validators.length > 0) {

--- a/packages/app-js/src/snippets/storage-examples.ts
+++ b/packages/app-js/src/snippets/storage-examples.ts
@@ -11,14 +11,14 @@ export const storageGetInfo: Snippet = {
   code: `// Get chain state information
 // Make our basic chain state/storage queries, all in one go
 
-const [blockPeriod, validators] = await Promise.all([
-  api.query.timestamp.blockPeriod(),
+const [minimumValidatorCount, validators] = await Promise.all([
+  api.query.staking.minimumValidatorCount(),
   api.query.session.validators()
 ]);
 
 const transferFee = api.consts.balances.transferFee;
 
-console.log('The block period: ' + blockPeriod);
+console.log('The minimum validator count: ' + minimumValidatorCount);
 console.log('transfer fee: ', transferFee);
 
 if (validators && validators.length > 0) {

--- a/packages/app-treasury/src/Overview/Approve.tsx
+++ b/packages/app-treasury/src/Overview/Approve.tsx
@@ -50,7 +50,13 @@ class Approve extends TxModal<Props, State> {
   }
 
   protected renderTrigger = (): React.ReactNode => {
-    const { t } = this.props;
+    const { api, t } = this.props;
+
+    // disable voting for 1.x (we only use elections here)
+    if (!api.query.elections) {
+      return null;
+    }
+
     return (
       <div className='ui--Row-buttons'>
         <Button.Group>
@@ -100,13 +106,10 @@ export default withMulti(
   translate,
   withApi,
   withCalls(
-    [
-      'query.elections.members',
-      {
-        propName: 'threshold',
-        transform: (value: [AccountId, BlockNumber][]): number =>
-          1 + (value.length / 2)
-      }
-    ]
+    ['query.elections.members', {
+      propName: 'threshold',
+      transform: (value: [AccountId, BlockNumber][]): number =>
+        1 + (value.length / 2)
+    }]
   )
 );

--- a/packages/app-treasury/src/Settings.tsx
+++ b/packages/app-treasury/src/Settings.tsx
@@ -201,10 +201,10 @@ export default withMulti(
   Settings,
   translate,
   withCalls<Props>(
-    ['query.treasury.proposalBond', { propName: 'proposalBond' }],
-    ['query.treasury.proposalBondMinimum', { propName: 'proposalBondMinimum' }],
-    ['query.treasury.spendPeriod', { propName: 'spendPeriod' }],
-    ['query.treasury.burn', { propName: 'burn' }],
+    ['consts.treasury.proposalBond', { fallback: 'query.treasury.proposalBond', propName: 'proposalBond' }],
+    ['consts.treasury.proposalBondMinimum', { fallback: 'query.treasury.proposalBondMinimum', propName: 'proposalBondMinimum' }],
+    ['consts.treasury.spendPeriod', { fallback: 'query.treasury.spendPeriod', propName: 'spendPeriod' }],
+    ['consts.treasury.burn', { fallback: 'query.treasury.burn', propName: 'burn' }],
     ['query.treasury.pot', { propName: 'pot' }]
   )
 );

--- a/packages/app-treasury/src/Settings.tsx
+++ b/packages/app-treasury/src/Settings.tsx
@@ -201,10 +201,10 @@ export default withMulti(
   Settings,
   translate,
   withCalls<Props>(
-    ['consts.treasury.proposalBond', { fallback: 'query.treasury.proposalBond', propName: 'proposalBond' }],
-    ['consts.treasury.proposalBondMinimum', { fallback: 'query.treasury.proposalBondMinimum', propName: 'proposalBondMinimum' }],
-    ['consts.treasury.spendPeriod', { fallback: 'query.treasury.spendPeriod', propName: 'spendPeriod' }],
-    ['consts.treasury.burn', { fallback: 'query.treasury.burn', propName: 'burn' }],
+    ['consts.treasury.proposalBond', { fallbacks: ['query.treasury.proposalBond'], propName: 'proposalBond' }],
+    ['consts.treasury.proposalBondMinimum', { fallbacks: ['query.treasury.proposalBondMinimum'], propName: 'proposalBondMinimum' }],
+    ['consts.treasury.spendPeriod', { fallbacks: ['query.treasury.spendPeriod'], propName: 'spendPeriod' }],
+    ['consts.treasury.burn', { fallbacks: ['query.treasury.burn'], propName: 'burn' }],
     ['query.treasury.pot', { propName: 'pot' }]
   )
 );

--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -18,7 +18,7 @@ interface Method {
   multi: (params: any[], cb: (value?: any) => void) => Promise<any>;
 }
 
-type ApiMethodInfo = [Method, any[], boolean, string];
+type ApiMethodInfo = [Method, any[], string];
 
 type State = CallState;
 
@@ -165,15 +165,13 @@ export default function withCall<P extends ApiProps> (
           return [
             fn,
             params,
-            true,
-            ''
+            'subscribe'
           ];
         }
 
         const endpoints: string[] = [endpoint].concat(fallbacks || []);
-        let apiSection, area, section, method;
 
-        [endpoint, apiSection, area, section, method] = endpoints
+        const [, apiSection, area, section, method] = endpoints
           .map(this.constructApiSection, this)
           .find(([, apiSection]) => apiSection);
 
@@ -190,8 +188,7 @@ export default function withCall<P extends ApiProps> (
         return [
           apiSection[method],
           newParams,
-          method.startsWith('subscribe'),
-          area
+          method.startsWith('subscribe') ? 'subscribe' : area
         ];
       }
 
@@ -217,14 +214,14 @@ export default function withCall<P extends ApiProps> (
           return;
         }
 
-        const [apiMethod, params, isSubscription, area] = info;
+        const [apiMethod, params, area] = info;
         const updateCb = (value?: any): void =>
           this.triggerUpdate(this.props, value);
 
         await this.unsubscribe();
 
         try {
-          if (isSubscription || area === 'derive' || (area === 'query' && (!at && !atProp))) {
+          if (['derive', 'subscribe'].includes(area) || (area === 'query' && (!at && !atProp))) {
             this.destroy = isMulti
               ? await apiMethod.multi(params, updateCb)
               : await apiMethod(...params, updateCb);

--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -32,7 +32,7 @@ export default function withCall<P extends ApiProps> (
     at,
     atProp,
     callOnResult,
-    fallback,
+    fallbacks,
     isMulti = false,
     params = [],
     paramName,
@@ -170,13 +170,7 @@ export default function withCall<P extends ApiProps> (
           ];
         }
 
-        const fallbacks: string[] = fallback
-          ? Array.isArray(fallback)
-            ? fallback
-            : [fallback]
-          : [];
-
-        const endpoints = [endpoint].concat(fallbacks);
+        const endpoints = [endpoint].concat(fallbacks || []);
         let apiSection, area, section, method;
         let i = 0;
 
@@ -246,7 +240,7 @@ export default function withCall<P extends ApiProps> (
             );
           }
         } catch (error) {
-          console.error(endpoint, '::', error);
+          // console.error(endpoint, '::', error);
         }
       }
 

--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -246,7 +246,7 @@ export default function withCall<P extends ApiProps> (
             updateCb(
               at
                 ? await apiMethod.at(at, ...params)
-                : await apiMethod
+                : await apiMethod(...params)
             );
           }
         } catch (error) {
@@ -283,14 +283,13 @@ export default function withCall<P extends ApiProps> (
 
       public render (): React.ReactNode {
         const { callUpdated, callUpdatedAt, callResult } = this.state;
-        // console.log('callResult', callResult);
         const _props = {
           ...this.props,
           callUpdated,
           callUpdatedAt,
           [propName || this.propName]: callResult
         };
-        // console.log('_PROPS'._props);
+
         return (
           <Inner {..._props} />
         );

--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -60,7 +60,7 @@ export default function withCall<P extends ApiProps> (
       public constructor (props: P) {
         super(props);
 
-        const [la, section, method] = endpoint.split('.');
+        const [, section, method] = endpoint.split('.');
 
         this.propName = `${section}_${method}`;
       }
@@ -141,9 +141,9 @@ export default function withCall<P extends ApiProps> (
 
       private constructApiSection (endpoint: string): any {
         const { api } = this.props;
-        const [area, section, method] = endpoint.split('.');
+        const [area, section, method, ...others] = endpoint.split('.');
 
-        assert(area.length && section.length && method.length, `Invalid API format, expected <area>.<section>.<method>, found ${endpoint}`);
+        assert(area.length && section.length && method.length && others.length === 0, `Invalid API format, expected <area>.<section>.<method>, found ${endpoint}`);
         assert(['consts', 'rpc', 'query', 'derive'].includes(area), `Unknown api.${area}, expected consts, rpc, query or derive`);
         assert(!at || area === 'query', `Only able to do an 'at' query on the api.query interface`);
 
@@ -186,9 +186,6 @@ export default function withCall<P extends ApiProps> (
         }
 
         assert(apiSection && apiSection[method], `Unable to find api.${area}.${section}.${method}`);
-
-        // TODO ??
-        const others = endpoint.split('.').slice(3);
 
         const meta = apiSection[method].meta;
 
@@ -240,7 +237,6 @@ export default function withCall<P extends ApiProps> (
               ? await apiMethod.multi(params, updateCb)
               : await apiMethod(...params, updateCb);
           } else if (isConst) {
-            console.log('Yes, its a const');
             updateCb(apiMethod);
           } else {
             updateCb(

--- a/packages/ui-api/src/with/call.tsx
+++ b/packages/ui-api/src/with/call.tsx
@@ -199,7 +199,7 @@ export default function withCall<P extends ApiProps> (
           apiSection[method],
           newParams,
           area === 'derive' || (area === 'query' && (!at && !atProp)) || method.startsWith('subscribe'),
-          area === 'const'
+          area === 'consts'
         ];
       }
 

--- a/packages/ui-api/src/with/types.ts
+++ b/packages/ui-api/src/with/types.ts
@@ -17,6 +17,7 @@ export interface Options {
   at?: Uint8Array | string;
   atProp?: string;
   callOnResult?: OnChangeCb;
+  fallback?: string[] | string;
   isMulti?: boolean;
   params?: any[];
   paramName?: string;

--- a/packages/ui-api/src/with/types.ts
+++ b/packages/ui-api/src/with/types.ts
@@ -17,7 +17,7 @@ export interface Options {
   at?: Uint8Array | string;
   atProp?: string;
   callOnResult?: OnChangeCb;
-  fallback?: string[] | string;
+  fallbacks?: string[];
   isMulti?: boolean;
   params?: any[];
   paramName?: string;

--- a/packages/ui-signer/src/Checks/Proposal.tsx
+++ b/packages/ui-signer/src/Checks/Proposal.tsx
@@ -92,6 +92,6 @@ export default withMulti(
   Proposal,
   translate,
   withCalls<Props>(
-    ['consts.democracy.minimumDeposit', { fallback: 'query.democracy.minimumDeposit' }]
+    ['consts.democracy.minimumDeposit', { fallbacks: ['query.democracy.minimumDeposit'] }]
   )
 );

--- a/packages/ui-signer/src/Checks/Proposal.tsx
+++ b/packages/ui-signer/src/Checks/Proposal.tsx
@@ -35,7 +35,11 @@ export class Proposal extends React.PureComponent<Props, State> {
     isBelowMinimum: false
   };
 
-  public static getDerivedStateFromProps ({ deposit, democracy_minimumDeposit = new BN(0), onChange }: Props): State {
+  public static getDerivedStateFromProps ({
+    deposit,
+    democracy_minimumDeposit = new BN(0),
+    onChange
+  }: Props): State {
     const extraAmount = deposit instanceof Compact
       ? deposit.toBn()
       : deposit;
@@ -87,5 +91,7 @@ export class Proposal extends React.PureComponent<Props, State> {
 export default withMulti(
   Proposal,
   translate,
-  withCalls<Props>('query.democracy.minimumDeposit')
+  withCalls<Props>(
+    ['consts.democracy.minimumDeposit', { fallback: 'query.democracy.minimumDeposit' }]
+  )
 );


### PR DESCRIPTION
Solves https://github.com/polkadot-js/apps/issues/1415

I added an option to pass fallback endpoints to the `ui-api` to provide an easy way to make the components backwards compatible.

I changed the ui-api so that it loops through the endpoint and fallback endpoints, if provided.
This way, we can just pass deprecated endpoints to `withCalls`.

If no fallbacks are provided `withCalls` will behave like before.

For 1 fallback call:
`['consts.democracy.launchPeriod', { fallback: ['query.democracy.launchPeriod'] }]`

For multiple fallback calls:  
`['consts.contracts.contractFee', { fallback: ['query.contracts.contractFee', 'query.contract.contractFee'] }]`
