### PR TITLE
Add PolkaStats links

### DIFF
--- a/packages/apps-config/src/links/index.ts
+++ b/packages/apps-config/src/links/index.ts
@@ -8,12 +8,14 @@ import Commonwealth from './commonwealth';
 import Polkascan from './polkascan';
 import Polkassembly from './polkassembly';
 import Subscan from './subscan';
+import Polkastats from './polkastats';
 
 const externals: Record<string, ExternalDef> = {
   Commonwealth,
   Polkascan,
   Polkassembly,
-  Subscan
+  Subscan,
+  Polkastats
 };
 
 export default externals;

--- a/packages/apps-config/src/links/index.ts
+++ b/packages/apps-config/src/links/index.ts
@@ -7,15 +7,15 @@ import { ExternalDef } from './types';
 import Commonwealth from './commonwealth';
 import Polkascan from './polkascan';
 import Polkassembly from './polkassembly';
-import Subscan from './subscan';
 import Polkastats from './polkastats';
+import Subscan from './subscan';
 
 const externals: Record<string, ExternalDef> = {
   Commonwealth,
   Polkascan,
   Polkassembly,
-  Subscan,
-  Polkastats
+  Polkastats,
+  Subscan
 };
 
 export default externals;

--- a/packages/apps-config/src/links/polkastats.ts
+++ b/packages/apps-config/src/links/polkastats.ts
@@ -1,0 +1,22 @@
+// Copyright 2017-2020 @polkadot/apps-config authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import BN from 'bn.js';
+
+export default {
+  chains: {
+    Kusama: 'kusama',
+    Polkadot: 'polkadot',
+    Westend: 'westend'
+  },
+  create: (chain: string, path: string, data: BN | number | string): string =>
+    `https://${chain}.polkastats.io/${path}/${data.toString()}`,
+  isActive: true,
+  paths: {
+    address: 'account',
+    block: 'block',
+    extrinsic: 'extrinsic'
+  },
+  url: 'https://polkastats.io/'
+};


### PR DESCRIPTION
Added links for account, block & extrinsic paths on currently supported networks Polkadot, Kusama and Westend.