### PR TITLE
use selected theme in the validator stats page

### DIFF
--- a/packages/page-staking/src/Query/Validator.tsx
+++ b/packages/page-staking/src/Query/Validator.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Props } from './types';
+import type { ThemeProps } from '@polkadot/react-components/types';
 
 import React from 'react';
 import styled from 'styled-components';
@@ -28,11 +29,11 @@ function Validator ({ className = '', validatorId }: Props): React.ReactElement<
   );
 }
 
-export default React.memo(styled(Validator)`
+export default React.memo(styled(Validator)(({ theme }: ThemeProps) =>`
   .staking--Chart {
-    background: white;
+    background: ${theme.theme};
     border: 1px solid #eeecea;
     border-radius: 0.25rem;
     padding: 1rem 1.5rem;
   }
-`);
+`));

--- a/packages/page-staking/src/Query/Validator.tsx
+++ b/packages/page-staking/src/Query/Validator.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Props } from './types';
-import type { ThemeProps } from '@polkadot/react-components/types';
 
 import React from 'react';
 import styled from 'styled-components';
@@ -29,11 +28,11 @@ function Validator ({ className = '', validatorId }: Props): React.ReactElement<
   );
 }
 
-export default React.memo(styled(Validator)(({ theme }: ThemeProps) =>`
+export default React.memo(styled(Validator)`
   .staking--Chart {
-    background: ${theme.theme};
-    border: 1px solid #eeecea;
+    background: var(--bg-table);
+    border: 1px solid var(--border-table);
     border-radius: 0.25rem;
     padding: 1rem 1.5rem;
   }
-`));
+`);


### PR DESCRIPTION
The validator stats page was not displayed correctly while in Dark theme, making it unreadable. (See attached before and after screenshots). This Pull request attempts to fix that, and I'd like some feedback. 
Thanks.

#### Before PR Changes (with Dark theme). I've annotated the chart titles with red rectangles which were not visible.
<img width="1440" alt="Screenshot 2021-05-30 at 08 45 59" src="https://user-images.githubusercontent.com/3910877/120095076-19c11600-c124-11eb-816a-b141a567afd3.png">

#### After PR Changes (With Dark theme) (actual fix)
<img width="1440" alt="Screenshot 2021-05-30 at 08 23 28" src="https://user-images.githubusercontent.com/3910877/120094905-55a7ab80-c123-11eb-81a9-1bd91b4a3bbd.png">


#### After PR Changes (With Light theme)
<img width="1440" alt="Screenshot 2021-05-30 at 08 24 09" src="https://user-images.githubusercontent.com/3910877/120095007-c8188b80-c123-11eb-926a-6fe8efdd030f.png">



