### PR TITLE
introduce alternative chain colors

### DIFF
--- a/packages/apps-config/src/ui/colors.ts
+++ b/packages/apps-config/src/ui/colors.ts
@@ -50,6 +50,12 @@ const chainIdavoll = '#ff43ff';
 const chainSubDAO = 'linear-gradient(50deg, #F20092 0%, #FF4D5D 100%)';
 const chainTrustBase = '#ff43aa';
 
+// chain alternative colors
+// alternative colors will be used in some cases
+// e.g. svg graphs that doesn't support gradient colors
+// alternative colors should only be rgb/rgba colors
+const chainCloverAlt = '#52ad75';
+
 // based on node name
 // alphabetical
 const nodeBitCountry = '#191a2e';
@@ -77,6 +83,11 @@ const nodeZero = '#0099cc';
 const nodeZenlink = 'linear-gradient(45deg, #F20082 0%, #FF4D4D 100%)';
 
 export { emptyColor };
+
+const colorsReducer = (colors: Record<string, any>, [chain, color]: string[]): Record<string, any> => ({
+  ...colors,
+  [chain.toLowerCase()]: color
+});
 
 // Alphabetical overrides based on the actual matched chain name
 // NOTE: This is as retrieved via the system.chain RPC
@@ -135,10 +146,11 @@ export const chainColors: Record<string, any> = [
   ['Westend', chainWestend],
   ['Zenlink PC1', chainZenlink],
   ['ZΞRO Alphaville', chainZero]
-].reduce((colors, [chain, color]): Record<string, any> => ({
-  ...colors,
-  [chain.toLowerCase()]: color
-}), {});
+].reduce(colorsReducer, {});
+
+export const chainAltColors: Record<string, any> = [
+  ['Clover', chainCloverAlt]
+].reduce(colorsReducer, {});
 
 // Alphabetical overrides based on the actual software node type
 // NOTE: This is as retrieved via the system.name RPC

--- a/packages/apps-config/src/ui/index.ts
+++ b/packages/apps-config/src/ui/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { chainColors, nodeColors } from './colors';
+import { chainAltColors, chainColors, nodeColors } from './colors';
 import { identityNodes } from './identityIcons';
 
 export * from './logos';
@@ -17,4 +17,9 @@ export function getSystemIcon (systemName: string): 'beachball' | 'polkadot' | '
 export function getSystemChainColor (systemChain: string, systemName: string): string | undefined {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return chainColors[sanitize(systemChain)] || nodeColors[sanitize(systemName)];
+}
+
+export function getSystemChainAltColor (systemChain: string, systemName: string): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return chainAltColors[sanitize(systemChain)] || getSystemChainColor(systemChain, systemName);
 }

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -7,7 +7,7 @@ import React, { useContext, useMemo } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
 import AccountSidebar from '@polkadot/app-accounts/Sidebar';
-import { getSystemChainColor } from '@polkadot/apps-config';
+import { getSystemChainAltColor, getSystemChainColor } from '@polkadot/apps-config';
 import GlobalStyle from '@polkadot/react-components/styles';
 import { useApi } from '@polkadot/react-hooks';
 import Signer from '@polkadot/react-signer';
@@ -28,9 +28,15 @@ function Apps ({ className = '' }: Props): React.ReactElement<Props> {
     [systemChain, systemName]
   );
 
+  const uiAltHighlight = useMemo(
+    () => getSystemChainAltColor(systemChain, systemName),
+    [systemChain, systemName]
+  );
+
   return (
     <>
-      <GlobalStyle uiHighlight={uiHighlight} />
+      <GlobalStyle uiAltHighlight={uiAltHighlight}
+        uiHighlight={uiHighlight} />
       <div className={`apps--Wrapper theme--${theme} ${className}`}>
         <Menu />
         <AccountSidebar>

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -203,7 +203,7 @@ export default createGlobalStyle<Props & ThemeProps>(({ theme, uiAltHighlight, u
     .ui--Toggle.isChecked {
       &:not(.isRadio) {
         .ui--Toggle-Slider {
-          background-color: ${getHighlight(uiAltHighlight)} !important;
+          background: ${getHighlight(uiHighlight)} !important;
 
           &:before {
             border-color: ${getHighlight(uiHighlight)} !important;

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -14,6 +14,7 @@ import cssTheme from './theme';
 
 interface Props {
   uiHighlight?: string;
+  uiAltHighlight?: string;
 }
 
 const BRIGHTNESS = 128 + 32;
@@ -35,7 +36,7 @@ function getContrast (uiHighlight: string | undefined): string {
     : 'rgba(255, 253, 251, 0.875)';
 }
 
-export default createGlobalStyle<Props & ThemeProps>(({ theme, uiHighlight }: Props & ThemeProps) => `
+export default createGlobalStyle<Props & ThemeProps>(({ theme, uiAltHighlight, uiHighlight }: Props & ThemeProps) => `
   .highlight--all {
     background: ${getHighlight(uiHighlight)} !important;
     border-color: ${getHighlight(uiHighlight)} !important;
@@ -174,7 +175,7 @@ export default createGlobalStyle<Props & ThemeProps>(({ theme, uiHighlight }: Pr
 
       .ui--Icon {
         background: transparent;
-        color: ${getHighlight(uiHighlight)};
+        color: ${getHighlight(uiAltHighlight)};
       }
     }
   }
@@ -202,7 +203,7 @@ export default createGlobalStyle<Props & ThemeProps>(({ theme, uiHighlight }: Pr
     .ui--Toggle.isChecked {
       &:not(.isRadio) {
         .ui--Toggle-Slider {
-          background-color: ${getHighlight(uiHighlight)} !important;
+          background-color: ${getHighlight(uiAltHighlight)} !important;
 
           &:before {
             border-color: ${getHighlight(uiHighlight)} !important;


### PR DESCRIPTION
This pull request fixes #4706.

Apps allows customizing the chain theme color by using chainColor
configuration.
Some chains uses css linear-gradient image as the chainColor
which works not well in some cases. E.g. svg colors and css background
colors  does not support images at all.

To fix this, we introduce alternative chain colors configuration.
The alternative chain color will be used in cases that chainColor not
work. It will fallback to use chainColor if there is no alternative
color configured for a chain.