### PR TITLE
Show icon in dock on linux

### DIFF
--- a/packages/apps-electron/src/electron/window.ts
+++ b/packages/apps-electron/src/electron/window.ts
@@ -10,6 +10,7 @@ export function createWindow (environment: string): Promise<unknown> {
 
   const win = new BrowserWindow({
     height,
+    icon: path.join(__dirname, 'icon.png'),
     webPreferences: {
       contextIsolation: true,
       enableRemoteModule: false,

--- a/packages/apps-electron/webpack.main.config.js
+++ b/packages/apps-electron/webpack.main.config.js
@@ -5,6 +5,7 @@
 /* eslint-disable camelcase */
 
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
 
 const ENV = process.env.NODE_ENV || 'production';
@@ -44,6 +45,9 @@ function createWebpack () {
         filename: '[name].js',
         path: path.join(__dirname, '/build')
       },
+      plugins: [
+        new CopyWebpackPlugin({ patterns: [{ from: 'assets' }] })
+      ],
       resolve: {
         extensions: ['.js', '.jsx', '.json', '.ts', '.tsx']
       },


### PR DESCRIPTION
Currently when running the AppImage version on Ubuntu, no icon is displayed in the system dock. This PR fixes it.