### PR TITLE
Fix address row name overflow

### DIFF
--- a/packages/react-components/src/Row.tsx
+++ b/packages/react-components/src/Row.tsx
@@ -141,7 +141,7 @@ export const styles = `
     white-space: normal;
 
     .withName {
-      white-space: nowrap;
+      white-space: normal;
       text-transform: uppercase;
       overflow: hidden;
       text-overflow: inherit;


### PR DESCRIPTION
Closes #1502 

Don't seem to be any issues with text overflow normal instead of ellipsis (unless I'm forgetting)?