### PR TITLE
Update Dusty chain type

### DIFF
--- a/packages/apps-config/src/api/spec/dusty.ts
+++ b/packages/apps-config/src/api/spec/dusty.ts
@@ -12,6 +12,7 @@ const definitions: OverrideBundleDefinition = {
       // on all versions
       minmax: [0, undefined],
       types: {
+        AccountInfo: 'AccountInfoWithProviders',
         AuthorityId: 'AccountId',
         AuthorityVote: 'u32',
         ChallengeGameOf: {


### PR DESCRIPTION
Added `AccountInfo` type definition for balance display issues.