### PR TITLE
add moonbeam spec name

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -4,9 +4,9 @@
 // The list of Ethereum networks, for these the UI will default to Ethereum-only accounts
 
 export const ethereumChains = [
-  "node-moonbeam",
-  "moonbase-alphanet",
-  "moonbeam-alphanet",
-  "moonbeam-standalone",
-  "moonbeam"
+  'node-moonbeam',
+  'moonbase-alphanet',
+  'moonbeam-alphanet',
+  'moonbeam-standalone',
+  'moonbeam'
 ];

--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -3,4 +3,10 @@
 
 // The list of Ethereum networks, for these the UI will default to Ethereum-only accounts
 
-export const ethereumChains = ['node-moonbeam', 'moonbase-alphanet', 'moonbeam-alphanet', 'moonbeam-standalone'];
+export const ethereumChains = [
+  "node-moonbeam",
+  "moonbase-alphanet",
+  "moonbeam-alphanet",
+  "moonbeam-standalone",
+  "moonbeam"
+];


### PR DESCRIPTION
Moonbeam now has a new network name (spec name) that needs to be added to the list of ethereum network