### PR TITLE
Add types for Substrate node template

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -5,9 +5,11 @@
 import centrifugeChain from './centrifuge-chain';
 import edgeware from './edgeware';
 import kulupu from './kulupu';
+import nodeTemplate from './node-template';
 
 export default {
   'centrifuge-chain': centrifugeChain,
   edgeware,
-  kulupu
+  kulupu,
+  'node-template': nodeTemplate
 };

--- a/packages/apps-config/src/api/spec/node-template.ts
+++ b/packages/apps-config/src/api/spec/node-template.ts
@@ -1,0 +1,8 @@
+// Copyright 2017-2020 @polkadot/apps-config authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export default {
+  Address: 'AccountId',
+  LookupSource: 'AccountId'
+};


### PR DESCRIPTION
Adds the necessary types to make apps work with the [node template](https://github.com/substrate-developer-hub/substrate-node-template) with zero-config from the end user, who is likely a learner.

These types became necessary with https://github.com/paritytech/substrate/pull/5025 and this PR was discussed in https://github.com/substrate-developer-hub/substrate-node-template/pull/25