### PR TITLE
Adjust the popup's arrow according to the theme

### DIFF
--- a/packages/react-components/src/styles/semantic.ts
+++ b/packages/react-components/src/styles/semantic.ts
@@ -173,6 +173,10 @@ export default (theme: ThemeDef): string => `
     .ui.text.menu .item {
       color: ${theme.color};
     }
+
+    &&::before {
+      background: ${theme.bgMenu};
+    }
   }
 
   .ui.secondary.vertical.menu > .item {


### PR DESCRIPTION
Hi, a little change, as in the picture:
![image](https://user-images.githubusercontent.com/55240109/106712498-5313ca00-65f9-11eb-854d-0b2c9cdac60c.png)
