### PR TITLE
s/replaceAll/replace/

### DIFF
--- a/packages/page-staking/src/Targets/index.tsx
+++ b/packages/page-staking/src/Targets/index.tsx
@@ -103,8 +103,8 @@ function applyFilter (validators: ValidatorInfo[], medianComm: number, allIdenti
           if (thisIdentity.display) {
             const sanitized = thisIdentity.display
               .replace(/[^\x20-\x7E]/g, '')
-              .replaceAll('-', ' ')
-              .replaceAll('_', ' ')
+              .replace(/-/g, ' ')
+              .replace(/_/g, ' ')
               .split(' ')
               .map((p) => p.trim())
               .filter((v) => !!v);


### PR DESCRIPTION
Cannot reproduce atm (FF or Chrome), however change `replaceAll` to just use replace (which is, well, everywhere)

Closes https://github.com/polkadot-js/apps/issues/4152