### PR TITLE
Fix an important translation error in Chinese

### DIFF
--- a/packages/apps/public/locales/zh/translation.json
+++ b/packages/apps/public/locales/zh/translation.json
@@ -1112,7 +1112,7 @@
   "nav.settings": "设置",
   "nav.staking": "质押",
   "nav.storage": "链状态",
-  "nav.sudo": "撤销",
+  "nav.sudo": "超级管理",
   "nav.tech-comm": "技术委员会",
   "nav.toolbox": "工具箱",
   "nav.transfer": "转账",


### PR DESCRIPTION
here `sudo` has been translated to `undo`, `撤销` means `cancel` or `undo` in Chinese and nothing to do with `sudo`...