### PR TITLE
Fix electron auto release

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -49,6 +49,7 @@ jobs:
           # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
           build_script_name: build:release:electron
+          release: true
 
   # dummy, GH actions fails outright when all steps are skipped (like it can be above)
   dummy:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "repository": "https://github.com/polkadot-js/apps",
   "main": "packages/apps-electron/build/electron.js",
   "description": "An Apps portal into the Polkadot network",
-  "author": "Jaco Greeff <jacogr@gmail.com>",
+  "author": {
+    "name": "Jaco Greeff",
+    "email": "jacogr@gmail.com"
+  },
   "version": "0.44.0-beta.28",
   "license": "Apache-2",
   "private": true,
@@ -22,6 +25,9 @@
     "mac": {
       "category": "public.app-category.finance",
       "target": "dmg"
+    },
+    "linux": {
+      "publish": "github"
     },
     "directories": {
       "buildResources": "./packages/apps-electron/assets",


### PR DESCRIPTION
Set releasing flag as 'always', extract author name and email into a separate field for auto-releasing, set Linux config to publish only on GitHub