### PR TITLE
Hex-only for H160/256/512 values

### DIFF
--- a/packages/react-params/src/Param/Hash160.tsx
+++ b/packages/react-params/src/Param/Hash160.tsx
@@ -10,6 +10,7 @@ import BaseBytes from './BaseBytes';
 function Hash160 ({ className = '', defaultValue, isDisabled, isError, label, name, onChange, onEnter, onEscape, type, withLabel }: Props): React.ReactElement<Props> {
   return (
     <BaseBytes
+      asHex
       className={className}
       defaultValue={defaultValue}
       isDisabled={isDisabled}

--- a/packages/react-params/src/Param/Hash256.tsx
+++ b/packages/react-params/src/Param/Hash256.tsx
@@ -10,6 +10,7 @@ import BaseBytes from './BaseBytes';
 function Hash256 ({ className = '', defaultValue, isDisabled, isError, label, name, onChange, onEnter, onEscape, type, withLabel }: Props): React.ReactElement<Props> {
   return (
     <BaseBytes
+      asHex
       className={className}
       defaultValue={defaultValue}
       isDisabled={isDisabled}

--- a/packages/react-params/src/Param/Hash512.tsx
+++ b/packages/react-params/src/Param/Hash512.tsx
@@ -10,6 +10,7 @@ import BaseBytes from './BaseBytes';
 function Hash512 ({ className = '', defaultValue, isDisabled, isError, label, name, onChange, onEnter, onEscape, type, withLabel }: Props): React.ReactElement<Props> {
   return (
     <BaseBytes
+      asHex
       className={className}
       defaultValue={defaultValue}
       isDisabled={isDisabled}


### PR DESCRIPTION
The u8a, when wrapped as an Option, gets handled incorrectly in these cases.

Closes https://github.com/polkadot-js/apps/issues/5070