### PR TITLE
Fix IPC communication in Electron account store

### DIFF
--- a/packages/apps-electron/src/main/ipc-main-handler.ts
+++ b/packages/apps-electron/src/main/ipc-main-handler.ts
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type IpcMainHandler = {
-  [channel: string]: (...args: any[]) => Promise<void> | any
+  [channel: string]: (...args: any[]) => unknown
 }

--- a/packages/apps-electron/src/main/register-ipc-handler.ts
+++ b/packages/apps-electron/src/main/register-ipc-handler.ts
@@ -6,8 +6,8 @@ import { IpcMainHandler } from './ipc-main-handler';
 
 export const registerIpcHandler = (ipcHandler: IpcMainHandler): void => {
   for (const [channel, listener] of Object.entries(ipcHandler)) {
-    ipcMain.handle(channel, (_, ...args): void => {
-      listener(...args);
+    ipcMain.handle(channel, (_, ...args) => {
+      return listener(...args);
     });
   }
 };


### PR DESCRIPTION
Frankly, I don't know how this could've ever worked... 😮 

Currently, no information is passed from main to renderer. So account is saved on disk, but nothing can be loaded. This change fixes it.