### PR TITLE
Add tokens alias for Zeitgeist

### DIFF
--- a/packages/apps-config/src/api/spec/zeitgeist.ts
+++ b/packages/apps-config/src/api/spec/zeitgeist.ts
@@ -10,7 +10,7 @@ import { typesFromDefs } from '../util';
 const bundle = {
   alias: {
     tokens: {
-      AccountData: "TokensAccountData"
+      AccountData: 'TokensAccountData'
     }
   },
   types: [{
@@ -18,10 +18,10 @@ const bundle = {
     types: {
       ...typesFromDefs(typeDefs),
       TokensAccountData: {
-        free: "Balance",
-        reserved: "Balance",
-        frozen: "Balance",
-      },
+        free: 'Balance',
+        frozen: 'Balance',
+        reserved: 'Balance'
+      }
     }
   }]
 };

--- a/packages/apps-config/src/api/spec/zeitgeist.ts
+++ b/packages/apps-config/src/api/spec/zeitgeist.ts
@@ -8,10 +8,22 @@ import * as typeDefs from '@zeitgeistpm/type-defs';
 import { typesFromDefs } from '../util';
 
 const bundle = {
+  alias: {
+    tokens: {
+      AccountData: "TokensAccountData"
+    }
+  },
   types: [{
     minmax: [0, undefined],
-    types: { ...typesFromDefs(typeDefs) }
+    types: {
+      ...typesFromDefs(typeDefs),
+      TokensAccountData: {
+        free: "Balance",
+        reserved: "Balance",
+        frozen: "Balance",
+      },
+    }
   }]
 };
 
-export default bundle as OverrideBundleDefinition;
+export default bundle as never as OverrideBundleDefinition;


### PR DESCRIPTION
Adding an alias for the Tokens pallet so that the clash of `AccoundData` types between that pallet and Balances' AccountData doesn't cause Apps to complain. Something of a stop-gap for now until we start generating the full bundle in our own package.