### PR TITLE
Add link to Polkassembly

### DIFF
--- a/packages/apps-config/src/links/index.ts
+++ b/packages/apps-config/src/links/index.ts
@@ -6,11 +6,13 @@ import { ExternalDef } from './types';
 
 import Commonwealth from './commonwealth';
 import Polkascan from './polkascan';
+import Polkassembly from './polkassembly';
 import Subscan from './subscan';
 
 const externals: Record<string, ExternalDef> = {
   Commonwealth,
   Polkascan,
+  Polkassembly,
   Subscan
 };
 

--- a/packages/apps-config/src/links/polkassembly.ts
+++ b/packages/apps-config/src/links/polkassembly.ts
@@ -1,0 +1,21 @@
+// Copyright 2017-2020 @polkadot/apps-config authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import BN from 'bn.js';
+
+export default {
+  chains: {
+    Kusama: 'kusama',
+    'Kusama CC3': 'kusama'
+  },
+  create: (chain: string, path: string, data: BN | number | string): string =>
+    `https://${chain}.polkassembly.io/${path}/${data.toString()}`,
+  isActive: true,
+  paths: {
+    council: 'motion',
+    proposal: 'proposal',
+    referendum: 'referendum',
+    treasury: 'treasury'
+  }
+};


### PR DESCRIPTION
This adds a link to Polkassembly for kusama.
Tested all proposal, council, treasury and referendum live, because we have them all as of writing.