### PR TITLE
Display reward destination for isAccount

### DIFF
--- a/packages/page-staking/src/Actions/Account/SetRewardDestination.tsx
+++ b/packages/page-staking/src/Actions/Account/SetRewardDestination.tsx
@@ -2,14 +2,17 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { RewardDestination } from '@polkadot/types/interfaces';
+import { DestinationType } from '../types';
+
 import React, { useState } from 'react';
 import { Dropdown, InputAddress, Modal, TxButton } from '@polkadot/react-components';
 
 import { useTranslation } from '../../translate';
-import { rewardDestinationOptions } from '../constants';
+import { rewardDestinationOptions, rewardDestinationOptionsPrev } from '../constants';
 
 interface Props {
-  defaultDestination?: number;
+  defaultDestination?: RewardDestination;
   controllerId: string;
   onClose: () => void;
   stashId: string;
@@ -17,7 +20,13 @@ interface Props {
 
 function SetRewardDestination ({ controllerId, defaultDestination, onClose, stashId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [destination, setDestination] = useState(0);
+  const [destination, setDestination] = useState<DestinationType>(((defaultDestination?.isAccount ? 'Account' : defaultDestination?.toString()) || 'Staked') as 'Staked');
+  const [destAccount, setDestAccount] = useState<string | null>(defaultDestination?.isAccount ? defaultDestination.asAccount.toString() : null);
+
+  const options = defaultDestination?.isAccount
+    ? rewardDestinationOptions
+    : rewardDestinationOptionsPrev;
+  const isAccount = destination === 'Account';
 
   return (
     <Modal
@@ -46,13 +55,22 @@ function SetRewardDestination ({ controllerId, defaultDestination, onClose, stas
         <Modal.Columns>
           <Modal.Column>
             <Dropdown
-              defaultValue={defaultDestination}
+              defaultValue={defaultDestination?.toString()}
               help={t<string>('The destination account for any payments as either a nominator or validator')}
               label={t<string>('payment destination')}
               onChange={setDestination}
-              options={rewardDestinationOptions}
+              options={options}
               value={destination}
             />
+            {isAccount && (
+              <InputAddress
+                help={t('An account that is to receive the rewards')}
+                label={t('the payment account')}
+                onChange={setDestAccount}
+                type='account'
+                value={destAccount}
+              />
+            )}
           </Modal.Column>
           <Modal.Column>
             <p>{t<string>('All rewards will go towards the selected output destination when a payout is made.')}</p>
@@ -63,11 +81,15 @@ function SetRewardDestination ({ controllerId, defaultDestination, onClose, stas
         <TxButton
           accountId={controllerId}
           icon='sign-in-alt'
-          isDisabled={!controllerId}
+          isDisabled={!controllerId || (isAccount && !destAccount)}
           label={t<string>('Set reward destination')}
           onStart={onClose}
-          params={[destination]}
-          tx={'staking.setPayee'}
+          params={[
+            isAccount
+              ? { Account: destAccount }
+              : destination
+          ]}
+          tx='staking.setPayee'
         />
       </Modal.Actions>
     </Modal>

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -66,7 +66,7 @@ function useStashCalls (api: ApiPromise, stashId: string) {
   return { balancesAll, spanCount, stakingAccount };
 }
 
-function Account ({ allSlashes, className = '', info: { controllerId, destination, destinationId, hexSessionIdNext, hexSessionIdQueue, isLoading, isOwnController, isOwnStash, isStashNominating, isStashValidating, nominating, sessionIds, stakingLedger, stashId }, isDisabled, targets }: Props): React.ReactElement<Props> {
+function Account ({ allSlashes, className = '', info: { controllerId, destination, hexSessionIdNext, hexSessionIdQueue, isLoading, isOwnController, isOwnStash, isStashNominating, isStashValidating, nominating, sessionIds, stakingLedger, stashId }, isDisabled, targets }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const { queueExtrinsic } = useContext(StatusContext);
@@ -149,7 +149,7 @@ function Account ({ allSlashes, className = '', info: { controllerId, destinatio
         {isRewardDestinationOpen && controllerId && (
           <SetRewardDestination
             controllerId={controllerId}
-            defaultDestination={destinationId}
+            defaultDestination={destination}
             onClose={toggleRewardDestination}
             stashId={stashId}
           />
@@ -180,7 +180,7 @@ function Account ({ allSlashes, className = '', info: { controllerId, destinatio
       <td className='address'>
         <AddressMini value={controllerId} />
       </td>
-      <td className='number media--1200'>
+      <td className='start media--1200'>
         {destination?.isAccount
           ? <AddressMini value={destination.asAccount} />
           : destination?.toString()

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -180,7 +180,12 @@ function Account ({ allSlashes, className = '', info: { controllerId, destinatio
       <td className='address'>
         <AddressMini value={controllerId} />
       </td>
-      <td className='number media--1200'>{destination}</td>
+      <td className='number media--1200'>
+        {destination?.isAccount
+          ? <AddressMini value={destination.asAccount} />
+          : destination?.toString()
+        }
+      </td>
       <td className='number'>
         <StakingBonded stakingInfo={stakingAccount} />
         <StakingUnbonding stakingInfo={stakingAccount} />

--- a/packages/page-staking/src/Actions/constants.tsx
+++ b/packages/page-staking/src/Actions/constants.tsx
@@ -2,8 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-export const rewardDestinationOptions = [
+export const rewardDestinationOptionsPrev = [
   { text: 'Stash account (increase the amount at stake)', value: 'Staked' },
   { text: 'Stash account (do not increase the amount at stake)', value: 'Stash' },
   { text: 'Controller account', value: 'Controller' }
+];
+
+export const rewardDestinationOptions = [
+  ...rewardDestinationOptionsPrev,
+  { text: 'Payment account', value: 'Account' }
 ];

--- a/packages/page-staking/src/Actions/index.tsx
+++ b/packages/page-staking/src/Actions/index.tsx
@@ -59,7 +59,7 @@ function Actions ({ className = '', isInElection, ownStashes, targets }: Props):
   const headerRef = useRef([
     [t('stashes'), 'start', 2],
     [t('controller'), 'address'],
-    [t('rewards'), 'number media--1200'],
+    [t('rewards'), 'start media--1200'],
     [t('bonded'), 'number'],
     [undefined, undefined, 2]
   ]);

--- a/packages/page-staking/src/Actions/partials/Bond.tsx
+++ b/packages/page-staking/src/Actions/partials/Bond.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { DeriveBalancesAll } from '@polkadot/api-derive/types';
-import { AmountValidateState } from '../types';
+import { AmountValidateState, DestinationType } from '../types';
 import { BondInfo } from './types';
 
 import BN from 'bn.js';
@@ -16,15 +16,13 @@ import { BN_ZERO } from '@polkadot/util';
 import { useTranslation } from '../../translate';
 import InputValidateAmount from '../Account/InputValidateAmount';
 import InputValidationController from '../Account/InputValidationController';
-import { rewardDestinationOptions } from '../constants';
+import { rewardDestinationOptionsPrev } from '../constants';
 import useUnbondDuration from '../useUnbondDuration';
 
 interface Props {
   className?: string;
   onChange: (info: BondInfo) => void;
 }
-
-type DestinationType = 'Staked' | 'Stash' | 'Controller' | 'Account';
 
 function Bond ({ className = '', onChange }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
@@ -152,7 +150,7 @@ function Bond ({ className = '', onChange }: Props): React.ReactElement<Props> {
             help={t<string>('The destination account for any payments as either a nominator or validator')}
             label={t<string>('payment destination')}
             onChange={setDestination}
-            options={rewardDestinationOptions}
+            options={rewardDestinationOptionsPrev}
             value={destination}
           />
         </Modal.Column>

--- a/packages/page-staking/src/Actions/types.ts
+++ b/packages/page-staking/src/Actions/types.ts
@@ -23,3 +23,5 @@ export interface Slash {
   era: BN;
   slashes: Unapplied[];
 }
+
+export type DestinationType = 'Staked' | 'Stash' | 'Controller' | 'Account';

--- a/packages/page-treasury/src/Tips/Tips.tsx
+++ b/packages/page-treasury/src/Tips/Tips.tsx
@@ -105,7 +105,7 @@ export default React.memo(styled(Tips)`
 
     .ui--Toggle {
       margin-right: 1rem;
-      margin-top: 0.5rem;
+      margin-top: 0.75rem;
     }
   }
 `);

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -123,7 +123,6 @@ export interface UseAccountInfo {
 export interface StakerState {
   controllerId: string | null;
   destination?: RewardDestination;
-  destinationId: number;
   exposure?: Exposure;
   hexSessionIdNext: string | null;
   hexSessionIdQueue: string | null;

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -5,7 +5,7 @@
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { DeriveAccountFlags, DeriveAccountRegistration } from '@polkadot/api-derive/types';
 import { ConstructTxFn, StringOrNull, VoidFn } from '@polkadot/react-components/types';
-import { AccountId, Balance, BlockNumber, Call, Exposure, Hash, SessionIndex, StakingLedger, ValidatorPrefs } from '@polkadot/types/interfaces';
+import { AccountId, Balance, BlockNumber, Call, Exposure, Hash, RewardDestination, SessionIndex, StakingLedger, ValidatorPrefs } from '@polkadot/types/interfaces';
 import { IExtrinsic } from '@polkadot/types/types';
 import { KeyringJson$Meta } from '@polkadot/ui-keyring/types';
 
@@ -122,7 +122,7 @@ export interface UseAccountInfo {
 
 export interface StakerState {
   controllerId: string | null;
-  destination?: string;
+  destination?: RewardDestination;
   destinationId: number;
   exposure?: Exposure;
   hexSessionIdNext: string | null;

--- a/packages/react-hooks/src/useOwnStashInfos.ts
+++ b/packages/react-hooks/src/useOwnStashInfos.ts
@@ -35,7 +35,6 @@ function getStakerState (stashId: string, allAccounts: string[], allStashes: str
   return {
     controllerId,
     destination: rewardDestination,
-    destinationId: rewardDestination?.toNumber() || 0,
     exposure,
     hexSessionIdNext: u8aToHex(nextConcat, 48),
     hexSessionIdQueue: u8aToHex(currConcat.length ? currConcat : nextConcat, 48),

--- a/packages/react-hooks/src/useOwnStashInfos.ts
+++ b/packages/react-hooks/src/useOwnStashInfos.ts
@@ -34,7 +34,7 @@ function getStakerState (stashId: string, allAccounts: string[], allStashes: str
 
   return {
     controllerId,
-    destination: rewardDestination?.toString().toLowerCase(),
+    destination: rewardDestination,
     destinationId: rewardDestination?.toNumber() || 0,
     exposure,
     hexSessionIdNext: u8aToHex(nextConcat, 48),


### PR DESCRIPTION
Part of https://github.com/polkadot-js/apps/issues/3354

Allows -

- display in staking actions
- allows changing once set

(Initial set assumed via extrinsics)