### PR TITLE
Fix Dusty chain types

### DIFF
--- a/packages/apps-config/src/api/spec/dusty.ts
+++ b/packages/apps-config/src/api/spec/dusty.ts
@@ -42,7 +42,7 @@ const definitions: OverrideBundleDefinition = {
           individual: 'BTreeMap<AccountId, Balance>',
           total: 'Balance'
         },
-        Keys: 'SessionKeys2',
+        Keys: 'SessionKeys3',
         Lockdrop: {
           duration: 'u64',
           public_key: '[u8; 33]',


### PR DESCRIPTION
**Changes**

From now `SessionKeys` contains 3 elemets.