### PR TITLE
Avoid overflow on staking pages #1502

### DIFF
--- a/packages/app-staking/src/Actions/Account/index.tsx
+++ b/packages/app-staking/src/Actions/Account/index.tsx
@@ -598,9 +598,10 @@ export default withMulti(
     display: flex;
 
     .staking--Accounts {
-      flex: 1;
+      flex: 2;
       display: flex;
-      flex-direction: column
+      flex-direction: column;
+      width: 0px;
     }
 
     .staking--Account-detail.actions{

--- a/packages/app-staking/src/Actions/Account/index.tsx
+++ b/packages/app-staking/src/Actions/Account/index.tsx
@@ -598,7 +598,7 @@ export default withMulti(
     display: flex;
 
     .staking--Accounts {
-      flex: 2;
+      flex: 3;
       display: flex;
       flex-direction: column;
       width: 0px;

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -46,7 +46,7 @@ function CopyButtonInner (props: InnerProps): React.ReactElement<InnerProps> {
         onCopy={onCopy(props)}
         text={value}
       >
-        <div>
+        <div className='copyContainer'>
           {children}
           <span className='copySpan'>
             <Button
@@ -77,7 +77,8 @@ function CopyButton (props: Props): React.ReactElement<Props> {
   );
 }
 
-export default styled(CopyButton)`
+export default styled(CopyButton)`  
+  width: 100%;
   cursor: copy;
 
   button.ui.mini.icon.primary.button.iconButton {
@@ -86,5 +87,9 @@ export default styled(CopyButton)`
 
   .copySpan {
     white-space: nowrap;
+  }
+  .copyContainer {
+    display: flex;
+    text-overflow: ellipsis;
   }
 `;


### PR DESCRIPTION
Avoid overflow on staking pages while keeping consistent with the address ellipsis that we have on accounts app.

That's what I've got so far:

![0](https://user-images.githubusercontent.com/40487685/64490620-0dfe3380-d25f-11e9-8665-269e46efa991.png)
![1](https://user-images.githubusercontent.com/40487685/64490622-0f2f6080-d25f-11e9-8d9f-15ae5076be34.png)

Wasn't able to detect any side effects by the css changes, I'd appreciate a close look on those.

Thanks
