### PR TITLE
Update KILT types for upcoming release

### DIFF
--- a/packages/apps-config/src/api/spec/kilt.ts
+++ b/packages/apps-config/src/api/spec/kilt.ts
@@ -12,16 +12,35 @@ const definitions: OverrideBundleDefinition = {
       // on all versions
       minmax: [0, undefined],
       types: {
-        Address: 'AccountId',
-        BlockNumber: 'u64',
+        Attestation: {
+          attester: 'AccountId',
+          ctypeHash: 'Hash',
+          delegationId: 'Option<DelegationNodeId>',
+          revoked: 'bool'
+        },
+        Balance: 'u128',
+        DelegationNode: {
+          owner: 'AccountId',
+          parent: 'Option<DelegationNodeId>',
+          permissions: 'Permissions',
+          revoked: 'bool',
+          rootId: 'DelegationNodeId'
+        },
         DelegationNodeId: 'Hash',
-        ErrorCode: 'u16',
+        DelegationRoot: {
+          ctypeHash: 'Hash',
+          owner: 'AccountId',
+          revoked: 'bool'
+        },
+        DidRecord: {
+          boxKey: 'Hash',
+          docRef: 'Option<Vec<u8>>',
+          signKey: 'Hash'
+        },
         Index: 'u64',
-        LookupSource: 'AccountId',
         Permissions: 'u32',
         PublicBoxKey: 'Hash',
         PublicSigningKey: 'Hash',
-        RefCount: 'u8',
         Signature: 'MultiSignature'
       }
     }

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -155,7 +155,7 @@ export function createTesting (t: TFunction): LinkOption[] {
     },
     {
       info: 'kilt',
-      text: t('rpc.kilt', 'Mashnet', { ns: 'apps-config' }),
+      text: t('rpc.kilt', 'KILT Mashnet', { ns: 'apps-config' }),
       providers: {
         'KILT Protocol': 'wss://full-nodes.kilt.io:9944/'
       }

--- a/packages/apps/public/locales/en/apps-config.json
+++ b/packages/apps/public/locales/en/apps-config.json
@@ -37,7 +37,7 @@
   "rpc.hosted.by": "hosted by {{host}}",
   "rpc.hydra": "HydraDX",
   "rpc.jupiter": "Jupiter",
-  "rpc.kilt": "Mashnet",
+  "rpc.kilt": "KILT Mashnet",
   "rpc.kulupu": "Kulupu",
   "rpc.kusama.ava": "Kusama",
   "rpc.kusama.onfinality": "Kusama",


### PR DESCRIPTION
This PR updates the KILT types to be compliant with our upcoming (~1h from now) release 0.24.0 running on Substrate 3.0.0. It also adds the _KILT_ prefix to the `Mashnet` chain name.

According to my tests I suppose the `Address` and `LookupSource` keys are not required to be set manually anymore? If this is not the case, we would like to re-add them before this PR is merged. The same applies to the RefCount, for which we just follow Substrate.