### PR TITLE
kulupu: add CampaignIdentifier type for runtime 17

### DIFF
--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -36,6 +36,13 @@ const definitions: OverrideBundleDefinition = {
         Address: 'MultiAddress',
         LookupSource: 'MultiAddress'
       }
+    },
+    {
+      // enable pallet-lockdrop in runtime 17
+      minmax: [17, undefined],
+      types: {
+        CampaignIdentifier: "[u8; 4]"
+      }
     }
   ]
 };

--- a/packages/apps-config/src/api/spec/kulupu.ts
+++ b/packages/apps-config/src/api/spec/kulupu.ts
@@ -41,7 +41,7 @@ const definitions: OverrideBundleDefinition = {
       // enable pallet-lockdrop in runtime 17
       minmax: [17, undefined],
       types: {
-        CampaignIdentifier: "[u8; 4]"
+        CampaignIdentifier: '[u8; 4]'
       }
     }
   ]


### PR DESCRIPTION
This is due to the introduction of pallet-lockdrop.