### PR TITLE
Match the correct specName by getRuntimeVersion

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -74,7 +74,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'btc-parachain': polkabtc,
   canvas,
   'centrifuge-chain': centrifugeChain,
-  chainx,
+  'chainx-parachain': chainx,
   clover,
   'clover-rococo': cloverRococo,
   crust,
@@ -126,7 +126,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   ternoa,
   trustbase,
   uniarts,
-  zenlink
+  'dev-parachain': zenlink
 };
 
 export default spec;

--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -82,6 +82,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'cumulus-test-parachain': testPara,
   'darwinia-parachain': darwiniaParachain,
   'datahighway-parachain': datahighwayParachain,
+  'dev-parachain': zenlink,
   'dock-main-runtime': dock,
   'dock-testnet': dock,
   'dotmog-node': dotmog,
@@ -125,8 +126,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   subzero: zero,
   ternoa,
   trustbase,
-  uniarts,
-  'dev-parachain': zenlink
+  uniarts
 };
 
 export default spec;


### PR DESCRIPTION
Test the chainx and zenlink, The correct specnames:

chainx is  "chainx-parachain": https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsherpax.chainx.org#/rpc
zenlink is  "dev-parachain":  https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-parachain.zenlink.pro#/rpc