### PR TITLE
Update node-template types to include Weight `u32`

### DIFF
--- a/packages/apps-config/src/api/spec/node-template.ts
+++ b/packages/apps-config/src/api/spec/node-template.ts
@@ -7,5 +7,7 @@
 
 export default {
   Address: 'AccountId',
-  LookupSource: 'AccountId'
+  LookupSource: 'AccountId',
+  // Remove when https://github.com/substrate-developer-hub/substrate-node-template/ moves to alpha-v7
+  Weight: 'u32'
 };


### PR DESCRIPTION
Chains building with https://github.com/substrate-developer-hub/substrate-node-template/ will currently be using `alpha-v6` which has u32 weights. For the time being, I believe it makes sense for us to keep the default setting as Weight = u32 until the node template moves to a Substrate version that uses u64 weights.