### PR TITLE
Fix conviction dropdown block time display

### DIFF
--- a/packages/react-components/src/ConvictionDropdown.tsx
+++ b/packages/react-components/src/ConvictionDropdown.tsx
@@ -41,7 +41,7 @@ function createOptions (api: ApiPromise, t: TFunction, blockTime: number): { tex
 function Convictions ({ className = '', help, label, onChange, value }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { t } = useTranslation();
-  const [ blockTime ] = useBlockTime();
+  const [blockTime] = useBlockTime();
 
   const optionsRef = useRef(createOptions(api, t, blockTime));
 


### PR DESCRIPTION
Use the `useBlockTime` react hooks to calculate block time in the conviction dropdown.