### PR TITLE
Set higher default for contracts maximum gas allowed

### DIFF
--- a/packages/page-contracts/src/Contracts/Call.tsx
+++ b/packages/page-contracts/src/Contracts/Call.tsx
@@ -172,6 +172,7 @@ function Call (props: Props): React.ReactElement<Props> | null {
               value={endowment}
             />
             <InputNumber
+              bitLength={128}
               defaultValue={DEFAULT_GAS_LIMIT}
               help={t('The maximum amount of gas that can be used by this call. If the code requires more, the call will fail.')}
               isDisabled={isBusy}

--- a/packages/page-contracts/src/Modal.tsx
+++ b/packages/page-contracts/src/Modal.tsx
@@ -146,6 +146,7 @@ class ContractModal<P extends ContractModalProps, S extends ContractModalState> 
 
     return (
       <InputNumber
+        bitLength={128}
         help={t('The maximum amount of gas that can be used by this deployment, if the code requires more, the deployment will fail.')}
         isDisabled={isBusy}
         isError={!isGasValid}

--- a/packages/page-contracts/src/constants.ts
+++ b/packages/page-contracts/src/constants.ts
@@ -4,7 +4,7 @@
 
 export const ENDOWMENT = 1000;
 
-export const DEFAULT_GAS_LIMIT = '500000';
+export const DEFAULT_GAS_LIMIT = '100000000000';
 
 export const CONTRACT_NULL = {
   abi: null,


### PR DESCRIPTION
I read in one of the smart contract channels, that @kwingram25 is in the process of bigger contracts refactor. So this is just a a really basic quick fix for https://github.com/polkadot-js/apps/issues/2604 to enable people to instantiate their contracts through the UI until there's time for a more involved approach.

I just set higher default gas limit, and switched the bitlength for the gasLimit input field from u32 to u128.