### PR TITLE
useMemo in RPC params

### DIFF
--- a/packages/react-signer/src/index.tsx
+++ b/packages/react-signer/src/index.tsx
@@ -64,20 +64,16 @@ async function sendRpc (api: ApiPromise, queueSetTxStatus: QueueTxMessageSetStat
 
 function extractCurrent (txqueue: QueueTx[]): ItemState {
   const available = txqueue.filter(({ status }) => AVAIL_STATUS.includes(status));
-  const nextItem = available[0] || null;
+  const currentItem = available[0] || null;
   let isRpc = false;
   let isVisible = false;
-  let currentItem = null;
 
-  if (nextItem) {
-    // when the next up is an RPC, send it immediately
-    if (nextItem.status === 'queued' && !(nextItem.extrinsic || nextItem.payload)) {
+  if (currentItem) {
+    if (currentItem.status === 'queued' && !(currentItem.extrinsic || currentItem.payload)) {
       isRpc = true;
-    } else if (nextItem.status !== 'signing') {
+    } else if (currentItem.status !== 'signing') {
       isVisible = true;
     }
-
-    currentItem = nextItem;
   }
 
   return {

--- a/packages/react-signer/src/index.tsx
+++ b/packages/react-signer/src/index.tsx
@@ -5,7 +5,7 @@ import type { QueueTx, QueueTxMessageSetStatus, QueueTxResult } from '@polkadot/
 import type { BareProps as Props } from '@polkadot/react-components/types';
 import type { DefinitionRpcExt } from '@polkadot/types/types';
 
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import { ApiPromise } from '@polkadot/api';
 import { Modal, StatusContext } from '@polkadot/react-components';
@@ -20,6 +20,7 @@ import TxUnsigned from './TxUnsigned';
 interface ItemState {
   count: number;
   currentItem: QueueTx | null;
+  isRpc: boolean;
   isVisible: boolean;
   requestAddress: string | null;
 }
@@ -61,24 +62,29 @@ async function sendRpc (api: ApiPromise, queueSetTxStatus: QueueTxMessageSetStat
   }
 }
 
-function extractCurrent (api: ApiPromise, queueSetTxStatus: QueueTxMessageSetStatus, txqueue: QueueTx[]): ItemState {
+function extractCurrent (txqueue: QueueTx[]): ItemState {
   const available = txqueue.filter(({ status }) => AVAIL_STATUS.includes(status));
   const nextItem = available[0] || null;
+  let isRpc = false;
+  let isVisible = false;
   let currentItem = null;
 
   if (nextItem) {
     // when the next up is an RPC, send it immediately
     if (nextItem.status === 'queued' && !(nextItem.extrinsic || nextItem.payload)) {
-      sendRpc(api, queueSetTxStatus, nextItem).catch(console.error);
-    } else {
-      currentItem = nextItem;
+      isRpc = true;
+    } else if (nextItem.status !== 'signing') {
+      isVisible = true;
     }
+
+    currentItem = nextItem;
   }
 
   return {
     count: available.length,
     currentItem,
-    isVisible: !!currentItem && currentItem.status !== 'signing',
+    isRpc,
+    isVisible,
     requestAddress: (currentItem && currentItem.accountId) || null
   };
 }
@@ -88,10 +94,15 @@ function Signer ({ children, className = '' }: Props): React.ReactElement<Props>
   const { t } = useTranslation();
   const { queueSetTxStatus, txqueue } = useContext(StatusContext);
 
-  const { count, currentItem, isVisible, requestAddress } = useMemo(
-    () => extractCurrent(api, queueSetTxStatus, txqueue),
-    [api, queueSetTxStatus, txqueue]
+  const { count, currentItem, isRpc, isVisible, requestAddress } = useMemo(
+    () => extractCurrent(txqueue),
+    [txqueue]
   );
+
+  useEffect((): void => {
+    isRpc && currentItem &&
+      sendRpc(api, queueSetTxStatus, currentItem).catch(console.error);
+  }, [api, isRpc, currentItem, queueSetTxStatus]);
 
   return (
     <>


### PR DESCRIPTION
https://github.com/polkadot-js/apps/issues/4079 - actually added the useMemo before even attempting to debug and then couldn't reproduce. Not sure how it worked in the past.

Additionally fixes the RPC state updates in the signer.