### PR TITLE
Change Westmint RPC URL

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -36,7 +36,7 @@ export function createWestend (t: TFunction): EndpointOption {
         paraId: 1000,
         text: t('rpc.westend.shell', 'Westmint', { ns: 'apps-config' }),
         providers: {
-          Parity: 'wss://westend-shell-rpc.parity.io'
+          Parity: 'wss://westmint-rpc.polkadot.io'
         }
       },
       // (3) parachains with id, see Rococo (info here maps to the actual "named icon")


### PR DESCRIPTION
This PR changes the Westmint RPC URL to use the one on the polkadot.io domain. 

You can validate using this link that this new RPC endpoint is active (although the chain is currently stuck due to an issue) : https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestmint-rpc.polkadot.io#/explorer