### PR TITLE
No indices lookups anywhere, only on address book

### DIFF
--- a/packages/react-components/src/InputAddress/index.tsx
+++ b/packages/react-components/src/InputAddress/index.tsx
@@ -125,7 +125,7 @@ class InputAddress extends React.PureComponent<Props, State> {
       return {
         lastValue: lastValue || getLastValue(type),
         value: Array.isArray(value)
-          ? value.map(addressToAddress)
+          ? value.map((v) => addressToAddress(v))
           : (addressToAddress(value) || undefined)
       };
     } catch (error) {

--- a/packages/react-components/src/util/toAddress.ts
+++ b/packages/react-components/src/util/toAddress.ts
@@ -3,24 +3,22 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import keyring from '@polkadot/ui-keyring';
-import { hexToU8a, isHex } from '@polkadot/util';
+import { hexToU8a, isHex, assert } from '@polkadot/util';
 
-export default function toAddress (value?: string | Uint8Array | null): string | undefined {
-  if (!value) {
-    return;
-  }
-
-  let address: string | undefined;
-
-  try {
-    address = keyring.encodeAddress(
-      isHex(value)
+export default function toAddress (value?: string | Uint8Array | null, allowIndices = false): string | undefined {
+  if (value) {
+    try {
+      const u8a = isHex(value)
         ? hexToU8a(value)
-        : keyring.decodeAddress(value)
-    );
-  } catch (error) {
-    console.error('Unable to encode address', value);
+        : keyring.decodeAddress(value);
+
+      assert(allowIndices || u8a.length === 32, 'AccountIndex values not allowed');
+
+      return keyring.encodeAddress(u8a);
+    } catch (error) {
+      console.error('Unable to encode address', error.message, value);
+    }
   }
 
-  return address;
+  return undefined;
 }

--- a/packages/react-components/src/util/toAddress.ts
+++ b/packages/react-components/src/util/toAddress.ts
@@ -16,7 +16,7 @@ export default function toAddress (value?: string | Uint8Array | null, allowIndi
 
       return keyring.encodeAddress(u8a);
     } catch (error) {
-      console.error('Unable to encode address', error.message, value);
+      console.error('Unable to encode address', (error as Error).message, value);
     }
   }
 


### PR DESCRIPTION
Some apparent misunderstanding on indices are spreading and since the apps UI has support for chains with `Address: 'LookupSource'` people are misinterpreting the config of chain such as Kusma and Polkadot.

For these it seems there is an effort ongoing (as per txs on-chain) to registering indices and expecting it to work in the situation where `Address: 'AccountId'`. It doesn't and there is no space-savings, featuring only (a) vanity & (b) lookups to address book.

To protect users against themselves using functionality not built into the UI (indices registration), take a blanket approach and just always skip indices as destinations.