### PR TITLE
sub accounts search fix

### DIFF
--- a/packages/page-staking/src/Overview/Address/index.tsx
+++ b/packages/page-staking/src/Overview/Address/index.tsx
@@ -85,8 +85,8 @@ function checkVisibility (api: ApiPromise, address: string, filterName: string, 
       if (accountId?.toString().includes(filterName) || accountIndex?.toString().includes(filterName)) {
         isVisible = true;
       } else if (api.query.identity && api.query.identity.identityOf) {
-        isVisible = (identity?.display && identity.display.toLowerCase().includes(filterLower)) ||
-          (identity?.displayParent && identity.displayParent.toLowerCase().includes(filterLower));
+        isVisible = (!!identity?.display && identity.display.toLowerCase().includes(filterLower)) ||
+          (!!identity?.displayParent && identity.displayParent.toLowerCase().includes(filterLower));
       } else if (nickname) {
         isVisible = nickname.toLowerCase().includes(filterLower);
       }

--- a/packages/page-staking/src/Overview/Address/index.tsx
+++ b/packages/page-staking/src/Overview/Address/index.tsx
@@ -84,8 +84,9 @@ function checkVisibility (api: ApiPromise, address: string, filterName: string, 
 
       if (accountId?.toString().includes(filterName) || accountIndex?.toString().includes(filterName)) {
         isVisible = true;
-      } else if (api.query.identity && api.query.identity.identityOf && identity?.display) {
-        isVisible = identity.display.toLowerCase().includes(filterLower);
+      } else if (api.query.identity && api.query.identity.identityOf) {
+        isVisible = (identity?.display && identity.display.toLowerCase().includes(filterLower)) ||
+          (identity?.displayParent && identity.displayParent.toLowerCase().includes(filterLower));
       } else if (nickname) {
         isVisible = nickname.toLowerCase().includes(filterLower);
       }


### PR DESCRIPTION
Currently polkadot.js filters validators with sub-accounts incorrectly:
I.e. only one Ryabina validator is shown despite there being two of them, no sub-account of the other:
![image](https://user-images.githubusercontent.com/6272279/79351912-86397f80-7f39-11ea-93db-37af41ccd6e9.png)

We propose a fix to filter sub-accounts as intended:
![image (1)](https://user-images.githubusercontent.com/6272279/79352043-a2d5b780-7f39-11ea-9c1b-680875c07eb8.png)
