### PR TITLE
Clarify signed message input

### DIFF
--- a/packages/page-claims/src/index.tsx
+++ b/packages/page-claims/src/index.tsx
@@ -264,6 +264,7 @@ function ClaimsApp (): React.ReactElement {
                 text={didCopy ? t<string>('copied') : t<string>('click to copy')}
                 trigger='tx-payload'
               />
+              <div>{t<string>('Paste the signed message into the field below. The placeholder text is there as a hint to what the message should look like:')}</div>
               <Signature
                 onChange={onChangeSignature}
                 placeholder={`{\n  "address": "0x ...",\n  "msg": "${prefix}:...",\n  "sig": "0x ...",\n  "version": "2"\n}`}


### PR DESCRIPTION
Some claimants have been confused about the final input field as it has no explanation and seemingly contains value (the placeholder). This will hopefully help.