### PR TITLE
Bump API & Edgeware types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "afterSign": "electron-builder-notarize"
   },
   "resolutions": {
-    "@polkadot/api": "^1.35.0-beta.5",
-    "@polkadot/api-contract": "^1.35.0-beta.5",
+    "@polkadot/api": "^1.35.0-beta.6",
+    "@polkadot/api-contract": "^1.35.0-beta.6",
     "@polkadot/keyring": "^3.4.1",
-    "@polkadot/types": "^1.35.0-beta.5",
+    "@polkadot/types": "^1.35.0-beta.6",
     "@polkadot/util": "^3.4.1",
     "@polkadot/util-crypto": "^3.4.1",
     "@polkadot/wasm-crypto": "^1.4.1",

--- a/packages/apps-config/src/api/chain/beresheet.ts
+++ b/packages/apps-config/src/api/chain/beresheet.ts
@@ -4,19 +4,10 @@
 // structs need to be in order
 /* eslint-disable sort-keys */
 
-import * as edgewareDefinitions from '@edgeware/node-types/dist/interfaces/definitions';
-
-const edgTypes = Object
-  .values(edgewareDefinitions)
-  .reduce((res, { types }) => ({ ...res, ...types }), {});
+import { Beresheet } from '@edgeware/node-types';
 
 export default {
-  ...edgTypes,
-  // aliases that don't do well as part of interfaces
-  'voting::VoteType': 'VoteType',
-  'voting::TallyType': 'TallyType',
-  'voting::Tally': 'VotingTally',
+  ...Beresheet.types,
   // Substrate overrides
-  RefCount: 'u8',
-  Weight: 'u64'
+  RefCount: 'u8'
 };

--- a/packages/apps-config/src/api/spec/edgeware.ts
+++ b/packages/apps-config/src/api/spec/edgeware.ts
@@ -4,23 +4,10 @@
 // structs need to be in order
 /* eslint-disable sort-keys */
 
-import * as edgewareDefinitions from '@edgeware/node-types/dist/interfaces/definitions';
-
-const edgTypes = Object
-  .values(edgewareDefinitions)
-  .reduce((res, { types }) => ({ ...res, ...types }), {});
+import { Beresheet } from '@edgeware/node-types';
 
 export default {
-  ...edgTypes,
-  'voting::VoteType': 'VoteType',
-  'voting::TallyType': 'TallyType',
-  'voting::Tally': 'VotingTally',
+  ...Beresheet.types,
   // chain-specific overrides
-  Address: 'GenericAddress',
-  Keys: 'SessionKeys4',
-  StakingLedger: 'StakingLedgerTo223',
-  Votes: 'VotesTo230',
-  ReferendumInfo: 'ReferendumInfoTo239',
-  RefCount: 'u8',
-  Weight: 'u32'
+  RefCount: 'u8'
 };

--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -19,7 +19,7 @@ import plasm from './plasm';
 import robonomics from './robonomics';
 import stablePoc from './stable-poc';
 import stafi from './stafi';
-import subsocialNode from './subsocial';
+import subsocial from './subsocial';
 
 export default {
   Crab: crab,
@@ -43,5 +43,5 @@ export default {
   'stable-poc': stablePoc,
   stable_poc: stablePoc,
   stafi,
-  subsocial: subsocialNode
+  subsocial
 };

--- a/packages/page-contracts/package.json
+++ b/packages/page-contracts/package.json
@@ -12,6 +12,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@polkadot/api-contract": "^1.35.0-beta.5"
+    "@polkadot/api-contract": "^1.35.0-beta.6"
   }
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/polkadot-js/ui/tree/master/packages/ui-reactive#readme",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@polkadot/api": "^1.35.0-beta.5",
+    "@polkadot/api": "^1.35.0-beta.6",
     "@polkadot/extension-dapp": "^0.35.0-beta.2",
     "rxjs-compat": "^6.6.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,57 +3061,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-contract@npm:^1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/api-contract@npm:1.35.0-beta.5"
+"@polkadot/api-contract@npm:^1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/api-contract@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/api": 1.35.0-beta.5
-    "@polkadot/rpc-core": 1.35.0-beta.5
-    "@polkadot/types": 1.35.0-beta.5
+    "@polkadot/api": 1.35.0-beta.6
+    "@polkadot/rpc-core": 1.35.0-beta.6
+    "@polkadot/types": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     bn.js: ^5.1.3
     rxjs: ^6.6.3
-  checksum: 33108f55ee2574a4b6605c6732fbbf3fcbb6df6cb9f39d04711a5acf7700a303ce127003568ab3f6f6ca84642413925c8c4cc4ab7fec154236508fe8f6beb7f2
+  checksum: 49a593ada2efeaa89fe45b24d68d562983f3452f640275ff88ef43f03a55e2219eaed0b424825d57bd5df585c88e62e9886ec881390e8c7de2a9134dd1bfe64c
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/api-derive@npm:1.35.0-beta.5"
+"@polkadot/api-derive@npm:1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/api-derive@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/api": 1.35.0-beta.5
-    "@polkadot/rpc-core": 1.35.0-beta.5
-    "@polkadot/rpc-provider": 1.35.0-beta.5
-    "@polkadot/types": 1.35.0-beta.5
+    "@polkadot/api": 1.35.0-beta.6
+    "@polkadot/rpc-core": 1.35.0-beta.6
+    "@polkadot/rpc-provider": 1.35.0-beta.6
+    "@polkadot/types": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     "@polkadot/util-crypto": ^3.4.1
     bn.js: ^5.1.3
     memoizee: ^0.4.14
     rxjs: ^6.6.3
-  checksum: cef759388ecfd1f9721da9ad9a3be47d8584bee18b77b61cf206307bc15ac13496f8290e1fd7b4069fdfa673182f587f647c128feda41d5bbb4c5e95d8163ced
+  checksum: 325bdd38956cf16e72424fe39edaf122594e623b3a11d8623e5d45b35235fdb370a14eb0fb488625ac951c9adb08de037cb28bad551a4db69627be4a7f414bae
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/api@npm:1.35.0-beta.5"
+"@polkadot/api@npm:^1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/api@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/api-derive": 1.35.0-beta.5
+    "@polkadot/api-derive": 1.35.0-beta.6
     "@polkadot/keyring": ^3.4.1
-    "@polkadot/metadata": 1.35.0-beta.5
-    "@polkadot/rpc-core": 1.35.0-beta.5
-    "@polkadot/rpc-provider": 1.35.0-beta.5
-    "@polkadot/types": 1.35.0-beta.5
-    "@polkadot/types-known": 1.35.0-beta.5
+    "@polkadot/metadata": 1.35.0-beta.6
+    "@polkadot/rpc-core": 1.35.0-beta.6
+    "@polkadot/rpc-provider": 1.35.0-beta.6
+    "@polkadot/types": 1.35.0-beta.6
+    "@polkadot/types-known": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     "@polkadot/util-crypto": ^3.4.1
     bn.js: ^5.1.3
     eventemitter3: ^4.0.7
     rxjs: ^6.6.3
-  checksum: f1b124df2c28cd0428227727a00133cb98d62df0a02d80dfd17454e42fc6221794dbc2cd2236ee3ce2da05f4723187bff812726d6a5b048ab8ae042540d62968
+  checksum: bce92b57a72ce915f28691419057fdb3e1bab7e8ee5441e5980beee0bfc5dea258a0c11e9bb9f207bff3ac69a0735331c4db39a5b2958d66793145a34f12d2d0
   languageName: node
   linkType: hard
 
@@ -3167,7 +3167,7 @@ __metadata:
   resolution: "@polkadot/app-contracts@workspace:packages/page-contracts"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/api-contract": ^1.35.0-beta.5
+    "@polkadot/api-contract": ^1.35.0-beta.6
   languageName: unknown
   linkType: soft
 
@@ -3553,17 +3553,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/metadata@npm:1.35.0-beta.5"
+"@polkadot/metadata@npm:1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/metadata@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/types": 1.35.0-beta.5
-    "@polkadot/types-known": 1.35.0-beta.5
+    "@polkadot/types": 1.35.0-beta.6
+    "@polkadot/types-known": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     "@polkadot/util-crypto": ^3.4.1
     bn.js: ^5.1.3
-  checksum: 080dabb0227c68bb985dc6bb2cc6539a22729ce8e21efd85e0d1be70e8a053da17f4afa7e7142fa5ded95edc66477a2edbe66fe4a18405b6bdd33f8e9c2617d4
+  checksum: 9865349908e6848ed430ea21392aa7cc738681efa1e2c2a7ad950cbae453fc42e5ea08cce3a77d46d901337a8fd7fa86d83b83ed87c8ee321998eeaa61d1f08e
   languageName: node
   linkType: hard
 
@@ -3572,7 +3572,7 @@ __metadata:
   resolution: "@polkadot/react-api@workspace:packages/react-api"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/api": ^1.35.0-beta.5
+    "@polkadot/api": ^1.35.0-beta.6
     "@polkadot/extension-dapp": ^0.35.0-beta.2
     rxjs-compat: ^6.6.3
   languageName: unknown
@@ -3695,35 +3695,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/rpc-core@npm:1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/rpc-core@npm:1.35.0-beta.5"
+"@polkadot/rpc-core@npm:1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/rpc-core@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/metadata": 1.35.0-beta.5
-    "@polkadot/rpc-provider": 1.35.0-beta.5
-    "@polkadot/types": 1.35.0-beta.5
+    "@polkadot/metadata": 1.35.0-beta.6
+    "@polkadot/rpc-provider": 1.35.0-beta.6
+    "@polkadot/types": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     memoizee: ^0.4.14
     rxjs: ^6.6.3
-  checksum: cc658ba137fbf986705417edf0ab57018dd8c28f533f39bc51fb0094f339d067182753ea5e6fbb27f4b286246d880a47fc72b3c2cdad805cb1a5f98abfe1286e
+  checksum: f544270c6f5d2b429895c04679c6651616da74a5775befbead99c10893e36a9e7fb3c760a7363e2cf2c1b22997b5875ce3dcb6a44af3a37d653f79a4778cbf2b
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/rpc-provider@npm:1.35.0-beta.5"
+"@polkadot/rpc-provider@npm:1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/rpc-provider@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/metadata": 1.35.0-beta.5
-    "@polkadot/types": 1.35.0-beta.5
+    "@polkadot/metadata": 1.35.0-beta.6
+    "@polkadot/types": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     "@polkadot/util-crypto": ^3.4.1
     "@polkadot/x-fetch": ^0.3.2
     "@polkadot/x-ws": ^0.3.2
     bn.js: ^5.1.3
     eventemitter3: ^4.0.7
-  checksum: 072e5e984423a7f8d966d369e425e66cfbd5e2d2278a78d872de8bc75e9dfbf93c996ce63a93eb3206d966621afdad2f4602c493573d9a7cd6a9392819608ad7
+  checksum: 8fb59eb6408108129437903c4c492da8dc833fb3806a7d2e3b3956008d42909cca8f8ab694b708ae609f2efe28aed895bbe82bc9c19bb93d748103a55f64cc2f
   languageName: node
   linkType: hard
 
@@ -3736,31 +3736,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/types-known@npm:1.35.0-beta.5"
+"@polkadot/types-known@npm:1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/types-known@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/types": 1.35.0-beta.5
+    "@polkadot/types": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     bn.js: ^5.1.3
-  checksum: 948434fd0baea5aad9e19d52047f1111a90a2c97a24fa9cc9d24d245e43f39dfe6b565c17833f8dbbda01e05d3303a14ef1c5c316e51230f281786550576af45
+  checksum: e418eccbac2f57546a07101fb405f3016c2a8ac785378e9bdd5c3c9727bfd295605a3a3829e0a9b089e8258584b01f6b99f295d686a822d858ee33ad22be4952
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:^1.35.0-beta.5":
-  version: 1.35.0-beta.5
-  resolution: "@polkadot/types@npm:1.35.0-beta.5"
+"@polkadot/types@npm:^1.35.0-beta.6":
+  version: 1.35.0-beta.6
+  resolution: "@polkadot/types@npm:1.35.0-beta.6"
   dependencies:
     "@babel/runtime": ^7.11.2
-    "@polkadot/metadata": 1.35.0-beta.5
+    "@polkadot/metadata": 1.35.0-beta.6
     "@polkadot/util": ^3.4.1
     "@polkadot/util-crypto": ^3.4.1
     "@types/bn.js": ^4.11.6
     bn.js: ^5.1.3
     memoizee: ^0.4.14
     rxjs: ^6.6.3
-  checksum: 0180644fb685d86ce1693a406289d2ddd63b63e8bbe5e580c029e98a0aaf90a4e12a60e307a24810c0ec2aaca3be007d9c720b4f9af9490070158dbedcb8177a
+  checksum: 91e7b62b480711df50c693fbc52a9cdaf7c8c34d2825d1433453cf0888d2e8fea638ea38cd1ac5992d13e9a5a1fb911043e11d1e53c9584668236ee2ab1a89d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/3752
Replaces & closes https://github.com/polkadot-js/apps/pull/3753

This is similar to #3753 with a couple of changes -

- it pulls in the latest API with a filter for null keys (there are really worrying, I'm hoping it is not a long-term issue, but rather just part of the initial migration - only seen here)
- The Mainnet types (since they are still previous-gen) now pulls in Beresheet which is current. As soon as the library gets update, this needs adjustment

As it stands it does make the UI appear, but since some of the keys are non-decodable, there is bound to be inaccuracies, not exactly sure what they are atm.

cc @drewstone 