### PR TITLE
Display error.message || error (when string is thrown)

### DIFF
--- a/packages/react-components/src/Status/index.tsx
+++ b/packages/react-components/src/Status/index.tsx
@@ -138,7 +138,7 @@ function renderItem ({ error, extrinsic, id, removeItem, rpc, status }: QueueTx)
               {section}.{method}
             </div>
             <div className='status'>
-              {error ? error.message : status}
+              {error ? (error.message || error) : status}
             </div>
           </div>
         </div>

--- a/packages/react-signer/src/TxSigned.tsx
+++ b/packages/react-signer/src/TxSigned.tsx
@@ -79,9 +79,9 @@ async function signAndSend (queueSetTxStatus: QueueTxMessageSetStatus, currentIt
     }));
   } catch (error) {
     console.error('signAndSend: error:', error);
-    queueSetTxStatus(currentItem.id, 'error', {}, error);
+    queueSetTxStatus(currentItem.id, 'error', undefined, error);
 
-    currentItem.txFailedCb && currentItem.txFailedCb(null);
+    currentItem.txFailedCb && currentItem.txFailedCb(error);
   }
 }
 
@@ -93,6 +93,7 @@ async function signAsync (queueSetTxStatus: QueueTxMessageSetStatus, { id, txFai
 
     return tx.toJSON();
   } catch (error) {
+    console.error('signAsync: error:', error);
     queueSetTxStatus(id, 'error', undefined, error);
 
     txFailedCb(error);

--- a/packages/react-signer/src/TxSigned.tsx
+++ b/packages/react-signer/src/TxSigned.tsx
@@ -79,7 +79,7 @@ async function signAndSend (queueSetTxStatus: QueueTxMessageSetStatus, currentIt
     }));
   } catch (error) {
     console.error('signAndSend: error:', error);
-    queueSetTxStatus(currentItem.id, 'error', undefined, error);
+    queueSetTxStatus(currentItem.id, 'error', {}, error);
 
     currentItem.txFailedCb && currentItem.txFailedCb(error);
   }


### PR DESCRIPTION
Enzyme signing doesn't return an error object, ensure that when an error string is received, it is still displayed.