### PR TITLE
Display AuthorityId param as Address

### DIFF
--- a/packages/ui-params/src/Param/findComponent.ts
+++ b/packages/ui-params/src/Param/findComponent.ts
@@ -34,7 +34,7 @@ interface TypeToComponent {
 }
 
 const components: ComponentMap = ([
-  { c: Account, t: ['AccountId', 'AccountIdOf', 'Address', 'SessionKey'] },
+  { c: Account, t: ['AccountId', 'AccountIdOf', 'Address', 'AuthorityId', 'SessionKey'] },
   { c: Amount, t: ['AccountIndex', 'BlockNumber', 'Gas', 'Index', 'Nonce', 'ParaId', 'ProposalIndex', 'PropIndex', 'ReferendumIndex', 'u16', 'u32', 'u64', 'u128', 'u256', 'VoteIndex'] },
   { c: Balance, t: ['Amount', 'AssetOf', 'Balance', 'BalanceOf'] },
   { c: Bool, t: ['bool'] },


### PR DESCRIPTION
Instead of the picture in #1438 (without the icon and name), we now have this -

![image](https://user-images.githubusercontent.com/1424473/61700135-78edbc80-ad3c-11e9-8b7e-0309fd35eea8.png)
