### PR TITLE
ss58Format overrides

### DIFF
--- a/packages/app-settings/src/General.tsx
+++ b/packages/app-settings/src/General.tsx
@@ -36,12 +36,13 @@ function General ({ className, t }: Props): React.ReactElement<Props> {
   useEffect((): void => {
     const prev = uiSettings.get();
     const hasChanges = Object.entries(settings).some(([key, value]): boolean => (prev as any)[key] !== value);
+    const needsReload = prev.apiUrl !== settings.apiUrl || prev.prefix !== settings.prefix;
 
-    if (hasChanges) {
-      setChanged(prev.apiUrl !== settings.apiUrl);
-    } else {
-      setChanged(null);
-    }
+    setChanged(
+      hasChanges
+        ? needsReload
+        : null
+    );
   }, [settings]);
 
   const _onChangeApiUrl = (apiUrl: string): void => setSettings({ ...settings, apiUrl });

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -158,6 +158,7 @@ export default class Api extends React.PureComponent<Props, State> {
 
     // finally load the keyring
     keyring.loadAll({
+      addressPrefix: ss58Format,
       genesisHash: api.genesisHash,
       isDevelopment,
       ss58Format,


### PR DESCRIPTION
- Will require `@polkadot/util` 1.5.1 when https://github.com/polkadot-js/common/pull/472 is in
- Closes https://github.com/polkadot-js/apps/issues/1621
- Prefix change is a reload (this is not great)