### PR TITLE
Open external links in default system browser

### DIFF
--- a/packages/apps-electron/src/electron/index.ts
+++ b/packages/apps-electron/src/electron/index.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { app } from 'electron';
+import { app, shell } from 'electron';
 import { registerAccountStoreHandlers } from '../main/account-store';
 import { setupAutoUpdater } from './autoUpdater';
 import { createWindow } from './window';
@@ -14,5 +14,12 @@ const onReady = async () => {
   await createWindow(ENV);
   await setupAutoUpdater();
 };
+
+app.on('web-contents-created', (e, webContents) => {
+  webContents.on('new-window', (e, url) => {
+    e.preventDefault();
+    shell.openExternal(url).catch(console.error);
+  });
+});
 
 app.whenReady().then(onReady).catch(console.error);


### PR DESCRIPTION
We have at least 2 links (GitHub, Wiki) that lead to external resources. Electron by default opens them in a new Electron window, which doesn't make much sense. This PR changes this behaviour to open those links in a system browser.