### PR TITLE
find the first available URL

### DIFF
--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -62,19 +62,19 @@ export default [
   {
     isHeader: true,
     text: 'Live networks',
-    value: -1
+    value: ''
   },
   ...LIVE,
   {
     isHeader: true,
     text: 'Test networks',
-    value: -1
+    value: ''
   },
   ...TEST,
   {
     isHeader: true,
     text: 'Development',
-    value: -1
+    value: ''
   },
   ...DEV
 ].map((option): Option => ({ ...option, withI18n: true }));

--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -18,11 +18,12 @@ if (Array.isArray(urlOptions.rpc)) {
   throw new Error('Invalid WS endpoint specified');
 }
 
+const fallbackUrl = availableEndpoints.find(({ value }) => !!value) || { value: 'http://127.0.0.1:9944' };
 const apiUrl = urlOptions.rpc // we have a supplied value
   ? urlOptions.rpc.split('#')[0] // https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer
   : [stored.apiUrl, process.env.WS_URL].includes(settings.apiUrl) // overridden, or stored
     ? settings.apiUrl // keep as-is
-    : availableEndpoints[0].value as string; // grab first available
+    : fallbackUrl.value as string; // grab the fallback
 
 // set the default as retrieved here
 settings.set({ apiUrl });


### PR DESCRIPTION
- Replaces https://github.com/polkadot-js/apps/pull/2348
- Closes #2347 

(Introduction of headers - the find allows non-headers as well)