### PR TITLE
Update Kulupu treasury threshold

### DIFF
--- a/packages/page-council/src/thresholds.ts
+++ b/packages/page-council/src/thresholds.ts
@@ -18,7 +18,7 @@ const SLASH_THRESHOLDS: Record<string, number> = {
 };
 
 const TREASURY_THRESHOLDS: Record<string, number> = {
-  [KULUPU_GENESIS]: 0.8,
+  [KULUPU_GENESIS]: 0.5,
   [KUSAMA_GENESIS]: 0.6,
   [POLKADOT_GENESIS]: 0.6,
   default: 0.6


### PR DESCRIPTION
In the current runtime it's changed to 0.5. It's planned to be changed back (of course, given the community agrees) to 0.8 when we get `MoreThanMajorityThenPrimeDefaultVote`.