### PR TITLE
Add ReferendumInfo type overrides

### DIFF
--- a/packages/apps-config/src/api/chain/berlin.ts
+++ b/packages/apps-config/src/api/chain/berlin.ts
@@ -3,6 +3,8 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 export default {
+  // previous substrate versions
   BalanceLock: 'BalanceLockTo212',
+  ReferendumInfo: 'ReferendumInfoTo239',
   StakingLedger: 'StakingLedgerTo223'
 };

--- a/packages/apps-config/src/api/chain/westend.ts
+++ b/packages/apps-config/src/api/chain/westend.ts
@@ -4,7 +4,9 @@
 
 export default {
   Address: 'GenericAddress',
-  BalanceLock: 'BalanceLockTo212',
   Keys: 'SessionKeys5',
+  // previous substrate versions
+  BalanceLock: 'BalanceLockTo212',
+  ReferendumInfo: 'ReferendumInfoTo239',
   StakingLedger: 'StakingLedgerTo223'
 };

--- a/packages/apps-config/src/api/spec/centrifuge-chain.ts
+++ b/packages/apps-config/src/api/spec/centrifuge-chain.ts
@@ -24,5 +24,7 @@ export default {
   },
   // Overwrites to Substrate types
   Address: 'AccountId',
-  LookupSource: 'AccountId'
+  LookupSource: 'AccountId',
+  // previous substrate versions
+  ReferendumInfo: 'ReferendumInfoTo239'
 };

--- a/packages/apps-config/src/api/spec/edgeware.ts
+++ b/packages/apps-config/src/api/spec/edgeware.ts
@@ -8,5 +8,7 @@ export default {
   ...EdgewareTypes,
   Address: 'GenericAddress',
   Keys: 'SessionKeys4',
+  // previous substrate versions
+  ReferendumInfo: 'ReferendumInfoTo239',
   StakingLedger: 'StakingLedgerTo223'
 };

--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -4,17 +4,19 @@
 
 export default {
   Address: 'GenericAddress',
-  BalanceLock: 'BalanceLockTo212',
   Difficulty: 'U256',
   DifficultyAndTimestamp: {
     difficulty: 'Difficulty',
     timestamp: 'Moment'
   },
+  // previous substrate versions
+  BalanceLock: 'BalanceLockTo212',
   DispatchError: 'DispatchErrorTo198',
   DispatchResult: 'DispatchResultTo198',
   DispatchInfo: {
     weight: 'Weight',
     class: 'DispatchClass'
   },
+  ReferendumInfo: 'ReferendumInfoTo239',
   StakingLedger: 'StakingLedgerTo223'
 };


### PR DESCRIPTION
- Substrate ReferendumInfo type changes, overrides for non-upgraded chains
- API support in https://github.com/polkadot-js/api/pull/2078
- UI support in https://github.com/polkadot-js/apps/pull/2432

cc @drewstone @jnaviask @philipstanislaus 