### PR TITLE
Show unapplied slashes for the active era

### DIFF
--- a/packages/react-hooks/src/useAvailableSlashes.ts
+++ b/packages/react-hooks/src/useAvailableSlashes.ts
@@ -27,7 +27,7 @@ export default function useAvailableSlashes (): [BN, UnappliedSlash[]][] {
       const range: BN[] = [];
       let start = new BN(from);
 
-      while (start.lt(indexes.activeEra)) {
+      while (start.lte(indexes.activeEra)) {
         range.push(start);
         start = start.addn(1);
       }


### PR DESCRIPTION
Not sure if there's any specific reason why we wouldn't want this. I was looking into some slash event that just happened on Kusama and it wasn't showing on the UI for this reason. I haven't tested this PR though.