### PR TITLE
add alpha.6 types for arcadia

### DIFF
--- a/packages/apps-config/src/api/chain/arcadia.ts
+++ b/packages/apps-config/src/api/chain/arcadia.ts
@@ -2,10 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import Arcadia from './arcadia';
-import Berlin from './berlin';
-
 export default {
-  Arcadia,
-  Berlin
+  // previous substrate versions
+  Weight: 'u32'
 };


### PR DESCRIPTION
As per the [polkadot JS FAQ](https://polkadot.js.org/api/start/FAQ.html#using-a-non-current-master-node-i-have-issues-parsing-events) non substrate master nodes need to define a custom type to correctly parse events. This PR cover this for Nodle's Arcadia test network.
