### PR TITLE
Change dockerfile to use local version as opposed to cloning polkadot…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 
 WORKDIR /app
-RUN git clone https://github.com/polkadot-js/apps
+COPY . .
 
 WORKDIR /app/apps
 RUN npm install yarn -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ RUN apt-get update && apt-get install -y curl git gnupg
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 
-WORKDIR /app
+WORKDIR /apps
 COPY . .
 
-WORKDIR /app/apps
 RUN npm install yarn -g
 RUN yarn
 RUN NODE_ENV=production yarn build
@@ -19,7 +18,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update && apt-get -y install nginx
 
-COPY --from=builder /app/apps/packages/apps/build /var/www/html
+COPY --from=builder /apps/packages/apps/build /var/www/html
 
 EXPOSE 80
 


### PR DESCRIPTION
…-js/apps

The current behavior does not allow the dockerfile to be used with forked repositories.