### PR TITLE
Correct typo in JSON example.

### DIFF
--- a/packages/app-settings/src/md/basics.md
+++ b/packages/app-settings/src/md/basics.md
@@ -47,7 +47,7 @@ Be aware that the types are registered in the order they appear here. Since `Tra
       "Two": "u64",
       "Three": null
     }
-  }.
+  },
   "MyNumber": "u32",
   "Thing": {
     "count_enum": "SimpleEnum",


### PR DESCRIPTION
Makes the types example a valid json object.

Noticed the typo when copy-pasting the code.