### PR TITLE
Restrict attest to accounts, allow claimAttest for all

### DIFF
--- a/packages/page-claims/src/Attest.tsx
+++ b/packages/page-claims/src/Attest.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Button, Card, TxButton } from '@polkadot/react-components';
 import { TxCallback } from '@polkadot/react-components/Status/types';
-import { useApi } from '@polkadot/react-hooks';
+import { useAccounts, useApi } from '@polkadot/react-hooks';
 import { FormatBalance } from '@polkadot/react-query';
 import { Option } from '@polkadot/types';
 import { BalanceOf, EthereumAddress, StatementKind } from '@polkadot/types/interfaces';
@@ -26,6 +26,7 @@ interface Props {
 }
 
 function Attest ({ accountId, className, ethereumAddress, onSuccess, statementKind, systemChain }: Props): React.ReactElement<Props> | null {
+  const accounts = useAccounts();
   const { t } = useTranslation();
   const { api } = useApi();
   const [claimValue, setClaimValue] = useState<BalanceOf | null>(null);
@@ -56,6 +57,23 @@ function Attest ({ accountId, className, ethereumAddress, onSuccess, statementKi
 
   if (!hasClaim || !statementSentence) {
     return null;
+  }
+
+  // Attesting is impossible if the account is not owned.
+  if (!accounts.isAccount(accountId)) {
+    return (
+      <Card isError>
+        <div className={className}>
+          {t<string>('We found a pre-claim with this Polkadot address. However, attesting requires signing with this account. To continue with attesting, please add this account as an owned account first.')}
+          <h3>
+            <FormatBalance
+              label={t<string>('Account balance:')}
+              value={claimValue}
+            />
+          </h3>
+        </div>
+      </Card>
+    );
   }
 
   return (

--- a/packages/page-claims/src/Claim.tsx
+++ b/packages/page-claims/src/Claim.tsx
@@ -94,7 +94,6 @@ function Claim ({ accountId, className = '', ethereumAddress, ethereumSignature,
               <h2><FormatBalance value={claimValue} /></h2>
               <Button.Group>
                 <TxButton
-                  accountId={accountId}
                   icon='send'
                   isPrimary
                   isUnsigned

--- a/packages/page-claims/src/index.tsx
+++ b/packages/page-claims/src/index.tsx
@@ -196,7 +196,7 @@ function ClaimsApp (): React.ReactElement {
               help={t<string>('The account you want to claim to.')}
               label={t<string>('claim to account')}
               onChange={setAccountId}
-              type='account'
+              type='all'
             />
             {(step === Step.Account) && (
               <Button.Group>


### PR DESCRIPTION
fixes #2838 

Tested on Polkadot:
- [x] attest with owned account: Green box
- [x] attest with paste-only address: Red box
- [x] claimAttest with owned account: works
- [x] claimAttest with paste-only addres: works

todo:
- [x] claim on Kusama

cc @joepetrowski @lsaether @Tbaut @0x7CFE @ascjones 