### PR TITLE
Fix account wrongly seen as current validator

### DIFF
--- a/packages/app-staking/src/Actions/Account/index.tsx
+++ b/packages/app-staking/src/Actions/Account/index.tsx
@@ -27,9 +27,10 @@ import Validate from './Validate';
 
 type Props = ApiProps & I18nProps & {
   accountId: string;
+  allStashes?: string[];
+  balances_all?: DerivedBalances;
   className?: string;
   recentlyOffline: RecentlyOfflineMap;
-  balances_all?: DerivedBalances;
   staking_info?: DerivedStaking;
   stashOptions: KeyringSectionOption[];
 };
@@ -37,7 +38,6 @@ type Props = ApiProps & I18nProps & {
 interface State {
   controllerId: string | null;
   destination: number;
-  isActiveStash: boolean;
   isBondExtraOpen: boolean;
   isNominateOpen: boolean;
   isSetControllerAccountOpen: boolean;
@@ -66,7 +66,6 @@ class Account extends React.PureComponent<Props, State> {
   public state: State = {
     controllerId: null,
     destination: 0,
-    isActiveStash: false,
     isBondExtraOpen: false,
     isNominateOpen: false,
     isSetControllerAccountOpen: false,
@@ -81,36 +80,36 @@ class Account extends React.PureComponent<Props, State> {
     stashId: null
   };
 
-  public static getDerivedStateFromProps ({ accountId, staking_info }: Props): Pick<State, never> | null {
+  public static getDerivedStateFromProps ({ accountId, allStashes, staking_info }: Props): Pick<State, never> | null {
     if (!staking_info) {
       return null;
     }
 
     const { controllerId, nextSessionId, nominators, rewardDestination, stakers, stakingLedger, stashId, validatorPrefs } = staking_info;
     const isStashNominating = nominators && nominators.length !== 0;
-    const isStashValidating = !!validatorPrefs && !validatorPrefs.isEmpty && !isStashNominating;
+    const _stashId = toIdString(stashId);
+    const isStashValidating = !!allStashes && !!_stashId && allStashes.includes(_stashId);
 
     return {
       controllerId: toIdString(controllerId),
       destination: rewardDestination && rewardDestination.toNumber(),
-      isActiveStash: accountId === toIdString(stashId),
       isStashNominating,
       isStashValidating,
       nominees: nominators && nominators.map(toIdString),
       sessionId: toIdString(nextSessionId),
       stakers,
       stakingLedger,
-      stashId: toIdString(stashId),
+      stashId: _stashId,
       validatorPrefs
     };
   }
 
   public render (): React.ReactNode {
     const { className, t } = this.props;
-    const { isActiveStash, stashId } = this.state;
+    const { stashId } = this.state;
 
-    if (!isActiveStash || !stashId) {
-      return null;
+    if (!stashId) {
+      return;
     }
 
     // Each component is rendered and gets a `is[Component]Open` passed in a `isOpen` props.

--- a/packages/app-staking/src/Actions/Account/index.tsx
+++ b/packages/app-staking/src/Actions/Account/index.tsx
@@ -80,7 +80,7 @@ class Account extends React.PureComponent<Props, State> {
     stashId: null
   };
 
-  public static getDerivedStateFromProps ({ accountId, allStashes, staking_info }: Props): Pick<State, never> | null {
+  public static getDerivedStateFromProps ({ allStashes, staking_info }: Props): Pick<State, never> | null {
     if (!staking_info) {
       return null;
     }
@@ -109,7 +109,7 @@ class Account extends React.PureComponent<Props, State> {
     const { stashId } = this.state;
 
     if (!stashId) {
-      return;
+      return null;
     }
 
     // Each component is rendered and gets a `is[Component]Open` passed in a `isOpen` props.

--- a/packages/app-staking/src/Actions/Accounts.tsx
+++ b/packages/app-staking/src/Actions/Accounts.tsx
@@ -32,7 +32,7 @@ class Accounts extends React.PureComponent<Props, State> {
   };
 
   public render (): React.ReactNode {
-    const { className, recentlyOffline, t } = this.props;
+    const { allStashes, className, recentlyOffline, t } = this.props;
     const { isNewStakeOpen } = this.state;
     const stashOptions = this.getStashOptions();
     const myStashes = this.getMyStashes();
@@ -61,6 +61,7 @@ class Accounts extends React.PureComponent<Props, State> {
         {myStashes && myStashes.map((address, index): React.ReactNode => (
           address &&
           <Account
+            allStashes={allStashes}
             accountId={address}
             key={index}
             recentlyOffline={recentlyOffline}

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -119,7 +119,7 @@ class App extends React.PureComponent<Props, State> {
 
   private renderComponent (Component: React.ComponentType<ComponentProps>): () => React.ReactNode {
     return (): React.ReactNode => {
-      const { allControllers, recentlyOffline, allStashes, currentValidatorsControllersV1OrStashesV2 } = this.state;
+      const { allControllers, allStashes, currentValidatorsControllersV1OrStashesV2, recentlyOffline } = this.state;
       const { allAccounts } = this.props;
 
       if (!allAccounts) {


### PR DESCRIPTION
- closes https://github.com/polkadot-js/apps/issues/1445
- remove useless `isActiveStash` (I remember telling this to myself earlier.. but hadn't had the chance yet)
- nits alphabetical ordering

Because of https://github.com/polkadot-js/apps/issues/1408 (I'll get to it soon) it's not easy to play with, you need to send `staking.validate` manually.