### PR TITLE
Fix overflow in proxy overview for long names

### DIFF
--- a/packages/page-accounts/src/Accounts/modals/ProxyOverview.tsx
+++ b/packages/page-accounts/src/Accounts/modals/ProxyOverview.tsx
@@ -327,7 +327,7 @@ export default React.memo(styled(ProxyOverview)`
   .proxy-container {
     display: grid;
     grid-column-gap: 0.5rem;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     margin-bottom: 1rem;
 
     .input-column {


### PR DESCRIPTION
Fixes the following:
![image](https://user-images.githubusercontent.com/33178835/89398577-9310f780-d711-11ea-8036-ead37983f474.png)

Now looks like:
![image](https://user-images.githubusercontent.com/33178835/89398594-999f6f00-d711-11ea-8f9d-d938e128e2c9.png)
