### PR TITLE
Fix edgeware linting

### DIFF
--- a/packages/apps-config/src/api/chain/berlin.ts
+++ b/packages/apps-config/src/api/chain/berlin.ts
@@ -2,9 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+// structs need to be in order
+/* eslint-disable sort-keys */
+
 import * as edgewareDefinitions from 'edgeware-node-types/dist/definitions';
 
-const edgTypes = Object.values(edgewareDefinitions)
+const edgTypes = Object
+  .values(edgewareDefinitions)
   .reduce((res, { default: { types } }): object => ({ ...res, ...types }), {});
 
 export default {
@@ -19,5 +23,5 @@ export default {
   StakingLedger: 'StakingLedgerTo223',
   Votes: 'VotesTo230',
   ReferendumInfo: 'ReferendumInfoTo239',
-  Weight: 'u32',
+  Weight: 'u32'
 };

--- a/packages/apps-config/src/api/spec/edgeware.ts
+++ b/packages/apps-config/src/api/spec/edgeware.ts
@@ -2,9 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+// structs need to be in order
+/* eslint-disable sort-keys */
+
 import * as edgewareDefinitions from 'edgeware-node-types/dist/definitions';
 
-const edgTypes = Object.values(edgewareDefinitions)
+const edgTypes = Object
+  .values(edgewareDefinitions)
   .reduce((res, { default: { types } }): object => ({ ...res, ...types }), {});
 
 export default {
@@ -19,5 +23,5 @@ export default {
   StakingLedger: 'StakingLedgerTo223',
   Votes: 'VotesTo230',
   ReferendumInfo: 'ReferendumInfoTo239',
-  Weight: 'u32',
+  Weight: 'u32'
 };


### PR DESCRIPTION
Cleanup up https://github.com/polkadot-js/apps/pull/2690 (specifically the ordering, just adds the eslint override, these are always somewhat problematic with types...)