### PR TITLE
fill in all empty values in all languageCaches.

### DIFF
--- a/packages/page-settings/src/I18n/index.tsx
+++ b/packages/page-settings/src/I18n/index.tsx
@@ -82,7 +82,7 @@ async function retrieveAll (): Promise<Defaults> {
         }
       });
     });
-  })
+  });
 
   return {
     english,

--- a/packages/page-settings/src/I18n/index.tsx
+++ b/packages/page-settings/src/I18n/index.tsx
@@ -68,11 +68,13 @@ async function retrieveAll (): Promise<Defaults> {
     ? await Promise.all(missing.map((lng) => retrieveJson(`${lng}/translation.json`)))
     : [];
 
+  // setup the language cache
   missing.forEach((lng, index): void => {
-    // setup the language cache
     languageCache[lng] = translations[index] as Record<string, string>;
+  });
 
-    // fill in all empty values (useful for download, filling in)
+  // fill in all empty values (useful for download, filling in)
+  keys.forEach((lng):void => {
     Object.keys(english).forEach((record): void => {
       Object.keys(english[record]).forEach((key): void => {
         if (!languageCache[lng][key]) {
@@ -80,7 +82,7 @@ async function retrieveAll (): Promise<Defaults> {
         }
       });
     });
-  });
+  })
 
   return {
     english,


### PR DESCRIPTION
This is bug fix.

On the settings page, when I select a language, the old value remains.
I think this is because the browser language is not initialized.

In my case, if I select Korean and then Japanese, the old value remains.

![20200904](https://user-images.githubusercontent.com/69296148/92217869-3a30ac80-eed3-11ea-852a-6e15ca3290e8.jpg)

(My browser language is 'ja')