### PR TITLE
Allow ss58 input on Bytes fields

### DIFF
--- a/packages/react-params/src/Param/BaseBytes.tsx
+++ b/packages/react-params/src/Param/BaseBytes.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Compact } from '@polkadot/types';
 import { Input } from '@polkadot/react-components';
 import { hexToU8a, isHex, u8aToHex } from '@polkadot/util';
+import { decodeAddress } from '@polkadot/util-crypto';
 
 import Bare from './Bare';
 
@@ -23,17 +24,35 @@ interface Props extends BaseProps {
 const defaultValidate = (): boolean =>
   true;
 
+function convertInput (value: string): [boolean, Uint8Array] {
+  // try hex conversion
+  try {
+    console.log('1');
+    return [true, hexToU8a(value)];
+  } catch (error) {
+    // we continue...
+  }
+
+  // maybe it is an ss58?
+  try {
+    console.log('2');
+    return [true, decodeAddress(value)];
+  } catch (error) {
+    // we continue
+  }
+
+  console.log('3');
+
+  return [false, new Uint8Array([])];
+}
+
 function onChange ({ asHex, length = -1, onChange, validate = defaultValidate, withLength }: Props): (_: string) => void {
   return function (hex: string): void {
-    let value: Uint8Array;
-    let isValid = true;
+    console.error('hex', hex);
 
-    try {
-      value = hexToU8a(hex);
-    } catch (error) {
-      value = new Uint8Array([]);
-      isValid = false;
-    }
+    let [isValid, value] = convertInput(hex);
+
+    console.error('result', isValid, hex);
 
     isValid = isValid && validate(value) && (
       length !== -1

--- a/packages/react-params/src/Param/BaseBytes.tsx
+++ b/packages/react-params/src/Param/BaseBytes.tsx
@@ -27,7 +27,6 @@ const defaultValidate = (): boolean =>
 function convertInput (value: string): [boolean, Uint8Array] {
   // try hex conversion
   try {
-    console.log('1');
     return [true, hexToU8a(value)];
   } catch (error) {
     // we continue...
@@ -35,24 +34,17 @@ function convertInput (value: string): [boolean, Uint8Array] {
 
   // maybe it is an ss58?
   try {
-    console.log('2');
     return [true, decodeAddress(value)];
   } catch (error) {
     // we continue
   }
-
-  console.log('3');
 
   return [false, new Uint8Array([])];
 }
 
 function onChange ({ asHex, length = -1, onChange, validate = defaultValidate, withLength }: Props): (_: string) => void {
   return function (hex: string): void {
-    console.error('hex', hex);
-
     let [isValid, value] = convertInput(hex);
-
-    console.error('result', isValid, hex);
 
     isValid = isValid && validate(value) && (
       length !== -1


### PR DESCRIPTION
This allows ss58 inputs anywhere we have Bytes types. 

(This is the reverse of existing functionality where we already allow 0x... publicKey inputs in any address field - in both the existing and new case, we just convert transparently)

![image](https://user-images.githubusercontent.com/1424473/66083455-a476f980-e56c-11e9-8e6b-bb3511242d08.png)

cc @shawntabrizi cc @JoshOrndorff - this may help somewhat