### PR TITLE
Don't crash if there is no tip field in extrinsics

### DIFF
--- a/packages/page-explorer/src/BlockInfo/Extrinsics.tsx
+++ b/packages/page-explorer/src/BlockInfo/Extrinsics.tsx
@@ -65,7 +65,7 @@ function renderExtrinsic (props: Props, extrinsic: Extrinsic, index: number, t: 
                 : t('mortal')
               : t('immortal')
           }
-          tip={extrinsic.tip.toBn()}
+          tip={extrinsic.tip?.toBn()}
           value={extrinsic}
           withHash
         />


### PR DESCRIPTION
Hello - this line was causing us some pain on our network which does not include tips in extrinsics. Thanks!