### PR TITLE
add rococo laminar

### DIFF
--- a/packages/apps-config/src/settings/endpoints.ts
+++ b/packages/apps-config/src/settings/endpoints.ts
@@ -148,6 +148,12 @@ function createTest (t: TFunction): LinkOption[] {
       value: 'wss://rococo-1.acala.laminar.one'
     },
     {
+      info: 'rococoLaminar',
+      isChild: true,
+      text: t<string>('rpc.rococo.laminar', 'Turbulence PC1 (Laminar Testpara, hosted by Laminar)', { ns: 'apps-config' }),
+      value: 'wss://rococo-1.laminar-chain.laminar.one'
+    },
+    {
       dnslink: 'westend',
       info: 'westend',
       text: t<string>('rpc.westend', 'Westend (Polkadot Testnet, hosted by Parity)', { ns: 'apps-config' }),

--- a/packages/apps-config/src/ui/general/index.ts
+++ b/packages/apps-config/src/ui/general/index.ts
@@ -14,6 +14,7 @@ const chainRoccoTick = '#22bb22';
 const chainRoccoTrack = '#bb2222';
 const chainRoccoTrick = '#2222bb';
 const chainRoccoAcala = '#173DC9';
+const laminarRoccoAcala = '#004FFF';
 const chainWestend = '#da68a7';
 
 const nodeCentrifuge = '#fcc367';
@@ -36,6 +37,7 @@ const chainColors: Record<string, any> = [
   ['Track', chainRoccoTrack],
   ['Trick', chainRoccoTrick],
   ['acala mandala pc1', chainRoccoAcala],
+  ['laminar turbulence pc1', laminarRoccoAcala],
   ['Westend', chainWestend]
 ].reduce((colors, [chain, color]): Record<string, any> => ({
   ...colors,

--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -84,6 +84,7 @@ const namedLogos: Record<string, any> = {
   polkadot: nodePolkadot,
   rococo: chainRococo,
   rococoAcala: nodeAcala,
+  rococoLaminar: nodeLaminar,
   rococoTick: chainRococoTick,
   rococoTrack: chainRococoTrack,
   rococoTrick: chainRococoTrick,


### PR DESCRIPTION
Hi, we've wired the Laminar Chain into Rococo and now want it to display on the Polkadot Apps.

Because a type is missing, only after this PR merge can it work well.

https://github.com/polkadot-js/api/pull/2519