### PR TITLE
Add explanation that Docker port is 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ You can run a docker container via -
 To build a docker container containing local changes -
 
   docker build -t chevdor/polkadot-ui:latest .
+  
+When using these Docker commands, you can access the UI via http://localhost:80 (or just http://localhost)


### PR DESCRIPTION
When compiling via `yarn`, the default port used is 3000 (see #L50).  However, the given Docker command runs the UI on port 80 (default HTTP port).  

I added an extra sentence enumerating this difference, because I used the same port with Docker as I did with the local build at first, and it was a bit confusing why I was getting a 404.