### PR TITLE
WIP: Switch the docker image to the webpack server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+.git
+.github

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         node-version: '12.x'
     - name: ${{ matrix.step }}
+      env:
+        NODE_ENV: development
       run: |
         yarn install --immutable | grep -v 'YN0013'
         yarn ${{ matrix.step }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,13 @@
-FROM ubuntu:18.04 as builder
+FROM node:alpine
 
-# Install any needed packages
-RUN apt-get update && apt-get install -y curl git gnupg
-
-# install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install -y nodejs
+ENV NODE_ENV=production
+ENV WS_URL=ws://localhost:9944
 
 WORKDIR /apps
 COPY . .
 
-RUN npm install yarn -g
-RUN yarn
-RUN NODE_ENV=production yarn build:www
-
-FROM ubuntu:18.04
-
-RUN apt-get update && apt-get -y install nginx
-
-COPY --from=builder /apps/packages/apps/build /var/www/html
+RUN yarn && yarn cache clean
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["yarn", "start"]

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -174,17 +174,15 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash:8].css'
       }),
-      isProd
-        ? null
-        : new WebpackPluginServe({
-          hmr: false, // switch off, Chrome WASM memory leak
-          liveReload: false, // explict off, overrides hmr
-          progress: false, // since we have hmr off, disable
-          port: 3000,
-          static: path.join(process.cwd(), '/build')
-        })
+      new WebpackPluginServe({
+        hmr: false, // switch off, Chrome WASM memory leak
+        liveReload: false, // explict off, overrides hmr
+        progress: false, // since we have hmr off, disable
+        port: isProd ? 80 : 3000,
+        static: path.join(process.cwd(), '/build')
+      })
     ]).filter((plugin) => plugin),
-    watch: !isProd,
+    watch: true,
     watchOptions: {
       ignored: ['.yarn', /build/, /node_modules/]
     }


### PR DESCRIPTION
This PR changes a few things.

First, it adds entries to the .dockerignore file to reduce the amount of files sent to build the image (450MB before the change, we are now around 100MB). I would like to remove also the .yarn folder but ran into some issues so I left it.

Second, it changes the docker image. Instead of a 2 stages image building and serving a static site, it switches to a single stage where webpack is serving the site. That allows using ENV variables without extra trickery.

To test, the docker build can be built as:
`docker build -t chevdor/polkadot-ui .`

and ran with:
`docker run --rm -it -e WS_URL=ws://localhost:9946 -p 80:80 chevdor/polkadot-ui`

The `WS_URL` part only making sense once #2421 has been merged.
