### PR TITLE
Don't reload i18n when cached

### DIFF
--- a/packages/page-settings/src/I18n/index.tsx
+++ b/packages/page-settings/src/I18n/index.tsx
@@ -33,10 +33,19 @@ type Progress = [[number, number, number], Record<string, [number, number, numbe
 type Strings = Record<string, string>;
 type StringsMod = Record<string, Strings>;
 
-async function retrieveJson (url: string): Promise<any> {
-  const response = await fetch(`locales/${url}`);
+const cache = new Map<string, unknown>();
 
-  return response.json();
+async function retrieveJson (url: string): Promise<any> {
+  if (cache.has(url)) {
+    return cache.get(url);
+  }
+
+  const response = await fetch(`locales/${url}`);
+  const json = await response.json() as unknown;
+
+  cache.set(url, json);
+
+  return json;
 }
 
 async function retrieveEnglish (): Promise<StringsMod> {


### PR DESCRIPTION
As per https://github.com/polkadot-js/apps/pull/2969#issuecomment-645302610

This protects against losing connecting to the node - when we have already loaded, it won't clobber what have have (or edits that have been made)