### PR TITLE
Electron build - restore zip target

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,6 +7,7 @@ files:
   - ./packages/apps-electron/appleEntitlements
 appId: com.polkadotjs.polkadotjs-apps
 mac:
+  artifactName: 'Polkadot-JS-Apps-mac-${version}.${ext}'
   category: public.app-category.finance
   entitlements: ./packages/apps-electron/appleEntitlements/entitlements.mac.plist
   hardenedRuntime: true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,16 @@
+---
+productName: Polkadot-JS Apps
+artifactName: 'Polkadot-JS-Apps-${version}.${ext}'
+files:
+  - ./packages/apps-electron/build
+  - ./packages/apps-electron/assets
+  - ./packages/apps-electron/appleEntitlements
+appId: com.polkadotjs.polkadotjs-apps
+mac:
+  category: public.app-category.finance
+  entitlements: ./packages/apps-electron/appleEntitlements/entitlements.mac.plist
+  hardenedRuntime: true
+directories:
+  buildResources: ./packages/apps-electron/assets
+  output: ./packages/apps-electron/release
+afterSign: electron-builder-notarize

--- a/package.json
+++ b/package.json
@@ -11,27 +11,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "build": {
-    "productName": "Polkadot-JS Apps",
-    "artifactName": "Polkadot-JS-Apps-${version}.${ext}",
-    "files": [
-      "./packages/apps-electron/build",
-      "./packages/apps-electron/assets",
-      "./packages/apps-electron/appleEntitlements"
-    ],
-    "appId": "com.polkadotjs.polkadotjs-apps",
-    "mac": {
-      "category": "public.app-category.finance",
-      "entitlements": "./packages/apps-electron/appleEntitlements/entitlements.mac.plist",
-      "hardenedRuntime": true,
-      "target": "dmg"
-    },
-    "directories": {
-      "buildResources": "./packages/apps-electron/assets",
-      "output": "./packages/apps-electron/release"
-    },
-    "afterSign": "electron-builder-notarize"
-  },
   "resolutions": {
     "@polkadot/api": "^1.22.0-beta.2",
     "@polkadot/api-contract": "^1.22.0-beta.2",


### PR DESCRIPTION
Extract Electron Builder config to a separate file.

Restore zip target for mac (needed for automatic updates - compare [note 2. in auto update guide](https://www.electron.build/auto-update#quick-setup-guide)).