### PR TITLE
Feature/better eth address addition

### DIFF
--- a/packages/page-accounts/src/modals/Create.tsx
+++ b/packages/page-accounts/src/modals/Create.tsx
@@ -272,7 +272,6 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
     },
     [api, derivePath, isDevelopment, isValid, name, onClose, onStatusChange, pairType, password, seed, t]
   );
-
   return (
     <Modal
       className={className}
@@ -322,7 +321,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                 />
                 < CopyButton
                   className='copyMoved'
-                  isMnemonic
+                  type={seedType === 'bip'?"mnemonic":seedType === 'raw'?isEthereum?'private key':'seed':'development seed'}
                   value={seed}
                 />
               </TextArea>

--- a/packages/page-accounts/src/modals/Create.tsx
+++ b/packages/page-accounts/src/modals/Create.tsx
@@ -204,8 +204,8 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
       : []
   ).concat(
     { text: t<string>('Mnemonic'), value: 'bip' },
-    isEthereum?{ text: t<string>('Private Key'), value: 'raw' }:{ text: t<string>('Raw seed'), value: 'raw' }
-  ), [isDevelopment, t]);
+    isEthereum ? { text: t<string>('Private Key'), value: 'raw' } : { text: t<string>('Raw seed'), value: 'raw' }
+  ), [isEthereum, isDevelopment, t]);
 
   const _onChangeDerive = useCallback(
     (newDerivePath: string) => setAddress(updateAddress(seed, newDerivePath, seedType, pairType)),
@@ -272,6 +272,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
     },
     [api, derivePath, isDevelopment, isValid, name, onClose, onStatusChange, pairType, password, seed, t]
   );
+
   return (
     <Modal
       className={className}
@@ -295,7 +296,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
             <Modal.Column>
               <TextArea
                 help={isEthereum
-                  ? t<string>("Your ethereum key pair is derived from your private key. Don't divulge this key." )
+                  ? t<string>("Your ethereum key pair is derived from your private key. Don't divulge this key.")
                   : t<string>('The private key for your account is derived from this seed. This seed must be kept secret as anyone in its possession has access to the funds of this account. If you validate, use the seed of the session account as the "--key" parameter of your node.')}
                 isAction
                 isError={!isSeedValid}
@@ -321,7 +322,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                 />
                 < CopyButton
                   className='copyMoved'
-                  type={seedType === 'bip'?"mnemonic":seedType === 'raw'?isEthereum?'private key':'seed':'development seed'}
+                  type={seedType === 'bip' ? 'mnemonic' : seedType === 'raw' ? isEthereum ? 'private key' : 'seed' : 'development seed'}
                   value={seed}
                 />
               </TextArea>

--- a/packages/page-accounts/src/modals/Create.tsx
+++ b/packages/page-accounts/src/modals/Create.tsx
@@ -322,7 +322,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                 />
                 < CopyButton
                   className='copyMoved'
-                  type={seedType === 'bip' ? 'mnemonic' : seedType === 'raw' ? isEthereum ? 'private key' : 'seed' : 'development seed'}
+                  type={seedType === 'bip' ? t<string>('mnemonic') : seedType === 'raw' ? isEthereum ? t<string>('private key') : 'seed' : t<string>('raw seed')}
                   value={seed}
                 />
               </TextArea>

--- a/packages/page-accounts/src/modals/Create.tsx
+++ b/packages/page-accounts/src/modals/Create.tsx
@@ -204,7 +204,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
       : []
   ).concat(
     { text: t<string>('Mnemonic'), value: 'bip' },
-    { text: t<string>('Raw seed'), value: 'raw' }
+    isEthereum?{ text: t<string>('Private Key'), value: 'raw' }:{ text: t<string>('Raw seed'), value: 'raw' }
   ), [isDevelopment, t]);
 
   const _onChangeDerive = useCallback(
@@ -295,7 +295,9 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
           <Modal.Columns>
             <Modal.Column>
               <TextArea
-                help={t<string>('The private key for your account is derived from this seed. This seed must be kept secret as anyone in its possession has access to the funds of this account. If you validate, use the seed of the session account as the "--key" parameter of your node.')}
+                help={isEthereum
+                  ? t<string>("Your ethereum key pair is derived from your private key. Don't divulge this key." )
+                  : t<string>('The private key for your account is derived from this seed. This seed must be kept secret as anyone in its possession has access to the funds of this account. If you validate, use the seed of the session account as the "--key" parameter of your node.')}
                 isAction
                 isError={!isSeedValid}
                 isReadOnly={seedType === 'dev'}
@@ -304,7 +306,9 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                     ? t<string>('mnemonic seed')
                     : seedType === 'dev'
                       ? t<string>('development seed')
-                      : t<string>('seed (hex or string)')
+                      : isEthereum
+                        ? t<string>('ethereum private key')
+                        : t<string>('seed (hex or string)')
                 }
                 onChange={_onChangeSeed}
                 seed={seed}
@@ -316,7 +320,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                   onChange={_selectSeedType}
                   options={seedOpt}
                 />
-                <CopyButton
+                < CopyButton
                   className='copyMoved'
                   isMnemonic
                   value={seed}

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -28,8 +28,8 @@ function CopyButton ({ children, className, icon = 'copy', type = 'other', value
 
   const _onCopy = useCallback(
     (): void => {
-      (type!=="other") && queueAction && queueAction({
-        account: type!=="mnemonic" ? value : undefined,
+      (type !== 'other') && queueAction && queueAction({
+        account: type !== 'mnemonic' ? value : undefined,
         action: t<string>('clipboard'),
         message: t<string>(`${type} copied`),
         status: 'queued'

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -15,27 +15,27 @@ interface Props {
   children?: React.ReactNode;
   className?: string;
   icon?: IconName;
-  isAddress?: boolean;
+  type?: string;
   isMnemonic?: boolean;
   value: string;
 }
 
 const NOOP = () => undefined;
 
-function CopyButton ({ children, className, icon = 'copy', isAddress = false, isMnemonic = false, value }: Props): React.ReactElement<Props> {
+function CopyButton ({ children, className, icon = 'copy', type = 'other', value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { queueAction } = useContext(StatusContext);
 
   const _onCopy = useCallback(
     (): void => {
-      (isAddress || isMnemonic) && queueAction && queueAction({
-        account: isAddress ? value : undefined,
+      (type!=="other") && queueAction && queueAction({
+        account: type!=="mnemonic" ? value : undefined,
         action: t<string>('clipboard'),
-        message: t<string>(`${isAddress ? 'address' : 'mnemonic'} copied`),
+        message: t<string>(`${type} copied`),
         status: 'queued'
       });
     },
-    [isAddress, isMnemonic, queueAction, t, value]
+    [type, queueAction, t, value]
   );
 
   return (

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const NOOP = () => undefined;
 
-function CopyButton ({ children, className, icon = 'copy', type = 'other', value }: Props): React.ReactElement<Props> {
+function CopyButton ({ children, className, icon = 'copy', type, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { queueAction } = useContext(StatusContext);
 
@@ -31,7 +31,7 @@ function CopyButton ({ children, className, icon = 'copy', type = 'other', value
       (type !== 'other') && queueAction && queueAction({
         account: type !== 'mnemonic' ? value : undefined,
         action: t<string>('clipboard'),
-        message: t<string>(`${type} copied`),
+        message: t<string>('{{type}} copied`, { replace: { type: type || t<string>('other') } }),
         status: 'queued'
       });
     },

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -31,7 +31,7 @@ function CopyButton ({ children, className, icon = 'copy', type, value }: Props)
       (type !== 'other') && queueAction && queueAction({
         account: type !== 'mnemonic' ? value : undefined,
         action: t<string>('clipboard'),
-        message: t<string>('{{type}} copied`, { replace: { type: type || t<string>('other') } }),
+        message: t<string>('{{type}} copied', { replace: { type: type || t<string>('other') } }),
         status: 'queued'
       });
     },


### PR DESCRIPTION
Addresses https://github.com/polkadot-js/apps/issues/4025

- Add ‘private key’ instead of 'rawSeed' for ethereum addresses (that wasnt clear to me)
- Make it clear that it needs to start with 0x
- when copying address to clipboard, the message shouldnt say "memnonic"

- modified the CopyButton to adapt to private key