### PR TITLE
Be able to select preimage hash in Firefox

### DIFF
--- a/packages/page-democracy/src/Overview/PreImage.tsx
+++ b/packages/page-democracy/src/Overview/PreImage.tsx
@@ -80,7 +80,7 @@ function PreImage ({ className = '', imageHash, isImminent: propsIsImminent, onC
               onChange={setProposal}
             />
             <Input
-              className={'disabledLook'}
+              className='disabledLook'
               help={t<string>('The hash of the selected proposal, use it for submitting the proposal')}
               isDisabledError={!isMatched}
               label={t<string>('preimage hash')}

--- a/packages/page-democracy/src/Overview/PreImage.tsx
+++ b/packages/page-democracy/src/Overview/PreImage.tsx
@@ -80,6 +80,7 @@ function PreImage ({ className = '', imageHash, isImminent: propsIsImminent, onC
               onChange={setProposal}
             />
             <Input
+              className={'disabledLook'}
               help={t<string>('The hash of the selected proposal, use it for submitting the proposal')}
               isDisabledError={!isMatched}
               label={t<string>('preimage hash')}
@@ -125,5 +126,14 @@ export default React.memo(styled(PreImage)`
   .toggleImminent {
     margin: 0.5rem 0;
     text-align: right;
+  }
+
+  .disabledLook input {
+    background: transparent;
+    border-style: dashed;
+    &:focus{
+      background: transparent;
+      border-color: #d9d8d7;
+    }
   }
 `);

--- a/packages/page-democracy/src/Overview/PreImage.tsx
+++ b/packages/page-democracy/src/Overview/PreImage.tsx
@@ -81,7 +81,6 @@ function PreImage ({ className = '', imageHash, isImminent: propsIsImminent, onC
             />
             <Input
               help={t<string>('The hash of the selected proposal, use it for submitting the proposal')}
-              isDisabled
               isDisabledError={!isMatched}
               label={t<string>('preimage hash')}
               value={encodedHash}


### PR DESCRIPTION
closes https://github.com/polkadot-js/apps/issues/2140

The field looks disabled. One can't edit it either, but selection is now possible on FF. 
I checked on Chrome and the behaviour is the same as on FF.

![select](https://user-images.githubusercontent.com/33178835/86126426-9bf12680-bade-11ea-97e4-4bb202da112f.gif)
