### PR TITLE
Improve error handling in remote electron account store

### DIFF
--- a/packages/apps-electron/src/renderer/remote-electron-store.ts
+++ b/packages/apps-electron/src/renderer/remote-electron-store.ts
@@ -14,28 +14,28 @@ export class RemoteElectronStore implements KeyringStore {
 
   all (cb: (key: string, value: KeyringJson) => void): void {
     this.#accountStore.all()
-      .then((result: { key: string, value: KeyringJson }[]) => result.forEach(({ key, value }) => cb(key, value)))
-      .catch(() => {
-        throw new Error('error getting all accounts');
+      .then((result: { key: string, value: KeyringJson }[]) => result?.forEach(({ key, value }) => cb(key, value)))
+      .catch((e: Error) => {
+        throw new Error(`error getting all accounts: ${e.message}`);
       });
   }
 
   get (key: string, cb: (value: KeyringJson) => void): void {
     this.#accountStore.get(key)
-      .then(cb).catch(() => {
-        throw new Error('error storing account');
+      .then(cb).catch((e: Error) => {
+        throw new Error(`error storing account: ${e.message}`);
       });
   }
 
   remove (key: string, cb: (() => void) | undefined): void {
-    this.#accountStore.remove(key).then(cb).catch(() => {
-      throw new Error('error removing account');
+    this.#accountStore.remove(key).then(cb).catch((e: Error) => {
+      throw new Error(`error removing account: ${e.message}`);
     });
   }
 
   set (key: string, value: KeyringJson, cb: (() => void) | undefined): void {
-    this.#accountStore.set(key, value).then(cb).catch(() => {
-      throw new Error('error saving account');
+    this.#accountStore.set(key, value).then(cb).catch((e: Error) => {
+      throw new Error(`error saving account: ${e.message}`);
     });
   }
 }


### PR DESCRIPTION
I found out that when there are no accounts yet the accounts list (`result` variable) can be undefined. That's a bit strange, because on the main process side we return an empty array. Probably has to do with how Electron handles IPC (inter-process communication).

Anyway, added a `?` to prevent the error from happening.

I also added the base error messages to ease debugging.