### PR TITLE
kulupu: add type definition of Era

### DIFF
--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -10,5 +10,10 @@ export default {
   DifficultyAndTimestamp: {
     difficulty: 'Difficulty',
     timestamp: 'Moment'
+  },
+  Era: {
+    genesisBlockHash: 'H256',
+    finalBlockHash: 'H256',
+    finalStateRoot: 'H256'
   }
 };


### PR DESCRIPTION
This adds the type definition of `Era` to Kulupu. This is a simple structure that stores pre-squash-fork genesis block hash, final block hash and state root, just in case they need to be used later.