### PR TITLE
Calculate auction range correctly (no BN_THREE)

### DIFF
--- a/packages/page-parachains/src/Auctions/Auction.tsx
+++ b/packages/page-parachains/src/Auctions/Auction.tsx
@@ -8,9 +8,9 @@ import React, { useCallback, useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
-import { BN_THREE } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
+import { useLeaseRangeMax } from '../useLeaseRanges';
 import WinRange from './WinRange';
 
 interface Props {
@@ -23,6 +23,7 @@ interface Props {
 function Auction ({ auctionInfo, campaigns, className, winningData }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
+  const rangeMax = useLeaseRangeMax();
   const newRaise = useCall<ParaId[]>(api.query.crowdloan.newRaise);
 
   const headerRef = useRef([
@@ -40,7 +41,7 @@ function Auction ({ auctionInfo, campaigns, className, winningData }: Props): Re
       }
 
       const leasePeriod = auctionInfo.leasePeriod;
-      const leasePeriodEnd = leasePeriod.add(BN_THREE);
+      const leasePeriodEnd = leasePeriod.add(rangeMax);
       const sorted = (campaigns.funds || [])
         .filter(({ firstSlot, lastSlot, paraId }) =>
           newRaise.some((n) => n.eq(paraId)) &&
@@ -75,7 +76,7 @@ function Auction ({ auctionInfo, campaigns, className, winningData }: Props): Re
             : a.firstSlot.cmp(b.firstSlot)
         );
     },
-    [auctionInfo, campaigns, newRaise]
+    [auctionInfo, campaigns, newRaise, rangeMax]
   );
 
   return (

--- a/packages/page-parachains/src/Auctions/Bid.tsx
+++ b/packages/page-parachains/src/Auctions/Bid.tsx
@@ -13,7 +13,7 @@ import { BN_ZERO, formatNumber } from '@polkadot/util';
 
 import InputOwner from '../InputOwner';
 import { useTranslation } from '../translate';
-import useRanges from '../useRanges';
+import { useLeaseRanges } from '../useLeaseRanges';
 
 interface Props {
   auctionInfo?: AuctionInfo;
@@ -36,7 +36,7 @@ function Bid ({ auctionInfo, className, lastWinners, ownedIds }: Props): React.R
   const { api } = useApi();
   const { hasAccounts } = useAccounts();
   const bestNumber = useBestNumber();
-  const ranges = useRanges();
+  const ranges = useLeaseRanges();
   const [{ accountId, paraId }, setOwnerInfo] = useState<OwnerInfo>(EMPTY_OWNER);
   const [amount, setAmount] = useState<BN | undefined>(BN_ZERO);
   const [range, setRange] = useState(0);

--- a/packages/page-parachains/src/Crowdloan/FundAdd.tsx
+++ b/packages/page-parachains/src/Crowdloan/FundAdd.tsx
@@ -12,7 +12,7 @@ import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
 import InputOwner from '../InputOwner';
 import { useTranslation } from '../translate';
-import useRanges from '../useRanges';
+import { useLeaseRanges } from '../useLeaseRanges';
 
 interface Props {
   auctionInfo?: AuctionInfo;
@@ -27,7 +27,7 @@ const EMPTY_OWNER: OwnerInfo = { accountId: null, paraId: 0 };
 function FundAdd ({ auctionInfo, bestNumber, className, leasePeriod, ownedIds }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const ranges = useRanges();
+  const ranges = useLeaseRanges();
   const [{ accountId, paraId }, setOwnerInfo] = useState<OwnerInfo>(EMPTY_OWNER);
   const [cap, setCap] = useState<BN | undefined>();
   const [endBlock, setEndBlock] = useState<BN | undefined>();

--- a/packages/page-parachains/src/useLeaseRanges.ts
+++ b/packages/page-parachains/src/useLeaseRanges.ts
@@ -3,6 +3,7 @@
 
 import type { u32 } from '@polkadot/types';
 
+import BN from 'bn.js';
 import { useMemo } from 'react';
 
 import { useApi } from '@polkadot/react-hooks';
@@ -18,7 +19,7 @@ function isU32 (leasePeriodsPerSlot: unknown): leasePeriodsPerSlot is u32 {
   return !!leasePeriodsPerSlot;
 }
 
-export default function useRanges (): [number, number][] {
+export function useLeaseRanges (): [number, number][] {
   const { api } = useApi();
 
   return useMemo(
@@ -38,5 +39,14 @@ export default function useRanges (): [number, number][] {
       return RANGES_DEFAULT;
     },
     [api]
+  );
+}
+
+export function useLeaseRangeMax (): BN {
+  const ranges = useLeaseRanges();
+
+  return useMemo(
+    () => new BN(ranges[ranges.length - 1][1] - ranges[0][0]),
+    [ranges]
   );
 }

--- a/packages/page-parachains/src/useLeaseRanges.ts
+++ b/packages/page-parachains/src/useLeaseRanges.ts
@@ -46,7 +46,7 @@ export function useLeaseRangeMax (): BN {
   const ranges = useLeaseRanges();
 
   return useMemo(
-    () => new BN(ranges[ranges.length - 1][1] - ranges[0][0]),
+    () => new BN(ranges[ranges.length - 1][1]),
     [ranges]
   );
 }

--- a/packages/page-parachains/src/useWinningData.ts
+++ b/packages/page-parachains/src/useWinningData.ts
@@ -12,7 +12,7 @@ import { useApi, useBestNumber, useCall, useEventTrigger } from '@polkadot/react
 import { BN_ONE, BN_ZERO, u8aEq } from '@polkadot/util';
 
 import { CROWD_PREFIX } from './constants';
-import useRanges from './useRanges';
+import { useLeaseRanges } from './useLeaseRanges';
 
 const FIRST_PARAM = [0];
 
@@ -123,7 +123,7 @@ function mergeFirst (ranges: [number, number][], auctionInfo: AuctionInfo, prev:
 
 export default function useWinningData (auctionInfo?: AuctionInfo): Winning[] | undefined {
   const { api } = useApi();
-  const ranges = useRanges();
+  const ranges = useLeaseRanges();
   const [result, setResult] = useState<Winning[] | undefined>();
   const bestNumber = useBestNumber();
   const trigger = useEventTrigger([api.events.auctions?.BidAccepted]);


### PR DESCRIPTION
We still had left-over hardcoded start + 3 for the ranges, correct these.

Also closes https://github.com/polkadot-js/apps/issues/5501