### PR TITLE
Node Template: Restore default weight type (u64)

### DIFF
--- a/packages/apps-config/src/api/spec/node-template.ts
+++ b/packages/apps-config/src/api/spec/node-template.ts
@@ -8,6 +8,4 @@
 export default {
   Address: 'AccountId',
   LookupSource: 'AccountId',
-  // Remove when https://github.com/substrate-developer-hub/substrate-node-template/ moves to alpha-v7
-  Weight: 'u32'
 };

--- a/packages/apps-config/src/api/spec/node-template.ts
+++ b/packages/apps-config/src/api/spec/node-template.ts
@@ -7,5 +7,5 @@
 
 export default {
   Address: 'AccountId',
-  LookupSource: 'AccountId',
+  LookupSource: 'AccountId'
 };


### PR DESCRIPTION
This PR removes the custom weight type for the node template.

Now that alpha.7 is released, we want builders to use that and it includes the u64 weight type, same as Substrate master

Followup on my previous plan to move these types to the api and spec-version them. I made a foolish mistake and missed the opportunity. All along I was thinking "we'll bump the spec version when alpha.7 comes out". But that is wrong. I needed to do it before alpha.7 was tagged. Because of this oversight on my part, the node template runtime is still not spec-versioned, and we still need to maintain types this way.