### PR TITLE
expose arcadia types correctly

### DIFF
--- a/packages/apps-config/src/api/chain/index.ts
+++ b/packages/apps-config/src/api/chain/index.ts
@@ -6,6 +6,6 @@ import Arcadia from './arcadia';
 import Berlin from './berlin';
 
 export default {
-  Arcadia,
+  'Arcadia Nodle Network': Arcadia,
   Berlin
 };

--- a/packages/apps-config/src/api/index.ts
+++ b/packages/apps-config/src/api/index.ts
@@ -8,7 +8,6 @@ import typesSpec from './spec';
 export function getChainTypes (specName: string, chainName: string): Record<string, string | object> {
   return {
     ...(typesSpec[specName as 'edgeware'] || {}),
-    ...(typesChain[chainName as 'Arcadia Nodle Network'] || {}),
     ...(typesChain[chainName as 'Berlin'] || {})
   };
 }

--- a/packages/apps-config/src/api/index.ts
+++ b/packages/apps-config/src/api/index.ts
@@ -8,6 +8,7 @@ import typesSpec from './spec';
 export function getChainTypes (specName: string, chainName: string): Record<string, string | object> {
   return {
     ...(typesSpec[specName as 'edgeware'] || {}),
+    ...(typesChain[chainName as 'Arcadia Nodle Network'] || {}),
     ...(typesChain[chainName as 'Berlin'] || {})
   };
 }


### PR DESCRIPTION
Seems like we did add the correct types in #2663 but forgot to link them to our chain name. This is now fixed and confirmed working from my machine.
