### PR TITLE
fix Chinese translation of 'comm.'

### DIFF
--- a/packages/apps/public/locales/zh/translation.json
+++ b/packages/apps/public/locales/zh/translation.json
@@ -966,7 +966,7 @@
   "code": "代码",
   "code for this contract": "该合约的代码",
   "code hash": "代码哈希",
-  "comm.": "委员会",
+  "comm.": "佣金",
   "commission": "佣金",
   "compiled contract WASM": "编译过的合约 WASM",
   "connected peers": "连接的节点",


### PR DESCRIPTION
string 'comm.' is used in https://github.com/polkadot-js/apps/blob/0360df1ccf47886c1247d0fa6d67578b230bbcb6/packages/page-staking/src/Targets/index.tsx#L274

here it is abbr of 'commission' which in Chinese should be '佣金' 