### PR TITLE
Add min staked to targets

### DIFF
--- a/packages/page-staking/src/Targets/Summary.tsx
+++ b/packages/page-staking/src/Targets/Summary.tsx
@@ -72,7 +72,6 @@ function Summary ({ avgStaked, lowStaked, minNominated, stakedReturn, totalIssua
           >
             <FormatBalance
               value={totalStaked}
-              withCurrency={false}
               withSi
             />
           </CardSummary>

--- a/packages/page-staking/src/Targets/Summary.tsx
+++ b/packages/page-staking/src/Targets/Summary.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from '../translate';
 interface Props {
   avgStaked?: BN;
   lowStaked?: BN;
+  minNominated?: BN;
   numNominators?: number;
   numValidators?: number;
   stakedReturn: number;
@@ -33,7 +34,7 @@ const transformEra = {
   transform: ({ activeEra }: DeriveSessionIndexes) => activeEra.gt(BN_ZERO) ? activeEra.sub(BN_ONE) : undefined
 };
 
-function Summary ({ avgStaked, lowStaked, numNominators, numValidators, stakedReturn, totalIssuance, totalStaked }: Props): React.ReactElement<Props> {
+function Summary ({ avgStaked, lowStaked, minNominated, stakedReturn, totalIssuance, totalStaked }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const lastEra = useCall<BN | undefined>(api.derive.session.indexes, undefined, transformEra);
@@ -64,74 +65,68 @@ function Summary ({ avgStaked, lowStaked, numNominators, numValidators, stakedRe
   return (
     <SummaryBox>
       <section className='media--800'>
-        {totalIssuance && (
-          <>
-            <CardSummary
-              label={`${totalStaked?.gtn(0) ? `${t<string>('total staked')} / ` : ''}${t<string>('total issuance')}`}
-              progress={progressStake}
-            >
-              <div>
-                {totalStaked?.gtn(0) && (
-                  <>
-                    <FormatBalance
-                      value={totalStaked}
-                      withCurrency={false}
-                      withSi
-                    />
-                    &nbsp;/&nbsp;
-                  </>
-                )}
-                <FormatBalance
-                  value={totalIssuance}
-                  withSi
-                />
-              </div>
-            </CardSummary>
-            {(stakedReturn > 0) && Number.isFinite(stakedReturn) && (
-              <CardSummary
-                className='media--1200'
-                label={t<string>('returns')}
-              >
-                {stakedReturn.toFixed(1)}%
-              </CardSummary>
-            )}
-          </>
+        {totalIssuance && totalStaked?.gt(BN_ZERO) && (
+          <CardSummary
+            label={t<string>('total staked')}
+            progress={progressStake}
+          >
+            <FormatBalance
+              value={totalStaked}
+              withCurrency={false}
+              withSi
+            />
+          </CardSummary>
         )}
       </section>
-      {avgStaked?.gtn(0) && lowStaked?.gtn(0) && (
-        <CardSummary
-          className='media--1000'
-          label={`${t<string>('lowest / avg staked')}`}
-          progress={progressAvg}
-        >
-          <FormatBalance
-            value={lowStaked}
-            withCurrency={false}
-            withSi
-          />
-          &nbsp;/&nbsp;
-          <FormatBalance
-            value={avgStaked}
-            withSi
-          />
-        </CardSummary>
-      )}
-      {numValidators && numNominators && (
-        <CardSummary
-          className='media--1600'
-          label={`${t<string>('nominators')} / ${t<string>('validators')}`}
-        >
-          {numNominators}&nbsp;/&nbsp;{numValidators}
-        </CardSummary>
-      )}
-      {lastReward?.gtn(0) && (
-        <CardSummary label={t<string>('last reward')}>
-          <FormatBalance
-            value={lastReward}
-            withSi
-          />
-        </CardSummary>
-      )}
+      <section className='media--800'>
+        {totalIssuance && (stakedReturn > 0) && Number.isFinite(stakedReturn) && (
+          <CardSummary label={t<string>('returns')}>
+            {stakedReturn.toFixed(1)}%
+          </CardSummary>
+        )}
+      </section>
+      <section className='media--1000'>
+        {avgStaked?.gtn(0) && lowStaked?.gtn(0) && (
+          <CardSummary
+            label={`${t<string>('lowest / avg staked')}`}
+            progress={progressAvg}
+          >
+            <FormatBalance
+              value={lowStaked}
+              withCurrency={false}
+              withSi
+            />
+            &nbsp;/&nbsp;
+            <FormatBalance
+              value={avgStaked}
+              withSi
+            />
+          </CardSummary>
+        )}
+      </section>
+      <section className='media--1600'>
+        {minNominated?.gt(BN_ZERO) && (
+          <CardSummary
+            className='media--1600'
+            label={t<string>('min nominated')}
+          >
+            <FormatBalance
+              value={minNominated}
+              withSi
+            />
+          </CardSummary>
+        )}
+      </section>
+      <section>
+        {lastReward?.gtn(0) && (
+          <CardSummary label={t<string>('last reward')}>
+            <FormatBalance
+              value={lastReward}
+              withSi
+            />
+          </CardSummary>
+        )}
+      </section>
     </SummaryBox>
   );
 }

--- a/packages/page-staking/src/Targets/index.tsx
+++ b/packages/page-staking/src/Targets/index.tsx
@@ -175,7 +175,7 @@ function selectProfitable (list: ValidatorInfo[]): string[] {
   return result;
 }
 
-function Targets ({ className = '', isInElection, ownStashes, targets: { avgStaked, inflation: { stakedReturn }, lowStaked, medianComm, nominators, totalIssuance, totalStaked, validatorIds, validators }, toggleFavorite, toggleLedger }: Props): React.ReactElement<Props> {
+function Targets ({ className = '', isInElection, ownStashes, targets: { avgStaked, inflation: { stakedReturn }, lowStaked, medianComm, minNominated, nominators, totalIssuance, totalStaked, validatorIds, validators }, toggleFavorite, toggleLedger }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const allSlashes = useAvailableSlashes();
@@ -345,6 +345,7 @@ function Targets ({ className = '', isInElection, ownStashes, targets: { avgStak
       <Summary
         avgStaked={avgStaked}
         lowStaked={lowStaked}
+        minNominated={minNominated}
         numNominators={nominators?.length}
         numValidators={validators?.length}
         stakedReturn={stakedReturn}


### PR DESCRIPTION
Display information for https://github.com/polkadot-js/apps/issues/4575 on targets (rolling, so updated each era)

The dover-tails with the information messages on the account actions when the stake is lower (not included) for any validator, so it tracks the changes there.