### PR TITLE
Use maxBlock value for weight limits

### DIFF
--- a/packages/page-contracts/src/useWeight.ts
+++ b/packages/page-contracts/src/useWeight.ts
@@ -17,7 +17,7 @@ export default function useWeight (): UseWeight {
   const [blockTime] = useBlockTime();
   const [megaGas, _setMegaGas] = useState<BN>(
     (api.consts.system.blockWeights
-      ? api.consts.system.blockWeights.perClass.normal.maxExtrinsic
+      ? api.consts.system.blockWeights.maxBlock
       : api.consts.system.maximumBlockWeight as Weight
     ).div(BN_MILLION).div(BN_TEN)
   );
@@ -26,7 +26,7 @@ export default function useWeight (): UseWeight {
   const setMegaGas = useCallback(
     (value?: BN | undefined) => _setMegaGas(value || (
       (api.consts.system.blockWeights
-        ? api.consts.system.blockWeights.perClass.normal.maxExtrinsic
+        ? api.consts.system.blockWeights.maxBlock
         : api.consts.system.maximumBlockWeight as Weight
       ).div(BN_MILLION).div(BN_TEN)
     )),
@@ -43,7 +43,7 @@ export default function useWeight (): UseWeight {
       weight = megaGas.mul(BN_MILLION);
       executionTime = weight.muln(blockTime).div(
         api.consts.system.blockWeights
-          ? api.consts.system.blockWeights.perClass.normal.maxExtrinsic
+          ? api.consts.system.blockWeights.maxBlock
           : api.consts.system.maximumBlockWeight as Weight
       ).toNumber();
       percentage = (executionTime / blockTime) * 100;

--- a/packages/page-staking/src/Payouts/PayButton.tsx
+++ b/packages/page-staking/src/Payouts/PayButton.tsx
@@ -89,15 +89,14 @@ function PayButton ({ className, isAll, isDisabled, payout }: Props): React.Reac
         .payoutStakers(validatorId, eras[0].era)
         .paymentInfo(allAccounts[0])
         .then((info) => setMaxPayouts(Math.floor(
-          api.consts.system.blockWeights
-            ? api.consts.system.blockWeights.perClass.normal.maxExtrinsic
-              .sub(api.consts.system.blockWeights.perClass.normal.baseExtrinsic)
-              .div(info.weight)
-              .toNumber()
-            : (api.consts.system.maximumBlockWeight as Weight)
-              .muln(64) // 65% of the block weight on a single extrinsic (64 for safety)
-              .div(info.weight)
-              .toNumber() / 100
+          (
+            api.consts.system.blockWeights
+              ? api.consts.system.blockWeights.maxBlock
+              : api.consts.system.maximumBlockWeight as Weight
+          )
+            .muln(64) // 65% of the block weight on a single extrinsic (64 for safety)
+            .div(info.weight)
+            .toNumber() / 100
         )))
         .catch(console.error);
     } else {


### PR DESCRIPTION
The per calls extrinsic value exhausts block limits, stick to 65%

Closes #4280 