### PR TITLE
Fix: Unalble to determine top level customise type

### DIFF
--- a/packages/ui-params/src/initValue.ts
+++ b/packages/ui-params/src/initValue.ts
@@ -104,7 +104,7 @@ export default function getInitValue (def: TypeDef): RawParamValue | RawParamVal
 
         if (instance instanceof BN) {
           return new BN(0);
-        } else if ([TypeDefInfo.Enum, TypeDefInfo.Struct].includes(raw.info)) {
+        } else if ([TypeDefInfo.Enum, TypeDefInfo.Struct, TypeDefInfo.Plain].includes(raw.info)) {
           return getInitValue(raw);
         }
       } catch (error) {


### PR DESCRIPTION
Problem:

We have a type alias of `pub type TokenSymbol = Vec<u8>;`, and it's a parameter in our substrate open endpoint. 

when we try to use polkadot-js/apps to send a request, the console says:

```
Unable to determine default type for {"info":5,"type":"TokenSymbol"}
```

and the input is grayed out:

<img width="250" alt="image" src="https://user-images.githubusercontent.com/1130984/62689125-c8024580-b9fc-11e9-8447-a80ee486651b.png">

This request will let plain type get a raw default value. 