### PR TITLE
fix: Fixes TypeError: Cannot read property 'receivedHeartbeats' of undefined

### DIFF
--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -39,7 +39,7 @@ function StakingApp ({ basePath, className }: Props): React.ReactElement<Props> 
     transform: ([stashes]: [AccountId[]]): string[] =>
       stashes.map((accountId): string => accountId.toString())
   }) as string[];
-  const recentlyOnline = useCall<DerivedHeartbeats>(api.derive.imOnline.receivedHeartbeats, []);
+  const recentlyOnline = useCall<DerivedHeartbeats>(api.derive.imOnline?.receivedHeartbeats, []);
   const stakingOverview = useCall<DerivedStakingOverview>(api.derive.staking.overview, []);
   const sessionRewards = useSessionRewards(MAX_SESSIONS);
   const hasQueries = hasAccounts && !!(api.query.imOnline?.authoredBlocks);


### PR DESCRIPTION
We're converting our chain from PoA to PoS in this PR https://github.com/DataHighway-DHX/node/pull/52/commits/7c8c96939ab6a2b77dd3a2f4bef427e831dafbda

But when I run the chain with those latest changes I got error `TypeError: Cannot read property 'receivedHeartbeats' of undefined` when I tried to go to the Staking app using polkadot.js.org/apps, as explained here https://matrix.to/#/!XOxcnpiHXHhAjJfRFP:matrix.parity.io/$0oidO-aZvsjMRdskB2nig6P_Y4CjH4Gc6TMrl4V7ZB8?via=matrix.parity.io&via=matrix.org&via=matrix.dapp.org.uk

After cloning https://github.com/polkadot-js/apps and debugging the error, I found that this change resolved the error and the Staking App runs