### PR TITLE
Check if accounts are loaded before hiding a tab in staking

### DIFF
--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -37,7 +37,7 @@ const transformElection = {
 function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const { hasAccounts } = useAccounts();
+  const { areAccountsLoaded, hasAccounts } = useAccounts();
   const { pathname } = useLocation();
   const [withLedger, setWithLedger] = useState(false);
   const [favorites, toggleFavorite] = useFavorites(STORE_FAVS_BASE);
@@ -103,9 +103,9 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
       <Tabs
         basePath={basePath}
         hidden={
-          hasAccounts
-            ? undefined
-            : HIDDEN_ACC
+          areAccountsLoaded && !hasAccounts
+            ? HIDDEN_ACC
+            : undefined
         }
         items={items}
       />

--- a/packages/react-hooks/src/useAccounts.ts
+++ b/packages/react-hooks/src/useAccounts.ts
@@ -9,11 +9,12 @@ import { useIsMountedRef } from './useIsMountedRef';
 
 interface UseAccounts {
   allAccounts: string[];
+  areAccountsLoaded: boolean
   hasAccounts: boolean;
   isAccount: (address?: string | null) => boolean;
 }
 
-const EMPTY: UseAccounts = { allAccounts: [], hasAccounts: false, isAccount: () => false };
+const EMPTY: UseAccounts = { allAccounts: [], areAccountsLoaded: false, hasAccounts: false, isAccount: () => false };
 
 export function useAccounts (): UseAccounts {
   const mountedRef = useIsMountedRef();
@@ -26,7 +27,7 @@ export function useAccounts (): UseAccounts {
         const hasAccounts = allAccounts.length !== 0;
         const isAccount = (address?: string | null) => !!address && allAccounts.includes(address);
 
-        setState({ allAccounts, hasAccounts, isAccount });
+        setState({ allAccounts, areAccountsLoaded: true, hasAccounts, isAccount });
       }
     });
 


### PR DESCRIPTION
Trying to solve a frustration: opening a "tab-level" url directly redirects to root of the section (eg. `#/staking/actions`).

It happens because accounts are not loaded at first, and the lack of accounts marks the "actions" tab as hidden. This in turn triggers a `window.location.hash` change to `/staking` root.

Provided solution checks whether accounts are loaded and only then hides (or not) the tab.