### PR TITLE
Fix isEmpty for CardGrid

### DIFF
--- a/packages/ui-app/src/CardGrid.tsx
+++ b/packages/ui-app/src/CardGrid.tsx
@@ -14,14 +14,12 @@ type Props = CollectionProps;
 type State = CollectionState;
 
 class CardGrid extends Collection<Props, State> {
-  public static getDerivedStateFromProps ({ children, headerText }: Props): State {
-    const isEmpty = !children || (Array.isArray(children) && !children.length);
+  public static getDerivedStateFromProps (props: Props): State {
+    const state = super.getDerivedStateFromProps(props);
 
     return {
-      isEmpty: isEmpty,
-      showHeader: isEmpty
-        ? !!headerText
-        : true
+      ...state,
+      showHeader: !state.isEmpty || !!props.headerText
     };
   }
 

--- a/packages/ui-app/src/Collection.tsx
+++ b/packages/ui-app/src/Collection.tsx
@@ -53,9 +53,9 @@ export default class Collection<P extends CollectionProps, S extends CollectionS
     return !children || (Array.isArray(children) && children.length === 0);
   }
 
-  public static getDerivedStateFromProps ({ children }: CollectionProps): Pick<any, never> {
+  public static getDerivedStateFromProps ({ isEmpty, children }: CollectionProps): CollectionState {
     return {
-      isEmpty: Collection.isEmpty(children)
+      isEmpty: isEmpty === undefined ? Collection.isEmpty(children) : isEmpty
     };
   }
 


### PR DESCRIPTION
Found this issue while working on #1452

The prop `isEmpty` was ignored. You can observe this bug in Address book with no addresses.

Also `Collection.isEmpty` gives false if children is `[false]`. I am not sure what is the desired behavior as do we want to ignore any non-renderable children or just strictly check children is empty array?