### PR TITLE
Show unbonding value in staking account actions

### DIFF
--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -126,7 +126,7 @@ function Account ({ className = '', info: { controllerId, destination, destinati
       <td className='number ui--media-1200'>{destination}</td>
       <td className='number'>
         <StakingBonded stakingInfo={stakingAccount} />
-        <StakingUnbonding stakingInfo={stakingAccount} />
+        <StakingUnbonding value={stakingAccount} />
         <StakingRedeemable stakingInfo={stakingAccount} />
       </td>
       {isStashValidating

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -126,7 +126,7 @@ function Account ({ className = '', info: { controllerId, destination, destinati
       <td className='number ui--media-1200'>{destination}</td>
       <td className='number'>
         <StakingBonded stakingInfo={stakingAccount} />
-        <StakingUnbonding value={stakingAccount} />
+        <StakingUnbonding stakingInfo={stakingAccount} />
         <StakingRedeemable stakingInfo={stakingAccount} />
       </td>
       {isStashValidating

--- a/packages/react-components/src/AddressInfo.tsx
+++ b/packages/react-components/src/AddressInfo.tsx
@@ -343,7 +343,7 @@ function renderBalances (props: Props, allAccounts: string[], t: <T = string> (k
         <>
           <Label label={t<string>('unbonding')} />
           <div className='result'>
-            <StakingUnbonding value={stakingInfo} />
+            <StakingUnbonding stakingInfo={stakingInfo} />
           </div>
         </>
       )}

--- a/packages/react-components/src/StakingUnbonding.tsx
+++ b/packages/react-components/src/StakingUnbonding.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from './translate';
 
 interface Props {
   className?: string;
-  value?: DeriveStakingAccount;
+  stakingInfo?: DeriveStakingAccount;
 }
 
 function remainingBlocks (remainingEras: BN, { eraLength, eraProgress }: DeriveSessionProgress): BN {
@@ -27,16 +27,16 @@ function remainingBlocks (remainingEras: BN, { eraLength, eraProgress }: DeriveS
     .add(eraLength.sub(eraProgress));
 }
 
-function StakingUnbonding ({ className = '', value }: Props): React.ReactElement<Props> | null {
+function StakingUnbonding ({ className = '', stakingInfo }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const progress = useCall<DeriveSessionProgress>(api.derive.session.progress, []);
   const { t } = useTranslation();
 
-  if (!value?.unlocking || !progress) {
+  if (!stakingInfo?.unlocking || !progress) {
     return null;
   }
 
-  const filtered = value.unlocking.filter(({ remainingEras, value }) => value.gtn(0) && remainingEras.gtn(0));
+  const filtered = stakingInfo.unlocking.filter(({ remainingEras, value }) => value.gtn(0) && remainingEras.gtn(0));
 
   if (!filtered.length) {
     return null;
@@ -44,7 +44,7 @@ function StakingUnbonding ({ className = '', value }: Props): React.ReactElement
 
   const mapped = filtered.map((unlock): [DeriveUnlocking, BN] => [unlock, remainingBlocks(unlock.remainingEras, progress)]);
   const total = mapped.reduce((total, [{ value }]) => total.add(value), BN_ZERO);
-  const trigger = `${value.accountId.toHex()}-unlocking-trigger`;
+  const trigger = `${stakingInfo.accountId.toHex()}-unlocking-trigger`;
 
   return (
     <div className={className}>


### PR DESCRIPTION
closes https://github.com/polkadot-js/apps/issues/3081
This was actually a little bug more than a missing feature. [this component](https://github.com/polkadot-js/apps/blob/master/packages/page-staking/src/Actions/Account/index.tsx#L129) was passing the account info in `stakingInfo` prop, although the prop name was `value`. I went for the renaming of the `prop` to keep things consistent with the other similar component.

![image](https://user-images.githubusercontent.com/33178835/86112007-bb308980-bac7-11ea-8f69-7c99ed854f7d.png)

![image](https://user-images.githubusercontent.com/33178835/86111965-ace26d80-bac7-11ea-8563-b89abf41f896.png)
