### PR TITLE
Fix broken contract deployment function

### DIFF
--- a/packages/app-contracts/src/Deploy.tsx
+++ b/packages/app-contracts/src/Deploy.tsx
@@ -210,7 +210,7 @@ class Deploy extends ContractModal<Props, State> {
           onFailed={this.toggleBusy(false)}
           onSuccess={this.onSuccess}
           params={this.constructCall}
-          tx={api.tx.contracts ? (api.tx.contracts.instantiate ? 'contracts.instantiate' : 'contracts.create' ) : 'contract.create'}
+          tx={api.tx.contracts ? (api.tx.contracts.instantiate ? 'contracts.instantiate' : 'contracts.create') : 'contract.create'}
           ref={this.button}
         />
       </Button.Group>

--- a/packages/app-contracts/src/Deploy.tsx
+++ b/packages/app-contracts/src/Deploy.tsx
@@ -210,7 +210,7 @@ class Deploy extends ContractModal<Props, State> {
           onFailed={this.toggleBusy(false)}
           onSuccess={this.onSuccess}
           params={this.constructCall}
-          tx={api.tx.contracts ? 'contracts.create' : 'contract.create'}
+          tx={api.tx.contracts ? (api.tx.contracts.instantiate ? 'contracts.instantiate' : 'contracts.create' ) : 'contract.create'}
           ref={this.button}
         />
       </Button.Group>


### PR DESCRIPTION
srml-contract deploy API renaming broke the contract deployment function.

- keep backward compatible with the deprecated function call
- substrate PR <https://github.com/paritytech/substrate/pull/3649>