### PR TITLE
Hide non-retrieved node values

### DIFF
--- a/packages/page-explorer/src/NodeInfo/Summary.tsx
+++ b/packages/page-explorer/src/NodeInfo/Summary.tsx
@@ -40,44 +40,39 @@ function Summary ({ info: { extrinsics, health, peers } = EMPTY_INFO, nextRefres
         <CardSummary label={t<string>('refresh in')}>
           <Elapsed value={nextRefresh} />
         </CardSummary>
-        <CardSummary
-          className='ui--media-small'
-          label={t<string>('total peers')}
-        >
-          {
-            health
-              ? `${health.peers.toNumber()}`
-              : '-'
-          }
-        </CardSummary>
-        <CardSummary
-          className='ui--media-small'
-          label={t<string>('syncing')}
-        >
-          {
-            health
-              ? (
-                health.isSyncing.valueOf()
-                  ? t<string>('yes')
-                  : t<string>('no')
-              )
-              : '-'
-          }
-        </CardSummary>
+        {health && (
+          <>
+            <CardSummary
+              className='ui--media-small'
+              label={t<string>('total peers')}
+            >
+              {formatNumber(health.peers)}
+            </CardSummary>
+            <CardSummary
+              className='ui--media-small'
+              label={t<string>('syncing')}
+            >
+              {health.isSyncing.valueOf()
+                ? t<string>('yes')
+                : t<string>('no')
+              }
+            </CardSummary>
+          </>
+        )}
       </section>
-      <section className='ui--media-large'>
-        <CardSummary label={t<string>('queued tx')}>
-          {
-            extrinsics
-              ? `${extrinsics.length}`
-              : '-'
-          }
-        </CardSummary>
-      </section>
+      {extrinsics && (extrinsics.length > 0) && (
+        <section className='ui--media-large'>
+          <CardSummary label={t<string>('queued tx')}>
+            {extrinsics.length}
+          </CardSummary>
+        </section>
+      )}
       <section>
-        <CardSummary label={t<string>('peer best')}>
-          {formatNumber(peerBest)}
-        </CardSummary>
+        {peerBest?.gtn(0) && (
+          <CardSummary label={t<string>('peer best')}>
+            {formatNumber(peerBest)}
+          </CardSummary>
+        )}
         <CardSummary label={t<string>('our best')}>
           <BestNumber />
         </CardSummary>

--- a/packages/page-explorer/src/NodeInfo/index.tsx
+++ b/packages/page-explorer/src/NodeInfo/index.tsx
@@ -19,9 +19,9 @@ async function retrieveInfo (api: ApiPromise): Promise<Partial<Info>> {
   try {
     const [blockNumber, health, peers, extrinsics] = await Promise.all([
       api.derive.chain.bestNumber(),
-      api.rpc.system.health(),
-      api.rpc.system.peers(),
-      api.rpc.author.pendingExtrinsics()
+      api.rpc.system.health().catch(() => null),
+      api.rpc.system.peers().catch(() => null),
+      api.rpc.author.pendingExtrinsics().catch(() => null)
     ]);
 
     return { blockNumber, extrinsics, health, peers };


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/3250 (well, that issue operates fully as expected, but the hardening inspired by it, empty values have no real benefit here)

Since these values are not retrieved since the RPC is displayed, just hide the summary columns completely. Additionally make sure we do fully treat the RPCs are optional (failures have no effect)