### PR TITLE
Fix translations loading for ever

### DIFF
--- a/packages/page-settings/src/I18n/index.tsx
+++ b/packages/page-settings/src/I18n/index.tsx
@@ -40,12 +40,13 @@ async function retrieveJson (url: string): Promise<any> {
     return cache.get(url);
   }
 
-  const response = await fetch(`locales/${url}`);
-  const json = await response.json() as unknown;
+  const json = await fetch(`locales/${url}`)
+    .then((response) => response.json())
+    .catch((e) => console.error(e)) as unknown;
 
   cache.set(url, json);
 
-  return json;
+  return json || {};
 }
 
 async function retrieveEnglish (): Promise<StringsMod> {


### PR DESCRIPTION
Currently when going to #/settings/i18n we have the spinner loading forever.

It is caused by 404 on locales/pl/translation.json missing.

bug introduced by this PR:
https://github.com/polkadot-js/apps/pull/4724

To avoid this in future and instead of creating a locales/pl/translation.json (that can be done in another PR) ii catch any error on retrieveJson and return an empty {}