### PR TITLE
Update Kulupu RPC endpoint

### DIFF
--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -101,7 +101,7 @@ function createLive (t: TFunction): LinkOption[] {
       dnslink: 'kulupu',
       info: 'substrate',
       text: t<string>('rpc.kulupu', 'Kulupu (Kulupu Mainnet, hosted by Kulupu)', { ns: 'apps-config' }),
-      value: 'wss://rpc.kulupu.network/ws'
+      value: 'wss://rpc.kulupu.corepaper.org/ws'
     }
   ];
 }


### PR DESCRIPTION
The old domain is usually troubled by adblocker for some reasons. Moving this to `rpc.kulupu.corepaper.org` to improve situations on that.