### PR TITLE
fix name of nodle spec

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -17,7 +17,6 @@ import stablePoc from './stable-poc';
 
 export default {
   Crab: crab,
-  'Nodle Chain Node': nodle,
   acala,
   'centrifuge-chain': centrifugeChain,
   'cumulus-test-parachain': testPara,
@@ -28,6 +27,7 @@ export default {
   kulupu,
   'mashnet-node': kilt,
   'node-template': nodeTemplate,
+  'nodle-chain': nodle,
   'stable-poc': stablePoc,
   stable_poc: stablePoc
 };


### PR DESCRIPTION
When submitting #3450 it seems like I tested the chain spec changes without removing the types I had set in the UI and thus didn't detect the fact they wouldn't be applied. This PR fixes this.