### PR TITLE
Sharing of user types

### DIFF
--- a/packages/page-accounts/src/modals/Create.tsx
+++ b/packages/page-accounts/src/modals/Create.tsx
@@ -321,7 +321,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
                   onChange={_selectSeedType}
                   options={seedOpt}
                 />
-                < CopyButton
+                <CopyButton
                   className='copyMoved'
                   type={seedType === 'bip' ? t<string>('mnemonic') : seedType === 'raw' ? isEthereum ? t<string>('private key') : 'seed' : t<string>('raw seed')}
                   value={seed}

--- a/packages/page-settings/package.json
+++ b/packages/page-settings/package.json
@@ -13,7 +13,6 @@
     "@polkadot/apps-config": "^0.71.3-1",
     "@polkadot/react-components": "^0.71.3-1",
     "@polkadot/react-query": "^0.71.3-1",
-    "fflate": "^0.4.2",
     "query-string": "^6.13.7"
   }
 }

--- a/packages/page-settings/package.json
+++ b/packages/page-settings/package.json
@@ -13,6 +13,7 @@
     "@polkadot/apps-config": "^0.71.3-1",
     "@polkadot/react-components": "^0.71.3-1",
     "@polkadot/react-query": "^0.71.3-1",
+    "fflate": "^0.4.2",
     "query-string": "^6.13.7"
   }
 }

--- a/packages/page-settings/src/Developer.tsx
+++ b/packages/page-settings/src/Developer.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import { registry } from '@polkadot/react-api';
 import { decodeUrlTypes, encodeUrlTypes } from '@polkadot/react-api/urlTypes';
-import { Button, Editor, InputFile } from '@polkadot/react-components';
+import { Button, CopyButton, Editor, InputFile } from '@polkadot/react-components';
 import { isJsonObject, stringToU8a, u8aToString } from '@polkadot/util';
 
 import { useTranslation } from './translate';
@@ -38,7 +38,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
   const [isTypesValid, setIsTypesValid] = useState(true);
   const [types, setTypes] = useState<Record<string, any>>(EMPTY_TYPES);
   const [typesPlaceholder, setTypesPlaceholder] = useState<string | null>(null);
-  const [, setEncodedUrl] = useState<string | null>(null);
+  const [sharedUrl, setSharedUrl] = useState<string | null>(null);
 
   useEffect((): void => {
     const types = decodeUrlTypes() || store.get('types') as Record<string, unknown> || {};
@@ -47,7 +47,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
       setCode(JSON.stringify(types, null, 2));
       setTypes({});
       setTypesPlaceholder(Object.keys(types).join(', '));
-      setEncodedUrl(encodeUrlTypes(types));
+      setSharedUrl(encodeUrlTypes(types));
     }
   }, []);
 
@@ -153,7 +153,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
         });
       }
 
-      setEncodedUrl(url);
+      setSharedUrl(url);
     },
     [onStatusChange, t, types]
   );
@@ -193,6 +193,11 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
         </div>
       </div>
       <Button.Group>
+        <CopyButton
+          label={t<string>('Share')}
+          type={t<string>('url')}
+          value={sharedUrl}
+        />
         <Button
           icon='sync'
           label={t<string>('Reset')}

--- a/packages/page-settings/src/Developer.tsx
+++ b/packages/page-settings/src/Developer.tsx
@@ -9,7 +9,7 @@ import store from 'store';
 import styled from 'styled-components';
 
 import { registry } from '@polkadot/react-api';
-import { encodeUrlTypes } from '@polkadot/react-api/urlTypes';
+import { decodeUrlTypes, encodeUrlTypes } from '@polkadot/react-api/urlTypes';
 import { Button, Editor, InputFile } from '@polkadot/react-components';
 import { isJsonObject, stringToU8a, u8aToString } from '@polkadot/util';
 
@@ -41,7 +41,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
   const [, setEncodedUrl] = useState<string | null>(null);
 
   useEffect((): void => {
-    const types = store.get('types') as Record<string, unknown> || {};
+    const types = decodeUrlTypes() || store.get('types') as Record<string, unknown> || {};
 
     if (Object.keys(types).length) {
       setCode(JSON.stringify(types, null, 2));

--- a/packages/page-settings/src/Developer.tsx
+++ b/packages/page-settings/src/Developer.tsx
@@ -9,6 +9,7 @@ import store from 'store';
 import styled from 'styled-components';
 
 import { registry } from '@polkadot/react-api';
+import { encodeUrlTypes } from '@polkadot/react-api/urlTypes';
 import { Button, Editor, InputFile } from '@polkadot/react-components';
 import { isJsonObject, stringToU8a, u8aToString } from '@polkadot/util';
 
@@ -37,6 +38,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
   const [isTypesValid, setIsTypesValid] = useState(true);
   const [types, setTypes] = useState<Record<string, any>>(EMPTY_TYPES);
   const [typesPlaceholder, setTypesPlaceholder] = useState<string | null>(null);
+  const [, setEncodedUrl] = useState<string | null>(null);
 
   useEffect((): void => {
     const types = store.get('types') as Record<string, unknown> || {};
@@ -45,6 +47,7 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
       setCode(JSON.stringify(types, null, 2));
       setTypes({});
       setTypesPlaceholder(Object.keys(types).join(', '));
+      setEncodedUrl(encodeUrlTypes(types));
     }
   }, []);
 
@@ -125,6 +128,8 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
 
   const _saveDeveloper = useCallback(
     (): void => {
+      let url = null;
+
       try {
         registry.register(types);
         store.set('types', types);
@@ -133,6 +138,12 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
           action: t<string>('Your custom types have been added'),
           status: 'success'
         });
+
+        if (Object.keys(types).length) {
+          url = encodeUrlTypes(types);
+
+          console.log(url);
+        }
       } catch (error) {
         console.error(error);
         setIsTypesValid(false);
@@ -141,6 +152,8 @@ function Developer ({ className = '', onStatusChange }: Props): React.ReactEleme
           status: 'error'
         });
       }
+
+      setEncodedUrl(url);
     },
     [onStatusChange, t, types]
   );

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -22,6 +22,7 @@
     "@babel/runtime": "^7.12.5",
     "@polkadot/api": "^3.0.1",
     "@polkadot/extension-dapp": "^0.35.2-12",
-    "fflate": "^0.4.2"
+    "fflate": "^0.4.2",
+    "rxjs-compat": "^6.6.3"
   }
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -22,6 +22,6 @@
     "@babel/runtime": "^7.12.5",
     "@polkadot/api": "^3.0.1",
     "@polkadot/extension-dapp": "^0.35.2-12",
-    "rxjs-compat": "^6.6.3"
+    "fflate": "^0.4.2"
   }
 }

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -25,6 +25,7 @@ import { defaults as addressDefaults } from '@polkadot/util-crypto/address/defau
 
 import ApiContext from './ApiContext';
 import registry from './typeRegistry';
+import { decodeUrlTypes } from './urlTypes';
 
 interface Props {
   children: React.ReactNode;
@@ -66,7 +67,7 @@ function isKeyringLoaded () {
 }
 
 function getDevTypes (): Record<string, Record<string, string>> {
-  const types = store.get('types', {}) as Record<string, Record<string, string>>;
+  const types = decodeUrlTypes() || store.get('types', {}) as Record<string, Record<string, string>>;
   const names = Object.keys(types);
 
   names.length && console.log('Injected types:', names.join(', '));

--- a/packages/react-api/src/urlTypes.ts
+++ b/packages/react-api/src/urlTypes.ts
@@ -5,7 +5,7 @@ import { unzlibSync, zlibSync } from 'fflate';
 import queryString from 'query-string';
 
 import uiSettings from '@polkadot/ui-settings';
-import { stringToU8a, u8aToString } from '@polkadot/util';
+import { assert, stringToU8a, u8aToString } from '@polkadot/util';
 import { base64Decode, base64Encode } from '@polkadot/util-crypto';
 
 export function decodeUrlTypes (): Record<string, any> | null {
@@ -13,7 +13,9 @@ export function decodeUrlTypes (): Record<string, any> | null {
 
   if (urlOptions.types) {
     try {
-      const compressed = base64Decode(urlOptions.types as string);
+      assert(!Array.isArray(urlOptions.types), 'Expected a single type specification');
+
+      const compressed = base64Decode(urlOptions.types);
       const uncompressed = unzlibSync(compressed);
 
       return JSON.parse(u8aToString(uncompressed)) as Record<string, any>;

--- a/packages/react-api/src/urlTypes.ts
+++ b/packages/react-api/src/urlTypes.ts
@@ -15,7 +15,8 @@ export function decodeUrlTypes (): Record<string, any> | null {
     try {
       assert(!Array.isArray(urlOptions.types), 'Expected a single type specification');
 
-      const compressed = base64Decode(urlOptions.types);
+      const parts = urlOptions.types.split('#');
+      const compressed = base64Decode(decodeURIComponent(parts[0]));
       const uncompressed = unzlibSync(compressed);
 
       return JSON.parse(u8aToString(uncompressed)) as Record<string, any>;
@@ -32,5 +33,5 @@ export function encodeUrlTypes (types: Record<string, any>): string {
   const compressed = zlibSync(jsonU8a, { level: 9 });
   const encoded = base64Encode(compressed);
 
-  return `${window.location.origin}${window.location.pathname}?rpc=${encodeURIComponent(uiSettings.apiUrl)}&types=${encoded}`;
+  return `${window.location.origin}${window.location.pathname}?rpc=${encodeURIComponent(uiSettings.apiUrl)}&types=${encodeURIComponent(encoded)}`;
 }

--- a/packages/react-api/src/urlTypes.ts
+++ b/packages/react-api/src/urlTypes.ts
@@ -1,0 +1,34 @@
+// Copyright 2017-2020 @polkadot/apps authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { unzlibSync, zlibSync } from 'fflate';
+import queryString from 'query-string';
+
+import uiSettings from '@polkadot/ui-settings';
+import { stringToU8a, u8aToString } from '@polkadot/util';
+import { base64Decode, base64Encode } from '@polkadot/util-crypto';
+
+export function decodeUrlTypes (): Record<string, any> | null {
+  const urlOptions = queryString.parse(location.href.split('?')[1]);
+
+  if (urlOptions.types) {
+    try {
+      const compressed = base64Decode(urlOptions.types as string);
+      const uncompressed = unzlibSync(compressed);
+
+      return JSON.parse(u8aToString(uncompressed)) as Record<string, any>;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return null;
+}
+
+export function encodeUrlTypes (types: Record<string, any>): string {
+  const jsonU8a = stringToU8a(JSON.stringify(types));
+  const compressed = zlibSync(jsonU8a, { level: 9 });
+  const encoded = base64Encode(compressed);
+
+  return `${window.location.origin}${window.location.pathname}?rpc=${encodeURIComponent(uiSettings.apiUrl)}&types=${encoded}`;
+}

--- a/packages/react-components/src/Button/Group.tsx
+++ b/packages/react-components/src/Button/Group.tsx
@@ -30,4 +30,8 @@ export default React.memo(styled(ButtonGroup)`
   .ui--Button {
     margin: 0 0.25rem;
   }
+
+  .ui--CopyButton {
+    display: inline-block;
+  }
 `);

--- a/packages/react-components/src/CopyButton.tsx
+++ b/packages/react-components/src/CopyButton.tsx
@@ -15,6 +15,7 @@ interface Props {
   children?: React.ReactNode;
   className?: string;
   icon?: IconName;
+  label?: React.ReactNode;
   type?: string;
   isMnemonic?: boolean;
   value: string;
@@ -22,20 +23,19 @@ interface Props {
 
 const NOOP = () => undefined;
 
-function CopyButton ({ children, className = '', icon = 'copy', type, value }: Props): React.ReactElement<Props> {
+function CopyButton ({ children, className = '', icon = 'copy', label, type, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { queueAction } = useContext(StatusContext);
 
   const _onCopy = useCallback(
     (): void => {
-      (type !== 'other') && queueAction && queueAction({
-        account: type !== 'mnemonic' ? value : undefined,
+      queueAction && queueAction({
         action: t<string>('clipboard'),
-        message: t<string>('{{type}} copied', { replace: { type: type || t<string>('other') } }),
+        message: t<string>('{{type}} copied', { replace: { type: type || t<string>('value') } }),
         status: 'queued'
       });
     },
-    [type, queueAction, t, value]
+    [type, queueAction, t]
   );
 
   return (
@@ -50,6 +50,8 @@ function CopyButton ({ children, className = '', icon = 'copy', type, value }: P
             <Button
               className='icon-button show-on-hover'
               icon={icon}
+              isDisabled={!value}
+              label={label}
               onClick={NOOP}
             />
           </span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,7 @@ __metadata:
     "@polkadot/apps-config": ^0.71.3-1
     "@polkadot/react-components": ^0.71.3-1
     "@polkadot/react-query": ^0.71.3-1
+    fflate: ^0.4.2
     query-string: ^6.13.7
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,6 +2505,7 @@ __metadata:
     "@polkadot/api": ^3.0.1
     "@polkadot/extension-dapp": ^0.35.2-12
     fflate: ^0.4.2
+    rxjs-compat: ^6.6.3
   languageName: unknown
   linkType: soft
 
@@ -16218,6 +16219,13 @@ fsevents@~2.1.2:
   version: 1.1.10
   resolution: "run-parallel@npm:1.1.10"
   checksum: 5c851a6bb74b6561002c53a68b896a4bfb7d6368c281fb9144098bdfd60188e4cb550ed88587ade3c60e3e961364a0d74c3c5f4fbffafe6842f0d2908d79e104
+  languageName: node
+  linkType: hard
+
+"rxjs-compat@npm:^6.6.3":
+  version: 6.6.3
+  resolution: "rxjs-compat@npm:6.6.3"
+  checksum: 487a948df603706a165642f97d0554924461d5cd35d2a7c390cb74c2acbab18d63b319579c7d8a6cd7bf8dbb79daebbbc0ee737f693fc9796ba85c6ef247d5de
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,7 +2151,6 @@ __metadata:
     "@polkadot/apps-config": ^0.71.3-1
     "@polkadot/react-components": ^0.71.3-1
     "@polkadot/react-query": ^0.71.3-1
-    fflate: ^0.4.2
     query-string: ^6.13.7
   languageName: unknown
   linkType: soft
@@ -2505,7 +2504,7 @@ __metadata:
     "@babel/runtime": ^7.12.5
     "@polkadot/api": ^3.0.1
     "@polkadot/extension-dapp": ^0.35.2-12
-    rxjs-compat: ^6.6.3
+    fflate: ^0.4.2
   languageName: unknown
   linkType: soft
 
@@ -16219,13 +16218,6 @@ fsevents@~2.1.2:
   version: 1.1.10
   resolution: "run-parallel@npm:1.1.10"
   checksum: 5c851a6bb74b6561002c53a68b896a4bfb7d6368c281fb9144098bdfd60188e4cb550ed88587ade3c60e3e961364a0d74c3c5f4fbffafe6842f0d2908d79e104
-  languageName: node
-  linkType: hard
-
-"rxjs-compat@npm:^6.6.3":
-  version: 6.6.3
-  resolution: "rxjs-compat@npm:6.6.3"
-  checksum: 487a948df603706a165642f97d0554924461d5cd35d2a7c390cb74c2acbab18d63b319579c7d8a6cd7bf8dbb79daebbbc0ee737f693fc9796ba85c6ef247d5de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] share button (rather not as-changed, there is overhead in calculating)
- [x] sharable link with compressed/base64 via `?types=...`
- [x] load of types via URL (complete replacement of dev types)
- [x] show loaded types via developer tab

Closes https://github.com/polkadot-js/apps/issues/4187