### PR TITLE
Adjust fee calc for signer

### DIFF
--- a/packages/react-signer/src/PaymentInfo.tsx
+++ b/packages/react-signer/src/PaymentInfo.tsx
@@ -16,7 +16,7 @@ import { formatBalance, isFunction } from '@polkadot/util';
 import { useTranslation } from './translate';
 
 interface Props {
-  accountId?: string | null;
+  accountId: string | null;
   className?: string;
   extrinsic?: SubmittableExtrinsic | null;
   isSendable: boolean;
@@ -49,6 +49,11 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
     return null;
   }
 
+  const isFeeError = api.consts.balances && !api.tx.balances?.transfer.is(extrinsic) && balances?.accountId.eq(accountId) && (
+    balances.availableBalance.lte(dispatchInfo.partialFee) ||
+    balances.freeBalance.sub(dispatchInfo.partialFee).lte(api.consts.balances.existentialDeposit)
+  );
+
   return (
     <>
       <Expander
@@ -59,7 +64,7 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
           </Trans>
         }
       />
-      {api.consts.balances && !api.tx.balances?.transfer.is(extrinsic) && balances?.accountId.eq(accountId) && balances.availableBalance.sub(dispatchInfo.partialFee).lte(api.consts.balances.existentialDeposit) && (
+      {isFeeError && (
         <MarkWarning content={t<string>('The account does not have enough free funds (excluding locked/bonded/reserved) available to cover the transaction fees without dropping the balance below the account existential amount.')} />
       )}
     </>

--- a/packages/react-signer/src/Transaction.tsx
+++ b/packages/react-signer/src/Transaction.tsx
@@ -13,6 +13,7 @@ import PaymentInfo from './PaymentInfo';
 import { useTranslation } from './translate';
 
 interface Props {
+  accountId: string | null;
   className?: string;
   currentItem: QueueTx;
   isSendable: boolean;
@@ -20,7 +21,7 @@ interface Props {
   tip?: BN;
 }
 
-function Transaction ({ className, currentItem: { accountId, extrinsic, isUnsigned, payload }, isSendable, onError, tip }: Props): React.ReactElement<Props> | null {
+function Transaction ({ accountId, className, currentItem: { extrinsic, isUnsigned, payload }, isSendable, onError, tip }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
 
   if (!extrinsic) {

--- a/packages/react-signer/src/TxSigned.tsx
+++ b/packages/react-signer/src/TxSigned.tsx
@@ -361,6 +361,7 @@ function TxSigned ({ className, currentItem, requestAddress }: Props): React.Rea
             : (
               <>
                 <Transaction
+                  accountId={senderInfo.signAddress}
                   currentItem={currentItem}
                   onError={toggleRenderError}
                 />


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/5100

2 issues -

- the proxy address above was never checked for the fees (only account being proxied, same would apply to eg. multisig)
- fees should come from available, but free balance should be checked for existential