### PR TITLE
Fix overflow in democracy proposal (polkadot)

### DIFF
--- a/packages/react-components/src/Expander.tsx
+++ b/packages/react-components/src/Expander.tsx
@@ -145,6 +145,9 @@ export default React.memo(styled(Expander)`
       text-overflow: ellipsis;
       vertical-align: middle;
       white-space: nowrap;
+      span {
+        white-space: normal;
+      }
     }
 
     .ui--Icon {

--- a/packages/react-components/src/Expander.tsx
+++ b/packages/react-components/src/Expander.tsx
@@ -145,6 +145,7 @@ export default React.memo(styled(Expander)`
       text-overflow: ellipsis;
       vertical-align: middle;
       white-space: nowrap;
+
       span {
         white-space: normal;
       }


### PR DESCRIPTION
I had a look at the account creation, Council motions, payout.. and couldn't notice any break.
Was like this
![image](https://user-images.githubusercontent.com/33178835/93876526-4ab89380-fcd7-11ea-92e9-c2e549aa24f1.png)

Is now:
![image](https://user-images.githubusercontent.com/33178835/93870192-1e981500-fccd-11ea-8043-b78067ff2ad5.png)
