### PR TITLE
Added RYO endpoint

### DIFF
--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -34,6 +34,11 @@ const LIVE: Option[] = [
     value: 'wss://cc3-5.kusama.network/'
   },
   {
+    info: 'kusama',
+    text: 'Kusama (Load balanced between user-run public nodes; see https://status.cloud.ava.do/)',
+    value: 'wss://kusama.polkadot.cloud.ava.do/'
+  },
+  {
     info: 'edgeware',
     text: 'Edgeware (Edgeware Mainnet, hosted by Commonwealth Labs)',
     value: 'wss://mainnet1.edgewa.re'


### PR DESCRIPTION
The ava.do cloud allows regular users to share their Kusama node with others through a load balanced mechanism.