### PR TITLE
feat: add KILT XCMP types

### DIFF
--- a/packages/apps-config/src/api/spec/kilt.ts
+++ b/packages/apps-config/src/api/spec/kilt.ts
@@ -41,7 +41,50 @@ const definitions: OverrideBundleDefinition = {
         Permissions: 'u32',
         PublicBoxKey: 'Hash',
         PublicSigningKey: 'Hash',
-        Signature: 'MultiSignature'
+        Signature: 'MultiSignature',
+        XCurrencyId: {
+          chainId: 'ChainId',
+          currencyId: 'Vec<u8>'
+        },
+        ChainId: {
+          _enum: {
+            RelayChain: 'Null',
+            ParaChain: 'ParaId'
+          }
+        },
+        CurrencyIdOf: 'CurrencyId',
+        CurrencyId: {
+          _enum: {
+            DOT: 0,
+            KSM: 1,
+            KILT: 2
+          }
+        },
+        XcmError: {
+          _enum: {
+            Undefined: 0,
+            Unimplemented: 1,
+            UnhandledXcmVersion: 2,
+            UnhandledXcmMessage: 3,
+            UnhandledEffect: 4,
+            EscalationOfPrivilege: 5,
+            UntrustedReserveLocation: 6,
+            UntrustedTeleportLocation: 7,
+            DestinationBufferOverflow: 8,
+            CannotReachDestination: 9,
+            MultiLocationFull: 10,
+            FailedToDecode: 11,
+            BadOrigin: 12,
+            ExceedsMaxMessageSize: 13,
+            FailedToTransactAsset: 14
+          }
+        },
+        ReferendumInfo: {
+          _enum: {
+            Ongoing: 'ReferendumStatus',
+            Finished: 'ReferendumInfoFinished'
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
This PR adds necessary types for XCMP which are required for the WS Connection, otherwise errors are thrown.