### PR TITLE
Claim payout from bounty list

### DIFF
--- a/packages/apps/public/locales/en/app-bounties.json
+++ b/packages/apps/public/locales/en/app-bounties.json
@@ -4,6 +4,7 @@
   "Bond is estimated based on bountyDepositBase and dataDepositPerByte constants.": "Bond is estimated based on bountyDepositBase and dataDepositPerByte constants.",
   "Bounties": "Bounties",
   "Calculated bond for bounty": "Calculated bond for bounty",
+  "Claim Bounty": "Claim Bounty",
   "Claimable": "Claimable",
   "Curators deposit": "Curators deposit",
   "Curators fee": "Curators fee",

--- a/packages/page-bounties/src/Bounties.tsx
+++ b/packages/page-bounties/src/Bounties.tsx
@@ -28,6 +28,7 @@ function Bounties (): React.ReactElement {
     [t('beneficiary'), 'start'],
     [t('payout due'), 'start'],
     [],
+    [],
     []
   ]);
 

--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -58,12 +58,13 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
         <td>{beneficiary ? <AddressSmall value={beneficiary} /> : EMPTY_CELL}</td>
         <td><DueBlocks dueBlocks={blocksUntilPayout} /></td>
         <td>
-          {beneficiary && blocksUntilPayout &&
-          <BountyClaim
-            beneficiaryId={beneficiary}
-            index={index}
-            payoutDue={blocksUntilPayout}
-          />}
+          {beneficiary && blocksUntilPayout && (
+            <BountyClaim
+              beneficiaryId={beneficiary}
+              index={index}
+              payoutDue={blocksUntilPayout}
+            />
+          )}
         </td>
         <td className='table-column-icon'>
           <LinkExternal

--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -12,8 +12,8 @@ import { useAccounts } from '@polkadot/react-hooks';
 import { BlockToTime, FormatBalance } from '@polkadot/react-query';
 import { formatNumber } from '@polkadot/util';
 
-import { getBountyStatus } from './helpers/getBountyStatus';
 import BountyClaim from './BountyClaim';
+import { getBountyStatus } from './helpers';
 import { useTranslation } from './translate';
 
 interface Props {

--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -8,10 +8,12 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { AddressSmall, Icon, LinkExternal } from '@polkadot/react-components';
+import { useAccounts } from '@polkadot/react-hooks';
 import { BlockToTime, FormatBalance } from '@polkadot/react-query';
 import { formatNumber } from '@polkadot/util';
 
 import { getBountyStatus } from './helpers/getBountyStatus';
+import BountyClaim from './BountyClaim';
 import { useTranslation } from './translate';
 
 interface Props {
@@ -41,6 +43,8 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
   const blocksUntilUpdate = useMemo(() => updateDue?.sub(bestNumber), [bestNumber, updateDue]);
   const blocksUntilPayout = useMemo(() => unlockAt?.sub(bestNumber), [bestNumber, unlockAt]);
 
+  const { allAccounts, hasAccounts } = useAccounts();
+
   const handleOnIconClick = useCallback(
     () => setIsExpanded((isExpanded) => !isExpanded),
     []
@@ -56,6 +60,15 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
         <td><DueBlocks dueBlocks={blocksUntilUpdate} /></td>
         <td>{beneficiary ? <AddressSmall value={beneficiary} /> : EMPTY_CELL}</td>
         <td><DueBlocks dueBlocks={blocksUntilPayout} /></td>
+        <td>
+          {hasAccounts && beneficiary && blocksUntilPayout &&
+          <BountyClaim
+            accounts={allAccounts}
+            beneficiaryId={beneficiary.toString()}
+            index={index}
+            payoutDue={blocksUntilPayout}
+          />}
+        </td>
         <td className='table-column-icon'>
           <LinkExternal
             data={index}
@@ -98,6 +111,7 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
           <div className='inline-balance'>{curator ? <FormatBalance value={fee} /> : EMPTY_CELL}</div>
           <div className='inline-balance'>{curator ? <FormatBalance value={curatorDeposit} /> : EMPTY_CELL}</div>
         </td>
+        <td />
         <td />
         <td />
         <td />

--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { AddressSmall, Icon, LinkExternal } from '@polkadot/react-components';
-import { useAccounts } from '@polkadot/react-hooks';
 import { BlockToTime, FormatBalance } from '@polkadot/react-query';
 import { formatNumber } from '@polkadot/util';
 
@@ -43,8 +42,6 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
   const blocksUntilUpdate = useMemo(() => updateDue?.sub(bestNumber), [bestNumber, updateDue]);
   const blocksUntilPayout = useMemo(() => unlockAt?.sub(bestNumber), [bestNumber, unlockAt]);
 
-  const { allAccounts, hasAccounts } = useAccounts();
-
   const handleOnIconClick = useCallback(
     () => setIsExpanded((isExpanded) => !isExpanded),
     []
@@ -61,10 +58,9 @@ function Bounty ({ bestNumber, bounty, className = '', description, index }: Pro
         <td>{beneficiary ? <AddressSmall value={beneficiary} /> : EMPTY_CELL}</td>
         <td><DueBlocks dueBlocks={blocksUntilPayout} /></td>
         <td>
-          {hasAccounts && beneficiary && blocksUntilPayout &&
+          {beneficiary && blocksUntilPayout &&
           <BountyClaim
-            accounts={allAccounts}
-            beneficiaryId={beneficiary.toString()}
+            beneficiaryId={beneficiary}
             index={index}
             payoutDue={blocksUntilPayout}
           />}

--- a/packages/page-bounties/src/BountyClaim.tsx
+++ b/packages/page-bounties/src/BountyClaim.tsx
@@ -4,7 +4,7 @@
 import type { AccountId } from '@polkadot/types/interfaces';
 
 import BN from 'bn.js';
-import React, { useCallback } from 'react';
+import React, { useMemo } from 'react';
 
 import { TxButton } from '@polkadot/react-components';
 import { useAccounts, useApi } from '@polkadot/react-hooks';
@@ -23,20 +23,22 @@ function BountyClaim ({ beneficiaryId, index, payoutDue }: Props) {
   const { api } = useApi();
   const { allAccounts, hasAccounts } = useAccounts();
 
-  const isBountyClaimable = useCallback(() => isClaimable(allAccounts, beneficiaryId, payoutDue), [allAccounts, beneficiaryId, payoutDue]);
+  const isBountyClaimable = useMemo(() => isClaimable(allAccounts, beneficiaryId, payoutDue), [allAccounts, beneficiaryId, payoutDue]);
 
-  return hasAccounts && isBountyClaimable()
-    ? <TxButton
-      accountId={beneficiaryId}
-      icon='plus'
-      label={t<string>('Claim Bounty')}
-      params={[index]}
-      tx={
-        api.tx.bounties
-          ? 'bounties.claimBounty'
-          : 'treasury.claimBounty'
-      }
-    />
+  return hasAccounts && isBountyClaimable
+    ? (
+      <TxButton
+        accountId={beneficiaryId}
+        icon='plus'
+        label={t<string>('Claim Bounty')}
+        params={[index]}
+        tx={
+          api.tx.bounties
+            ? 'bounties.claimBounty'
+            : 'treasury.claimBounty'
+        }
+      />
+    )
     : null;
 }
 

--- a/packages/page-bounties/src/BountyClaim.tsx
+++ b/packages/page-bounties/src/BountyClaim.tsx
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import { TxButton } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 
-import { isClaimable } from './helpers/isClaimable';
+import { isClaimable } from './helpers';
 import { useTranslation } from './translate';
 
 interface Props {
@@ -21,15 +21,12 @@ function BountyClaim ({ accounts, beneficiaryId, index, payoutDue }: Props) {
   const { t } = useTranslation();
   const { api } = useApi();
 
-  const [isValid] = useState(true);
-
   const isBountyClaimable = useCallback(() => isClaimable(accounts, beneficiaryId, payoutDue), [accounts, beneficiaryId, payoutDue]);
 
   return isBountyClaimable()
     ? <TxButton
       accountId={beneficiaryId}
       icon='plus'
-      isDisabled={!isValid}
       label={t<string>('Claim Bounty')}
       params={[index]}
       tx={

--- a/packages/page-bounties/src/BountyClaim.tsx
+++ b/packages/page-bounties/src/BountyClaim.tsx
@@ -1,29 +1,31 @@
 // Copyright 2017-2020 @polkadot/app-bounties authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AccountId } from '@polkadot/types/interfaces';
+
 import BN from 'bn.js';
 import React, { useCallback } from 'react';
 
 import { TxButton } from '@polkadot/react-components';
-import { useApi } from '@polkadot/react-hooks';
+import { useAccounts, useApi } from '@polkadot/react-hooks';
 
 import { isClaimable } from './helpers';
 import { useTranslation } from './translate';
 
 interface Props {
-  accounts: string[];
-  beneficiaryId: string;
+  beneficiaryId: AccountId;
   index: number;
   payoutDue: BN;
 }
 
-function BountyClaim ({ accounts, beneficiaryId, index, payoutDue }: Props) {
+function BountyClaim ({ beneficiaryId, index, payoutDue }: Props) {
   const { t } = useTranslation();
   const { api } = useApi();
+  const { allAccounts, hasAccounts } = useAccounts();
 
-  const isBountyClaimable = useCallback(() => isClaimable(accounts, beneficiaryId, payoutDue), [accounts, beneficiaryId, payoutDue]);
+  const isBountyClaimable = useCallback(() => isClaimable(allAccounts, beneficiaryId, payoutDue), [allAccounts, beneficiaryId, payoutDue]);
 
-  return isBountyClaimable()
+  return hasAccounts && isBountyClaimable()
     ? <TxButton
       accountId={beneficiaryId}
       icon='plus'

--- a/packages/page-bounties/src/BountyClaim.tsx
+++ b/packages/page-bounties/src/BountyClaim.tsx
@@ -1,0 +1,44 @@
+// Copyright 2017-2020 @polkadot/app-bounties authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import BN from 'bn.js';
+import React, { useCallback, useState } from 'react';
+
+import { TxButton } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
+
+import { isClaimable } from './helpers/isClaimable';
+import { useTranslation } from './translate';
+
+interface Props {
+  accounts: string[];
+  beneficiaryId: string;
+  index: number;
+  payoutDue: BN;
+}
+
+function BountyClaim ({ accounts, beneficiaryId, index, payoutDue }: Props) {
+  const { t } = useTranslation();
+  const { api } = useApi();
+
+  const [isValid] = useState(true);
+
+  const isBountyClaimable = useCallback(() => isClaimable(accounts, beneficiaryId, payoutDue), [accounts, beneficiaryId, payoutDue]);
+
+  return isBountyClaimable()
+    ? <TxButton
+      accountId={beneficiaryId}
+      icon='plus'
+      isDisabled={!isValid}
+      label={t<string>('Claim Bounty')}
+      params={[index]}
+      tx={
+        api.tx.bounties
+          ? 'bounties.claimBounty'
+          : 'treasury.claimBounty'
+      }
+    />
+    : null;
+}
+
+export default React.memo(BountyClaim);

--- a/packages/page-bounties/src/BountyCreate.tsx
+++ b/packages/page-bounties/src/BountyCreate.tsx
@@ -10,7 +10,7 @@ import { Button, Input, InputAddress, InputBalance, Modal, TxButton } from '@pol
 import { useApi, useToggle } from '@polkadot/react-hooks';
 import { BN_ZERO } from '@polkadot/util';
 
-import { calculateBountyBond } from './helpers/calculateBountyBond';
+import { calculateBountyBond } from './helpers';
 import { useTranslation } from './translate';
 
 function BountyCreate () {

--- a/packages/page-bounties/src/helpers/index.tsx
+++ b/packages/page-bounties/src/helpers/index.tsx
@@ -1,0 +1,6 @@
+// Copyright 2017-2020 @polkadot/app-bounties authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './calculateBountyBond';
+export * from './getBountyStatus';
+export * from './isClaimable';

--- a/packages/page-bounties/src/helpers/isClaimable.spec.ts
+++ b/packages/page-bounties/src/helpers/isClaimable.spec.ts
@@ -1,0 +1,42 @@
+// Copyright 2017-2020 @polkadot/app-bounties authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import BN from 'bn.js';
+
+import { TypeRegistry } from '@polkadot/types/create';
+
+import { isClaimable } from './isClaimable';
+
+describe('Is claimable', () => {
+  const registry = new TypeRegistry();
+  const accountAddress = '5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM';
+  const beneficiaryId = registry.createType('AccountId', [registry, accountAddress]);
+
+  it('returns false, when payout due is greater than 0', () => {
+    const accounts = [accountAddress];
+    const payoutDue = new BN('1');
+
+    expect(isClaimable(accounts, beneficiaryId, payoutDue)).toBe(false);
+  });
+
+  it('returns false, when payout due is equal 0', () => {
+    const accounts = [accountAddress];
+    const payoutDue = new BN('0');
+
+    expect(isClaimable(accounts, beneficiaryId, payoutDue)).toBe(false);
+  });
+
+  it('returns true, when payout due is lesser than 0 and beneficiary is among accounts', () => {
+    const accounts = [accountAddress];
+    const payoutDue = new BN('-1');
+
+    expect(isClaimable(accounts, beneficiaryId, payoutDue)).toBe(true);
+  });
+
+  it('returns false, when beneficiary is not among accounts', () => {
+    const accounts = ['This_is_not_the_treasury_address_27Tt8tkntv6Q7JVPhFsTB'];
+    const payoutDue = new BN('-1');
+
+    expect(isClaimable(accounts, beneficiaryId, payoutDue)).toBe(false);
+  });
+});

--- a/packages/page-bounties/src/helpers/isClaimable.ts
+++ b/packages/page-bounties/src/helpers/isClaimable.ts
@@ -1,8 +1,10 @@
 // Copyright 2017-2020 @polkadot/app-council authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AccountId } from '@polkadot/types/interfaces';
+
 import BN from 'bn.js';
 
-export const isClaimable = (accounts: string[], beneficiary: string, payoutDue: BN): boolean => {
-  return payoutDue.ltn(0) ? accounts.includes(beneficiary) : false;
+export const isClaimable = (accounts: string[], beneficiary: AccountId, payoutDue: BN): boolean => {
+  return payoutDue.ltn(0) && accounts.includes(beneficiary.toString());
 };

--- a/packages/page-bounties/src/helpers/isClaimable.ts
+++ b/packages/page-bounties/src/helpers/isClaimable.ts
@@ -1,0 +1,8 @@
+// Copyright 2017-2020 @polkadot/app-council authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import BN from 'bn.js';
+
+export const isClaimable = (accounts: string[], beneficiary: string, payoutDue: BN): boolean => {
+  return payoutDue.ltn(0) ? accounts.includes(beneficiary) : false;
+};

--- a/packages/page-bounties/src/helpers/isClaimable.ts
+++ b/packages/page-bounties/src/helpers/isClaimable.ts
@@ -5,6 +5,6 @@ import type { AccountId } from '@polkadot/types/interfaces';
 
 import BN from 'bn.js';
 
-export const isClaimable = (accounts: string[], beneficiary: AccountId, payoutDue: BN): boolean => {
+export function isClaimable (accounts: string[], beneficiary: AccountId, payoutDue: BN): boolean {
   return payoutDue.ltn(0) && accounts.includes(beneficiary.toString());
-};
+}


### PR DESCRIPTION
This PR adds Claim button to the bounty list, which allows beneficiary to claim the payout. The button is visible only if among accounts exists beneficiary, otherwise it's not rendered. Clicking the button performs the claim transaction from the beneficiary account.