### PR TITLE
Add type definitions for Snowbridge

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -16,7 +16,7 @@
     "@interlay/polkabtc-types": "^0.3.4",
     "@laminar/type-definitions": "^0.2.0-beta.143",
     "@polkadot/networks": "^5.7.1",
-    "@snowfork/snowbridge-types": "^0.2.2",
+    "@snowfork/snowbridge-types": "^0.2.3",
     "@sora-substrate/type-definitions": "^0.4.1",
     "@subsocial/types": "^0.4.29",
     "moonbeam-types-bundle": "1.1.6"

--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -16,6 +16,7 @@
     "@interlay/polkabtc-types": "^0.3.4",
     "@laminar/type-definitions": "^0.2.0-beta.143",
     "@polkadot/networks": "^5.7.1",
+    "@snowfork/snowbridge-types": "^0.2.2",
     "@sora-substrate/type-definitions": "^0.4.1",
     "@subsocial/types": "^0.4.29",
     "moonbeam-types-bundle": "1.1.6"

--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -46,6 +46,7 @@ import polkabtc from './polkabtc';
 import polkadex from './polkadex';
 import robonomics from './robonomics';
 import sgc from './sgc';
+import snowbridge from './snowbridge';
 import soraSubstrate from './soraSubstrate';
 import stafi from './stafi';
 import subdao from './subdao';
@@ -108,6 +109,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'plasm-parachain': plasmParachain,
   robonomics,
   sgc,
+  snowbridge,
   'sora-substrate': soraSubstrate,
   stafi,
   subdao,

--- a/packages/apps-config/src/api/spec/snowbridge.ts
+++ b/packages/apps-config/src/api/spec/snowbridge.ts
@@ -1,0 +1,6 @@
+// Copyright 2017-2021 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { definition } from '@snowfork/snowbridge-types';
+
+export default definition;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,7 +2361,7 @@ __metadata:
     "@interlay/polkabtc-types": ^0.3.4
     "@laminar/type-definitions": ^0.2.0-beta.143
     "@polkadot/networks": ^5.7.1
-    "@snowfork/snowbridge-types": ^0.2.2
+    "@snowfork/snowbridge-types": ^0.2.3
     "@sora-substrate/type-definitions": ^0.4.1
     "@subsocial/types": ^0.4.29
     i18next: ^19.8.5
@@ -3116,10 +3116,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowfork/snowbridge-types@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "@snowfork/snowbridge-types@npm:0.2.2"
-  checksum: 34a3c4558f0fceedc891b0166a47f07655587c773ef471a35d1a6c956b0fee9bd783c3a7a0bef5de0d57fc4ae23f44fb5e1b4943afa5056a08aae8f85e3dcb26
+"@snowfork/snowbridge-types@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@snowfork/snowbridge-types@npm:0.2.3"
+  checksum: 827621cac826c700d98ec19b94784df3087e37cd25099fdb2a30264ee75defbd6cb25f789c1b8c9a511c687018dff637b95affb9feaecaa56ae9cdf0b533108d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,6 +2361,7 @@ __metadata:
     "@interlay/polkabtc-types": ^0.3.4
     "@laminar/type-definitions": ^0.2.0-beta.143
     "@polkadot/networks": ^5.7.1
+    "@snowfork/snowbridge-types": ^0.2.2
     "@sora-substrate/type-definitions": ^0.4.1
     "@subsocial/types": ^0.4.29
     i18next: ^19.8.5
@@ -3112,6 +3113,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 64458b908773638dda08b555a00e6fbbbc679735348291dc1b7f437ada2f60242537fdc48e4ee82d2573d86984ec87e755b66a96c0ed9ebf0f46b4c6687ccde2
+  languageName: node
+  linkType: hard
+
+"@snowfork/snowbridge-types@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@snowfork/snowbridge-types@npm:0.2.2"
+  checksum: 34a3c4558f0fceedc891b0166a47f07655587c773ef471a35d1a6c956b0fee9bd783c3a7a0bef5de0d57fc4ae23f44fb5e1b4943afa5056a08aae8f85e3dcb26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Snowbridge](https://github.com/Snowfork/polkadot-ethereum) is a trust-minimized bridge between Polkadot and Ethereum.

The type definitions are sourced from our [@snowfork/snowbridge-types](https://www.npmjs.com/package/@snowfork/snowbridge-types) package, located in our repository [here](https://github.com/Snowfork/polkadot-ethereum/tree/main/types).
