### PR TITLE
Update Kulupu Address and LookupSource definitions

### DIFF
--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -5,6 +5,8 @@
 /* eslint-disable sort-keys */
 
 export default {
+  Address: 'MultiAddress',
+  LookupSource: 'MultiAddress',
   Difficulty: 'U256',
   DifficultyAndTimestamp: {
     difficulty: 'Difficulty',


### PR DESCRIPTION
The runtime just today was updated to include the new MultiAddress support https://github.com/paritytech/substrate/pull/7380 and hence we need to update the type definitions.