### PR TITLE
Menu hover adjustments (only background)

### DIFF
--- a/packages/apps/src/Menu/Item.tsx
+++ b/packages/apps/src/Menu/Item.tsx
@@ -22,7 +22,7 @@ function Item ({ className = '', isToplevel, route: { Modal, href, icon, name, t
   const count = useCounter();
 
   return (
-    <li className={`${className}${count ? ' withCounter' : ''} ${isToplevel ? 'topLevel  highlight--color-contrast' : 'highlight--hover-color'}`}>
+    <li className={`${className}${count ? ' withCounter' : ''} ${isToplevel ? 'topLevel  highlight--color-contrast' : ''}`}>
       <a
         href={Modal ? undefined : (href || `#/${name}`)}
         onClick={Modal ? toggleModal : undefined}

--- a/packages/page-calendar/src/Day.tsx
+++ b/packages/page-calendar/src/Day.tsx
@@ -59,7 +59,7 @@ function Day ({ className, date, hasNextDay, now, scheduled, setNextDay, setPrev
   return (
     <div className={className}>
       <h1>
-        <div className='highlight--color'>
+        <div>
           {viewSetter()}
           {date.getDate()} {monthRef.current[date.getMonth()]} {date.getFullYear()} {isToday && <DayTime />}
         </div>

--- a/packages/page-calendar/src/Month.tsx
+++ b/packages/page-calendar/src/Month.tsx
@@ -45,7 +45,7 @@ function Month ({ className, hasNextMonth, lastDay, now, scheduled, setDay, setN
   return (
     <div className={className}>
       <h1>
-        <div className='highlight--color'>{monthRef.current[dateMonth.getMonth()]} {dateMonth.getFullYear()}</div>
+        <div>{monthRef.current[dateMonth.getMonth()]} {dateMonth.getFullYear()}</div>
         <Button.Group>
           <Button
             icon='chevron-left'

--- a/packages/page-calendar/src/UpcomingEvents.tsx
+++ b/packages/page-calendar/src/UpcomingEvents.tsx
@@ -34,7 +34,7 @@ function UpcomingEvents ({ className, scheduled, setView }: Props): React.ReactE
   return (
     <div className={className}>
       <h1>
-        <div className='highlight--color'>
+        <div>
           {viewSetter()}
           Upcoming Events
         </div>

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -80,7 +80,7 @@ export default createGlobalStyle<Props & ThemeProps>(({ theme, uiHighlight }: Pr
   }
 
   .highlight--bg-light:before {
-    opacity: 0.125;
+    opacity: 0.2;
   }
 
   .highlight--border {


### PR DESCRIPTION
Still not 100% on the very light items such as Moonbeam and Centrifuge (it could use an increase in opacity there), but now good on the very dark ones such as Kusama.