### PR TITLE
Display locked amounts

### DIFF
--- a/packages/app-address-book/src/Address.tsx
+++ b/packages/app-address-book/src/Address.tsx
@@ -20,7 +20,7 @@ interface Props extends I18nProps {
   className?: string;
 }
 
-const WITH_BALANCE = { available: true, bonded: true, free: true, reserved: true, total: true };
+const WITH_BALANCE = { available: true, bonded: true, free: true, locked: true, reserved: true, total: true };
 const WITH_EXTENDED = { nonce: true };
 
 const isEditable = true;

--- a/packages/react-components/src/AddressInfo.tsx
+++ b/packages/react-components/src/AddressInfo.tsx
@@ -22,6 +22,7 @@ import translate from './translate';
 export interface BalanceActiveType {
   available?: boolean;
   bonded?: boolean | BN[];
+  locked?: boolean;
   redeemable?: boolean;
   reserved?: boolean;
   total?: boolean;
@@ -53,6 +54,7 @@ interface Props extends BareProps, I18nProps {
 const DEFAULT_BALANCES: BalanceActiveType = {
   available: true,
   bonded: true,
+  locked: true,
   redeemable: true,
   reserved: true,
   total: true,
@@ -207,6 +209,12 @@ function renderBalances (props: Props): React.ReactNode {
         <>
           <Label label={t('available')} />
           <div className='result'>{formatBalance(balances_all.availableBalance)}</div>
+        </>
+      )}
+      {balanceDisplay.locked && balances_all.lockedBalance && balances_all.lockedBalance.gtn(0) && (
+        <>
+          <Label label={t('locked')} />
+          <div className='result'>{formatBalance(balances_all.lockedBalance)}</div>
         </>
       )}
       {balanceDisplay.reserved && balances_all.reservedBalance && balances_all.reservedBalance.gtn(0) && (


### PR DESCRIPTION
- Adds the available locks (for some reason we didn't include this previously)
- Closes https://github.com/polkadot-js/apps/issues/1781

![image](https://user-images.githubusercontent.com/1424473/67670134-88038c80-f973-11e9-9de9-4d72f6d01ca3.png)

Will log to actually display the breakdowns and the to-block info (like with unlocking)