### PR TITLE
Add Vodka testnet endpoint

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -73,6 +73,7 @@ import unique from './unique';
 import unitv from './unitv';
 import vln from './vln';
 import vlnrococo from './vln-rococo';
+import vodka from './vodka';
 import web3games from './web3games';
 import westlake from './westlake';
 import zeitgeist from './zeitgeist';
@@ -167,6 +168,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   uart,
   'unit-node': unitv,
   'unit-parachain': unitv,
+  vodka,
   'web3games-node': web3games,
   westlake: westlake,
   zeitgeist: zeitgeist

--- a/packages/apps-config/src/api/spec/vodka.ts
+++ b/packages/apps-config/src/api/spec/vodka.ts
@@ -1,0 +1,20 @@
+// Copyright 2017-2021 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      minmax: [0, undefined],
+      types: {
+        NameHash: 'H256'
+      }
+    }
+  ]
+};
+
+export default definitions;

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -286,6 +286,13 @@ export function createTesting (t: TFunction): LinkOption[] {
       }
     },
     {
+      info: 'vodka',
+      text: t('rpc.vodka', 'Vodka', { ns: 'apps-config' }),
+      providers: {
+        Vodka: 'wss://vodka.rpc.neatcoin.org/ws'
+      }
+    },
+    {
       info: 'web3games',
       text: t('rpc.web3games', 'Web3Games', { ns: 'apps-config' }),
       providers: {


### PR DESCRIPTION
This adds the Vodka testnet endpoint and type definitions, Neatcoin's testnet.