### PR TITLE
[Plasm] Add AccountInfo type

### DIFF
--- a/packages/apps-config/src/api/spec/plasm.ts
+++ b/packages/apps-config/src/api/spec/plasm.ts
@@ -12,6 +12,7 @@ const definitions: OverrideBundleDefinition = {
       // on all versions
       minmax: [0, undefined],
       types: {
+        AccountInfo: 'AccountInfoWithRefCount',
         AuthorityId: 'AccountId',
         AuthorityVote: 'u32',
         Claim: {


### PR DESCRIPTION
Adds type `AccountInfo: 'AccountInfoWithRefCount'` for Plasm Main Network.