### PR TITLE
Improve support for WS_URL

### DIFF
--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -84,14 +84,14 @@ let endpoints = [
 ];
 
 if (ENV.length > 0) {
-  endpoints = endpoints.concat([
+  endpoints = [
     {
       isHeader: true,
-      text: 'ENV',
+      text: 'Custom ENV',
       value: ''
     },
     ...ENV
-  ]);
+  ].concat(endpoints);
 }
 
 // The available endpoints that will show in the dropdown. For the most part (with the exception of

--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -12,6 +12,15 @@ const DEV: Option[] = [
   }
 ];
 
+const ENV: Option[] = [];
+if (process.env.WS_URL) {
+  ENV.push({
+    info: 'WS_URL',
+    text: 'WS_URL: ' + process.env.WS_URL,
+    value: process.env.WS_URL
+  });
+}
+
 const LIVE: Option[] = [
   {
     info: 'kusama',
@@ -53,12 +62,7 @@ const TEST: Option[] = [
   }
 ];
 
-// The available endpoints that will show in the dropdown. For the most part (with the exception of
-// Polkadot) we try to keep this to live chains only, with RPCs hosted by the community/chain vendor
-//   info: The chain logo name as defined in ../logos, specifically in namedLogos
-//   text: The text to display on teh dropdown
-//   value: The actual hosted secure websocket endpoint
-export default [
+let endpoints = [
   {
     isHeader: true,
     text: 'Live networks',
@@ -77,4 +81,22 @@ export default [
     value: ''
   },
   ...DEV
-].map((option): Option => ({ ...option, withI18n: true }));
+];
+
+if (ENV.length > 0) {
+  endpoints = endpoints.concat([
+    {
+      isHeader: true,
+      text: 'ENV',
+      value: ''
+    },
+    ...ENV
+  ]);
+}
+
+// The available endpoints that will show in the dropdown. For the most part (with the exception of
+// Polkadot) we try to keep this to live chains only, with RPCs hosted by the community/chain vendor
+//   info: The chain logo name as defined in ../logos, specifically in namedLogos
+//   text: The text to display on teh dropdown
+//   value: The actual hosted secure websocket endpoint
+export default endpoints.map((option): Option => ({ ...option, withI18n: true }));

--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -13,6 +13,7 @@ const DEV: Option[] = [
 ];
 
 const ENV: Option[] = [];
+
 if (process.env.WS_URL) {
   ENV.push({
     info: 'WS_URL',

--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -19,7 +19,6 @@ if (Array.isArray(urlOptions.rpc)) {
 }
 
 const fallbackUrl = availableEndpoints.find(({ value }) => !!value) || { value: 'ws://127.0.0.1:9944' };
-
 const apiUrl = urlOptions.rpc // we have a supplied value
   ? urlOptions.rpc.split('#')[0] // https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer
   : [stored.apiUrl, process.env.WS_URL].includes(settings.apiUrl) // overridden, or stored

--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -19,6 +19,7 @@ if (Array.isArray(urlOptions.rpc)) {
 }
 
 const fallbackUrl = availableEndpoints.find(({ value }) => !!value) || { value: 'ws://127.0.0.1:9944' };
+
 const apiUrl = urlOptions.rpc // we have a supplied value
   ? urlOptions.rpc.split('#')[0] // https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer
   : [stored.apiUrl, process.env.WS_URL].includes(settings.apiUrl) // overridden, or stored


### PR DESCRIPTION
This PR brings a slightly better support for WS_URL and especially allows using WS_URL even in cases where the user already saved another network. This is especially useful on docker/k8s infrastructures where the containers may need to link dynamically.

In that case, passing `WS_URL` accordingly will make the endpoint show up in the list and even make it the default if the user did not define anything yet for this (UI) url.

If `WS_URL` is not provided, things work just like today and nothing special shows up:
![image](https://user-images.githubusercontent.com/738724/77079388-40e86780-69f8-11ea-9c53-bfc06dccb5a2.png)

However, if `WS_URL` is provided, it will show up in the endpoints list:
![image](https://user-images.githubusercontent.com/738724/77081393-e13f8b80-69fa-11ea-90c2-0c16242057cb.png)

I put the new ENV section at the top of the list for 2 reasons:
- if WS_URL is not specified (which is likely the majority...) the list looks as it does today
- it however WS_URL is provided, it will be selected as the default option on a browser where the user did not previously saved a value.
