### PR TITLE
Fix input addr crash

### DIFF
--- a/packages/react-components/src/AddressMini.tsx
+++ b/packages/react-components/src/AddressMini.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 import { AccountName } from '@polkadot/react-query';
 import { KeyringItemType } from '@polkadot/ui-keyring/types';
 
-import { classes } from './util';
+import { classes, toShortAddress } from './util';
 import BalanceDisplay from './Balance';
 import BondedDisplay from './Bonded';
 import IdentityIcon from './IdentityIcon';
@@ -30,10 +30,11 @@ interface Props extends BareProps {
   withBalance?: boolean;
   withBonded?: boolean;
   withLockedVote?: boolean;
+  withName?: boolean;
 }
 
 function AddressMini (props: Props): React.ReactElement<Props> | null {
-  const { balance, bonded, children, className, iconInfo, isPadded = true, style, value, withAddress = true, withBalance = false, withBonded = false, withLockedVote = false } = props;
+  const { balance, bonded, children, className, iconInfo, isPadded = true, style, value, withAddress = true, withBalance = false, withBonded = false, withLockedVote = false, withName = true } = props;
 
   if (!value) {
     return null;
@@ -49,7 +50,10 @@ function AddressMini (props: Props): React.ReactElement<Props> | null {
       <div className='ui--AddressMini-info'>
         {withAddress && (
           <div className='ui--AddressMini-address'>
-            <AccountName params={address} />
+            {withName
+              ? <AccountName params={address} />
+              : toShortAddress(address)
+            }
           </div>
         )}
         {children}

--- a/packages/react-components/src/InputAddress/index.tsx
+++ b/packages/react-components/src/InputAddress/index.tsx
@@ -256,7 +256,7 @@ class InputAddress extends React.PureComponent<Props, State> {
     const queryLower = query.toLowerCase();
     const matches = filteredOptions.filter((item): boolean =>
       item.value !== null && (
-        item.name.toLowerCase().includes(queryLower) ||
+        (item.name.toLowerCase && item.name.toLowerCase().includes(queryLower)) ||
         item.value.toLowerCase().includes(queryLower)
       )
     );

--- a/packages/react-components/src/Status/index.tsx
+++ b/packages/react-components/src/Status/index.tsx
@@ -68,7 +68,7 @@ function signerIconName (status: QueueTxStatus): any {
 
 function renderStatus ({ account, action, id, message, removeItem, status }: QueueStatus): React.ReactNode {
   const addressRendered = account
-    ? <AddressMini value={account} />
+    ? <AddressMini value={account} withName={false} />
     : undefined;
 
   return (


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/1797

This is actually problematic - since the names are now a wrapped component, we don't actually allow lookups on name, only address. This fixes the issue reported, however we need to have some magic somehow to do name lookups as well.