### PR TITLE
Switch back to white menu items in sidebar

### DIFF
--- a/packages/apps/src/SideBar/SideBar.css
+++ b/packages/apps/src/SideBar/SideBar.css
@@ -227,7 +227,7 @@ a.apps--SideBar-Item-NavLink {
 }
 
 a.apps--SideBar-Item-NavLink-active {
-  background: #fafafa !important;
+  background: #fafafa;
   border-radius: 0.28571429rem 0 0 0.28571429rem;
   color: inherit;
 

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -4,6 +4,9 @@
 
 import { css } from 'styled-components';
 
+/* background color of the main Content container */
+const colorContentBg = '#fafafa';
+
 /* default buttons, dark gray */
 const colorBtnDefault = '#666';
 
@@ -102,6 +105,15 @@ export default css`
     .ui.toggle.checkbox input:checked~.box:before,
     .ui.toggle.checkbox input:checked~label:before {
       background-color: ${colorBtnHighlight} !important;
+    }
+
+    a.apps--SideBar-Item-NavLink {
+      color: ${colorBtnText};
+    }
+    a.apps--SideBar-Item-NavLink-active,
+    a.apps--SideBar-Item-NavLink-active:hover {
+      color: ${colorBtnPrimary};
+      background: ${colorContentBg};
     }
   }
 `;


### PR DESCRIPTION
Change link color back to white in sidebar navigation to get better contrast.

Before:
<img width="1016" alt="Screenshot 2019-09-23 at 11 51 06" src="https://user-images.githubusercontent.com/125398/65419315-acad9700-ddfe-11e9-8e3f-262800c16f1d.png">

After:
<img width="743" alt="Screenshot 2019-09-23 at 12 32 24" src="https://user-images.githubusercontent.com/125398/65419316-acad9700-ddfe-11e9-960b-def62153fd4e.png">
 