### PR TITLE
Do not use filter on selected accounts

### DIFF
--- a/packages/react-components/src/InputAddressMulti/Selected.tsx
+++ b/packages/react-components/src/InputAddressMulti/Selected.tsx
@@ -8,7 +8,7 @@ import AddressToggle from '../AddressToggle';
 
 interface Props {
   address: string;
-  filter: string;
+  filter?: string;
   isHidden?: boolean;
   onDeselect: (address: string) => void;
 }

--- a/packages/react-components/src/InputAddressMulti/index.tsx
+++ b/packages/react-components/src/InputAddressMulti/index.tsx
@@ -75,7 +75,6 @@ function InputAddressMulti ({ available, availableLabel, className = '', default
             {selected.map((address): React.ReactNode => (
               <Selected
                 address={address}
-                filter={filter}
                 key={address}
                 onDeselect={_onDeselect}
               />


### PR DESCRIPTION
Naive fix that closes #3078
I know this component is used at many other places, I've considered this, however I think that the selected/right side should never be filtered, in any of the implementations we have. Also for consistency, we shouldn't have a multiselect that sometime filters all the fields, sometimes just the left part. Open to discussion if you disagree.