### PR TITLE
Fix account type in plasm parachian

### DIFF
--- a/packages/apps-config/src/api/spec/plasm-parachain.ts
+++ b/packages/apps-config/src/api/spec/plasm-parachain.ts
@@ -5,6 +5,6 @@
 /* eslint-disable sort-keys */
 
 export default {
-  Address: 'MultiAddress',
-  LookupSource: 'MultiAddress'
+  Address: 'AccountId',
+  LookupSource: 'AccountId'
 };


### PR DESCRIPTION
**Description**

In parachain `Address` should be `AccountId` for correct XCM work.