### PR TITLE
Use derive call in Bounty's useCounter

### DIFF
--- a/packages/page-bounties/src/useCounter.ts
+++ b/packages/page-bounties/src/useCounter.ts
@@ -8,7 +8,7 @@ import { useApi, useCall } from '@polkadot/react-hooks';
 
 export default function useCounter (): number {
   const { api, isApiReady } = useApi();
-  const bounties = useCall<DeriveBounties>(isApiReady && (api.derive.bounties || api.derive.treasury)?.bounties);
+  const bounties = useCall<DeriveBounties>(isApiReady && api.derive.bounties?.bounties);
 
   return useMemo(
     () => bounties?.length || 0,

--- a/packages/page-bounties/src/useCounter.ts
+++ b/packages/page-bounties/src/useCounter.ts
@@ -1,18 +1,17 @@
 // Copyright 2017-2020 @polkadot/app-bounties authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BountyIndex } from '@polkadot/types/interfaces';
-
 import { useMemo } from 'react';
 
+import { DeriveBounties } from '@polkadot/api-derive/types';
 import { useApi, useCall } from '@polkadot/react-hooks';
 
 export default function useCounter (): number {
   const { api, isApiReady } = useApi();
-  const bounties = useCall<BountyIndex>(isApiReady && (api.query.bounties || api.query.treasury)?.bountyCount);
+  const bounties = useCall<DeriveBounties>(isApiReady && (api.derive.bounties || api.derive.treasury)?.bounties);
 
   return useMemo(
-    () => bounties?.toNumber() || 0,
+    () => bounties?.length || 0,
     [bounties]
   );
 }


### PR DESCRIPTION
To correctly display the number of active bounties we should switch to `DeriveBounties` because `bountyCount` returns a number of all bounties ever created.