### PR TITLE
Add Content Security Policy headers.

### DIFF
--- a/packages/apps-electron/src/electron/contentSecurityPolicy.ts
+++ b/packages/apps-electron/src/electron/contentSecurityPolicy.ts
@@ -1,0 +1,23 @@
+// Copyright 2017-2020 @polkadot/apps authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { HeadersReceivedResponse, session } from 'electron';
+
+export const setupContentSecurityPolicy = (environment: string): void => {
+  session.defaultSession.webRequest.onHeadersReceived((details, cb: (headersReceivedResponse: HeadersReceivedResponse) => void) => {
+    const headersReceivedResponse = {
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [`default-src 'self' ${environment === 'development' ? "'unsafe-eval'" : ''};` +
+        " style-src-elem https://fonts.googleapis.com/css 'unsafe-inline';" +
+        " font-src data: 'self' https://fonts.gstatic.com;" +
+        " style-src 'unsafe-inline';" +
+        " connect-src 'self' wss:;" +
+        " img-src 'self' data:"]
+      }
+    };
+
+    cb(headersReceivedResponse);
+  });
+};

--- a/packages/apps-electron/src/electron/index.ts
+++ b/packages/apps-electron/src/electron/index.ts
@@ -5,12 +5,14 @@
 import { app } from 'electron';
 import { registerAccountStoreHandlers } from '../main/account-store';
 import { setupAutoUpdater } from './autoUpdater';
+import { setupContentSecurityPolicy } from './contentSecurityPolicy';
 import { createWindow } from './window';
 
 const ENV = process.env.NODE_ENV || 'production';
 
 const onReady = async () => {
   registerAccountStoreHandlers();
+  setupContentSecurityPolicy(ENV);
   await createWindow(ENV);
   await setupAutoUpdater();
 };


### PR DESCRIPTION
As per [Electron Security Tutorial](https://www.electronjs.org/docs/tutorial/security#6-define-a-content-security-policy), this PR adds a (hopefully minimal) CSP header configuration.