### PR TITLE
fix media query width

### DIFF
--- a/packages/page-staking/src/Targets/index.tsx
+++ b/packages/page-staking/src/Targets/index.tsx
@@ -264,7 +264,7 @@ function Targets ({ className = '', isInElection, ownStashes, targets: { avgStak
 
   const header = useMemo(() => [
     [t('validators'), 'start', 3],
-    [t('payout'), 'media--1500'],
+    [t('payout'), 'media--1400'],
     [t('nominators'), 'media--1200', 2],
     [t('comm.'), 'media--1100'],
     ...(SORT_KEYS as (keyof typeof labelsRef.current)[]).map((header) => [


### PR DESCRIPTION
Because the media query width set in the table body is 1400 and the media query width set in the table head is 1500, there will be problems with the display when the width is between 1400 and 1500

https://github.com/polkadot-js/apps/blob/master/packages/page-staking/src/Targets/Validator.tsx#L116

![image](https://user-images.githubusercontent.com/69485494/102570787-00677700-414d-11eb-930e-7b662658266f.png)
