### PR TITLE
Update Kulupu type definitions

### DIFF
--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -6,21 +6,9 @@
 /* eslint-disable sort-keys */
 
 export default {
-  Address: 'GenericAddress',
   Difficulty: 'U256',
   DifficultyAndTimestamp: {
     difficulty: 'Difficulty',
     timestamp: 'Moment'
-  },
-  // previous substrate versions
-  BalanceLock: 'BalanceLockTo212',
-  DispatchError: 'DispatchErrorTo198',
-  DispatchResult: 'DispatchResultTo198',
-  DispatchInfo: {
-    weight: 'Weight',
-    class: 'DispatchClass'
-  },
-  ReferendumInfo: 'ReferendumInfoTo239',
-  StakingLedger: 'StakingLedgerTo223',
-  Weight: 'u32'
+  }
 };


### PR DESCRIPTION
An update ("era change") is [planned](https://github.com/kulupu/kulupu/tree/era/1) on block number 320,000, approximately 8 days from now, on 6th May. This completely updates to Substrate master by exporting the current Kulupu state and regenerate a new genesis block. As a result, we don't need any of those custom type definitions from that point on.

It uses `Lookup = Indices` so I believe I don't need the custom type definitions as in `substrate-node-template`.

This indeed means that in the next ~8 days (or whenever this PR is merged to 6th May), the Kulupu interface on polkadot.js.org is broken, but I'd rather it breaks before the hard fork rather than after the hard fork.