### PR TITLE
Take unlocking and redeemable into account to bond more funds

### DIFF
--- a/packages/page-staking/src/Actions/Account/BondExtra.tsx
+++ b/packages/page-staking/src/Actions/Account/BondExtra.tsx
@@ -37,7 +37,10 @@ function BondExtra ({ controllerId, onClose, stakingInfo, stashId }: Props): Rea
 
   useEffect((): void => {
     if (stakingInfo && stakingInfo.stakingLedger && stashBalance) {
-      const available = stashBalance.freeBalance.sub(stakingInfo.stakingLedger.active.unwrap());
+      const sumUnlocking: BN = stakingInfo.unlocking?.reduce((acc, { value }) => acc.add(value), BN_ZERO) || BN_ZERO;
+      const redeemable: BN = stakingInfo.redeemable || BN_ZERO;
+
+      const available = stashBalance.freeBalance.sub(stakingInfo.stakingLedger.active.unwrap()).sub(sumUnlocking).sub(redeemable);
 
       setStartBalance(
         available.gt(api.consts.balances.existentialDeposit)

--- a/packages/page-staking/src/Actions/Account/BondExtra.tsx
+++ b/packages/page-staking/src/Actions/Account/BondExtra.tsx
@@ -37,9 +37,8 @@ function BondExtra ({ controllerId, onClose, stakingInfo, stashId }: Props): Rea
 
   useEffect((): void => {
     if (stakingInfo && stakingInfo.stakingLedger && stashBalance) {
-      const sumUnlocking: BN = stakingInfo.unlocking?.reduce((acc, { value }) => acc.add(value), BN_ZERO) || BN_ZERO;
-      const redeemable: BN = stakingInfo.redeemable || BN_ZERO;
-
+      const sumUnlocking = stakingInfo.unlocking?.reduce((acc, { value }) => acc.add(value), BN_ZERO) || BN_ZERO;
+      const redeemable = stakingInfo.redeemable || BN_ZERO;
       const available = stashBalance.freeBalance.sub(stakingInfo.stakingLedger.active.unwrap()).sub(sumUnlocking).sub(redeemable);
 
       setStartBalance(


### PR DESCRIPTION
closes #3232 
We now take any unbonding amount as well as any amount that hasn't been redeemed yet.

I've tested it with both unbonding (also several) and redeemable amounts.