### PR TITLE
Filter #<weight>...</weight> from metadata

### DIFF
--- a/packages/react-components/src/Expander.tsx
+++ b/packages/react-components/src/Expander.tsx
@@ -46,11 +46,12 @@ function formatMeta (meta?: Meta): React.ReactNode | null {
 
   const strings = meta.documentation.map((doc) => doc.toString().trim());
   const firstEmpty = strings.findIndex((doc) => !doc.length);
-  const parts = splitParts((
+  const combined = (
     firstEmpty === -1
       ? strings
       : strings.slice(0, firstEmpty)
-  ).join(' ').replace(/\\/g, '').replace(/`/g, ''));
+  ).join(' ').replace(/#(<weight>| <weight>).*<\/weight>/, '');
+  const parts = splitParts(combined.replace(/\\/g, '').replace(/`/g, ''));
 
   return <>{parts.map((part, index) => index % 2 ? <em key={index}>[{part}]</em> : <span key={index}>{part}</span>)}&nbsp;</>;
 }


### PR DESCRIPTION
As per https://github.com/polkadot-js/apps/pull/3739#issuecomment-696671595

Funnily enough, it actually has (mostly) been scrubbed from the code anyway.