### PR TITLE
fix ma (from Manta Network) display

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -146,7 +146,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   laminar,
   litentry,
   mandala: acala,
-  manta,
+  'manta-node': manta,
   'mashnet-node': kilt,
   'mathchain-galois': galois,
   'moonbase-alphanet': moonbeam,


### PR DESCRIPTION
Previously, the redirection of the type definitions didn't set properly. This PR fixes that.  