### PR TITLE
fix  could not connect after clearing the cache

### DIFF
--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -22,7 +22,7 @@ const apiUrl = urlOptions.rpc // we have a supplied value
   ? urlOptions.rpc.split('#')[0] // https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer
   : [stored.apiUrl, process.env.WS_URL].includes(settings.apiUrl) // overridden, or stored
     ? settings.apiUrl // keep as-is
-    : availableEndpoints[0].value as string; // grab first available
+    : availableEndpoints[1].value as string; // grab first available
 
 // set the default as retrieved here
 settings.set({ apiUrl });


### PR DESCRIPTION
Fixed a problem where the connection destination URL could not be obtained after clearing the cache or when connecting for the first time.

Maybe the cause of #2347 