### PR TITLE
Js console

### DIFF
--- a/packages/app-js/src/Playground.tsx
+++ b/packages/app-js/src/Playground.tsx
@@ -180,7 +180,6 @@ function Playground ({ className, history, match: { params: { base64 } }, t }: P
   };
   const _runJs = async (): Promise<void> => {
     setIsRunning(true);
-    _stopJs();
     _clearConsole();
 
     injectedRef.current = {
@@ -207,6 +206,8 @@ function Playground ({ className, history, match: { params: { base64 } }, t }: P
 
     // eslint-disable-next-line no-new-func
     new Function('injected', exec)(injectedRef.current);
+
+    setIsRunning(false);
   };
   const _selectExample = (value: string): void => {
     _stopJs();


### PR DESCRIPTION
Hi @jacogr 
I think the issue #1795 is caused by the `fn _stop()`, set the running `true` then switch to `false`.
I have modified a bit to enable the display of stop/play button.

While I think the best solution is to switch the  isRunning-state according to exec result. 
