### PR TITLE
Style identity bar for dark theme

### DIFF
--- a/packages/page-accounts/src/Sidebar/Sidebar.tsx
+++ b/packages/page-accounts/src/Sidebar/Sidebar.tsx
@@ -1,6 +1,8 @@
 // Copyright 2017-2020 @polkadot/app-accounts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { ThemeProps } from '@polkadot/react-components/types';
+
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { useAccountInfo, useToggle } from '@polkadot/react-hooks';
@@ -159,15 +161,15 @@ function FullSidebar ({ address, className = '', onClose, onUpdateName }: Props)
   );
 }
 
-export default React.memo(styled(FullSidebar)`
+export default React.memo(styled(FullSidebar)(({ theme }: ThemeProps) => `
   input {
     width: auto !important;
   }
 
   .ui--AddressMenu-header {
     align-items: center;
-    background: white;
-    border-bottom: 1px solid #e6e6e6;
+    background: ${theme.bgTabs};
+    border-bottom: 1px solid ${theme.borderTable};
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -195,7 +197,7 @@ export default React.memo(styled(FullSidebar)`
 
     .ui--AddressMenu-sectionHeader {
       display: inline-flex;
-      color: #aaa;
+      color: ${theme.color};
       margin-bottom: 0.4rem;
       width: 100%;
 
@@ -299,4 +301,4 @@ export default React.memo(styled(FullSidebar)`
       }
     }
   }
-`);
+`));


### PR DESCRIPTION
Now looks like this (it was originally unreadable in white on white): 
![image](https://user-images.githubusercontent.com/33178835/95589998-ce97ad00-0a45-11eb-8d6c-d42dd482c117.png)
![image](https://user-images.githubusercontent.com/33178835/95590003-d1929d80-0a45-11eb-9a66-b674c731d0cc.png)
