### PR TITLE
Remove type prop from address inputs in app-bounties

### DIFF
--- a/packages/page-bounties/src/BountyActions/AwardBounty.tsx
+++ b/packages/page-bounties/src/BountyActions/AwardBounty.tsx
@@ -63,7 +63,6 @@ function AwardBounty ({ curatorId, index }: Props): React.ReactElement<Props> | 
                     help={t<string>('Choose the Beneficiary for this bounty.')}
                     label={t<string>('beneficiary account')}
                     onChange={setBeneficiaryId}
-                    type='account'
                     withLabel
                   />
                 </Modal.Column>

--- a/packages/page-bounties/src/BountyActions/ProposeCuratorAction.tsx
+++ b/packages/page-bounties/src/BountyActions/ProposeCuratorAction.tsx
@@ -90,7 +90,6 @@ function ProposeCuratorAction ({ description, index, proposals, value }: Props):
                     help={t<string>('Select an account which (after a successful vote) will act as a curator.')}
                     label={t<string>('select curator')}
                     onChange={setCuratorId}
-                    type='account'
                     withLabel
                   />
                 </Modal.Column>

--- a/packages/page-bounties/src/BountyActions/SlashCurator.tsx
+++ b/packages/page-bounties/src/BountyActions/SlashCurator.tsx
@@ -128,7 +128,6 @@ function SlashCurator ({ action, curatorId, description, index, toggleOpen }: Pr
               help={helpMessage}
               isDisabled
               label={t<string>('current curator')}
-              type='account'
               withLabel
             />
           </Modal.Column>


### PR DESCRIPTION
It will fix the problem with selecting accounts in propose curator and award bounty actions. 