### PR TITLE
Update extra key for new Edgeware testnet

### DIFF
--- a/packages/react-api/src/overrides/spec/edgeware.ts
+++ b/packages/react-api/src/overrides/spec/edgeware.ts
@@ -12,6 +12,6 @@ export default {
   ...SignalingTypes,
   ...TreasuryRewardTypes,
   ...VotingTypes,
-  Keys: 'SessionKeys3',
+  Keys: 'SessionKeys4',
   ValidatorPrefs: 'ValidatorPrefsTo196'
 };


### PR DESCRIPTION
We can discontinue the current mainnet as it is an old testnet basically. For now, these are the most up to date settings.