### PR TITLE
feat: add KILT paraId

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -42,6 +42,14 @@ export function createKusama (t: TFunction): EndpointOption {
         providers: {
           Phala: 'wss://khala.phala.network/ws'
         }
+      },
+      {
+        info: 'kilt',
+        paraId: 2005,
+        text: t('rpc.kilt', 'KILT Mashnet', { ns: 'apps-config' }),
+        providers: {
+          'KILT Protocol': 'wss://mainnet.kilt.io/'
+        }
       }
     ]
   };


### PR DESCRIPTION
Adds KILT Parachain ID to the live parachains tab. Please note that the linked websocket address is not live yet.