### PR TITLE
Fix Payouts -> My Validators toggle on page refresh

### DIFF
--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -1,0 +1,67 @@
+// Copyright 2017-2021 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {ApiPromise} from '@polkadot/api';
+import i18next from '@polkadot/react-components/i18n';
+import {createAugmentedApi} from '@polkadot/test-support/api';
+import {mockHooks} from '@polkadot/test-support/hooks/mockHooks';
+import {MemoryStore} from '@polkadot/test-support/keyring';
+import {keyring} from '@polkadot/ui-keyring';
+
+import {PayoutsPage} from '../../test/pages/payoutsPage';
+
+jest.mock('@polkadot/react-hooks/useTreasury', () => ({
+  useTreasury: () => mockHooks.treasury
+}));
+
+jest.mock('@polkadot/react-hooks/useMembers', () => ({
+  useMembers: () => mockHooks.members
+}));
+
+jest.mock('@polkadot/react-hooks/useBlockTime', () => ({
+  useBlockTime: () => mockHooks.blockTime
+}));
+
+let augmentedApi: ApiPromise;
+
+describe('Payouts', () => {
+  let payoutsPage: PayoutsPage;
+
+  beforeAll(async () => {
+    await i18next.changeLanguage('en');
+    keyring.loadAll({isDevelopment: true, store: new MemoryStore()});
+    augmentedApi = createAugmentedApi();
+  });
+
+  beforeEach(() => {
+    payoutsPage = new PayoutsPage(augmentedApi);
+  });
+
+  describe('empty view', () => {
+    it('renders `My validators/stashes` toggle', async () => {
+      payoutsPage.renderMany();
+
+      await payoutsPage.expectText('My validators');
+      await payoutsPage.expectText('My stashes');
+    });
+
+    it('when no own validators, then `My validators` is disabled and `My stashes` selected', async () => {
+      payoutsPage.renderMany();
+
+      await payoutsPage.expectMyValidators({isDisabled: true, isSelected: false});
+    });
+
+    it('when some own validators, then `My validators` is enabled and selected', async () => {
+      payoutsPage.renderMany();
+
+      await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
+    });
+
+    it('when some own validators, but after accounts load and rerender, then `My validators` is selected',
+      async () => {
+        payoutsPage.renderMany();
+
+        await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
+    });
+  });
+});

--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -1,14 +1,13 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {ApiPromise} from '@polkadot/api';
 import i18next from '@polkadot/react-components/i18n';
-import {createAugmentedApi} from '@polkadot/test-support/api';
 import {mockHooks} from '@polkadot/test-support/hooks/mockHooks';
 import {MemoryStore} from '@polkadot/test-support/keyring';
 import {keyring} from '@polkadot/ui-keyring';
 
 import {PayoutsPage} from '../../test/pages/payoutsPage';
+import {StakerState} from "@polkadot/react-hooks/types";
 
 jest.mock('@polkadot/react-hooks/useTreasury', () => ({
   useTreasury: () => mockHooks.treasury
@@ -22,46 +21,56 @@ jest.mock('@polkadot/react-hooks/useBlockTime', () => ({
   useBlockTime: () => mockHooks.blockTime
 }));
 
-let augmentedApi: ApiPromise;
-
 describe('Payouts', () => {
   let payoutsPage: PayoutsPage;
+  const someOwnedValidator: StakerState = {
+    controllerId: 'someId',
+    hexSessionIdNext: '0x1112',
+    hexSessionIdQueue: 'sth',
+    isLoading: false,
+    isOwnController: false,
+    isOwnStash: false,
+    isStashNominating: false,
+    isStashValidating: false,
+    sessionIds: [],
+    stashId: 'someStashId'
+  }
 
   beforeAll(async () => {
     await i18next.changeLanguage('en');
     keyring.loadAll({isDevelopment: true, store: new MemoryStore()});
-    augmentedApi = createAugmentedApi();
   });
 
   beforeEach(() => {
-    payoutsPage = new PayoutsPage(augmentedApi);
+    payoutsPage = new PayoutsPage();
   });
 
   describe('empty view', () => {
     it('renders `My validators/stashes` toggle', async () => {
-      payoutsPage.renderMany();
+      payoutsPage.renderPage();
 
       await payoutsPage.expectText('My validators');
       await payoutsPage.expectText('My stashes');
     });
 
     it('when no own validators, then `My validators` is disabled and `My stashes` selected', async () => {
-      payoutsPage.renderMany();
+      payoutsPage.renderPage();
 
       await payoutsPage.expectMyValidators({isDisabled: true, isSelected: false});
     });
 
     it('when some own validators, then `My validators` is enabled and selected', async () => {
-      payoutsPage.renderMany();
+      payoutsPage.renderPage([someOwnedValidator]);
 
       await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
     });
 
     it('when some own validators, but after accounts load and rerender, then `My validators` is selected',
       async () => {
-        payoutsPage.renderMany();
-
+        payoutsPage.renderPage();
+        await payoutsPage.expectMyValidators({isDisabled: true, isSelected: false});
+        payoutsPage.renderPage([someOwnedValidator])
         await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
-    });
+      });
   });
 });

--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {PayoutsPage} from '../../test/pages/payoutsPage';
-import {StakerState} from "@polkadot/react-hooks/types";
+import { StakerState } from '@polkadot/react-hooks/types';
+
+import { PayoutsPage } from '../../test/pages/payoutsPage';
 
 describe('Payouts', () => {
   let payoutsPage: PayoutsPage;
@@ -17,7 +18,7 @@ describe('Payouts', () => {
     isStashValidating: false,
     sessionIds: [],
     stashId: 'someStashId'
-  }
+  };
 
   beforeEach(() => {
     payoutsPage = new PayoutsPage();
@@ -34,21 +35,21 @@ describe('Payouts', () => {
     it('when no own validators, then `My validators` is disabled and `My stashes` selected', async () => {
       payoutsPage.renderPage();
 
-      await payoutsPage.expectMyValidators({isDisabled: true, isSelected: false});
+      await payoutsPage.expectMyValidators({ isDisabled: true, isSelected: false });
     });
 
     it('when some own validators, then `My validators` is enabled and selected', async () => {
       payoutsPage.renderPage([someOwnedValidator]);
 
-      await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
+      await payoutsPage.expectMyValidators({ isDisabled: false, isSelected: true });
     });
 
     it('when some own validators, but after accounts load and rerender, then `My validators` is selected',
       async () => {
         payoutsPage.renderPage();
-        await payoutsPage.expectMyValidators({isDisabled: true, isSelected: false});
-        payoutsPage.renderPage([someOwnedValidator])
-        await payoutsPage.expectMyValidators({isDisabled: false, isSelected: true});
+        await payoutsPage.expectMyValidators({ isDisabled: true, isSelected: false });
+        payoutsPage.renderPage([someOwnedValidator]);
+        await payoutsPage.expectMyValidators({ isDisabled: false, isSelected: true });
       });
   });
 });

--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -1,25 +1,8 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import i18next from '@polkadot/react-components/i18n';
-import {mockHooks} from '@polkadot/test-support/hooks/mockHooks';
-import {MemoryStore} from '@polkadot/test-support/keyring';
-import {keyring} from '@polkadot/ui-keyring';
-
 import {PayoutsPage} from '../../test/pages/payoutsPage';
 import {StakerState} from "@polkadot/react-hooks/types";
-
-jest.mock('@polkadot/react-hooks/useTreasury', () => ({
-  useTreasury: () => mockHooks.treasury
-}));
-
-jest.mock('@polkadot/react-hooks/useMembers', () => ({
-  useMembers: () => mockHooks.members
-}));
-
-jest.mock('@polkadot/react-hooks/useBlockTime', () => ({
-  useBlockTime: () => mockHooks.blockTime
-}));
 
 describe('Payouts', () => {
   let payoutsPage: PayoutsPage;
@@ -35,11 +18,6 @@ describe('Payouts', () => {
     sessionIds: [],
     stashId: 'someStashId'
   }
-
-  beforeAll(async () => {
-    await i18next.changeLanguage('en');
-    keyring.loadAll({isDevelopment: true, store: new MemoryStore()});
-  });
 
   beforeEach(() => {
     payoutsPage = new PayoutsPage();

--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -32,7 +32,7 @@ describe('Payouts', () => {
       await payoutsPage.expectText('My stashes');
     });
 
-    it('when no own validators, then `My validators` is disabled and `My stashes` selected', async () => {
+    it('when no own validators, then `My validators` is disabled and not selected, async () => {
       payoutsPage.renderPage();
 
       await payoutsPage.expectMyValidators({ isDisabled: true, isSelected: false });

--- a/packages/page-staking/src/Payouts/index.spec.ts
+++ b/packages/page-staking/src/Payouts/index.spec.ts
@@ -32,7 +32,7 @@ describe('Payouts', () => {
       await payoutsPage.expectText('My stashes');
     });
 
-    it('when no own validators, then `My validators` is disabled and not selected, async () => {
+    it('when no own validators, then `My validators` is disabled and not selected', async () => {
       payoutsPage.renderPage();
 
       await payoutsPage.expectMyValidators({ isDisabled: true, isSelected: false });

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -7,7 +7,7 @@ import type { StakerState } from '@polkadot/react-hooks/types';
 import type { PayoutStash, PayoutValidator } from './types';
 
 import BN from 'bn.js';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { ApiPromise } from '@polkadot/api';
@@ -150,7 +150,7 @@ function getOptions (api: ApiPromise, eraLength: BN | undefined, historyDepth: B
   return [{ text: '', value: 0 }];
 }
 
-function getMyStashesIndex(api: ApiPromise, hasOwnValidators: boolean) {
+function getMyStashesIndex (api: ApiPromise, hasOwnValidators: boolean) {
   return (isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1;
 }
 
@@ -159,9 +159,10 @@ function Payouts ({ className = '', isInElection, ownValidators }: Props): React
   const { api } = useApi();
   const hasOwnValidators = useMemo(() => ownValidators.length !== 0, [ownValidators]);
   const [myStashesIndex, setMyStashesIndex] = useState(() => getMyStashesIndex(api, hasOwnValidators));
+
   useEffect(() => {
     setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
-  }, [hasOwnValidators]);
+  }, [api, hasOwnValidators]);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
   const eraLength = useCall<BN>(api.derive.session.eraLength);
   const historyDepth = useCall<BN>(api.query.staking.historyDepth);

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -157,11 +157,11 @@ function getMyStashesIndex(api: ApiPromise, hasOwnValidators: boolean) {
 function Payouts ({ className = '', isInElection, ownValidators }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const hasOwnValidators = useMemo(() => ownValidators.length !== 0, [ownValidators]);
+  const [hasOwnValidators] = useState(() => ownValidators.length !== 0);
   const [myStashesIndex, setMyStashesIndex] = useState(() => getMyStashesIndex(api, hasOwnValidators));
-  useEffect(() => {
-    setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
-  }, [hasOwnValidators]);
+  // useEffect(() => {
+  //   setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
+  // }, [hasOwnValidators]);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
   const eraLength = useCall<BN>(api.derive.session.eraLength);
   const historyDepth = useCall<BN>(api.query.staking.historyDepth);

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -7,7 +7,7 @@ import type { StakerState } from '@polkadot/react-hooks/types';
 import type { PayoutStash, PayoutValidator } from './types';
 
 import BN from 'bn.js';
-import React, { useMemo, useRef, useState } from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import styled from 'styled-components';
 
 import { ApiPromise } from '@polkadot/api';
@@ -153,8 +153,11 @@ function getOptions (api: ApiPromise, eraLength: BN | undefined, historyDepth: B
 function Payouts ({ className = '', isInElection, ownValidators }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const [hasOwnValidators] = useState(() => ownValidators.length !== 0);
+  const hasOwnValidators = useMemo(() => ownValidators.length !== 0, [ownValidators]);
   const [myStashesIndex, setMyStashesIndex] = useState(() => (isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1);
+  useEffect(() => {
+    setMyStashesIndex((isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1);
+  }, [hasOwnValidators]);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
   const eraLength = useCall<BN>(api.derive.session.eraLength);
   const historyDepth = useCall<BN>(api.query.staking.historyDepth);

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -150,13 +150,17 @@ function getOptions (api: ApiPromise, eraLength: BN | undefined, historyDepth: B
   return [{ text: '', value: 0 }];
 }
 
+function getMyStashesIndex(api: ApiPromise, hasOwnValidators: boolean) {
+  return (isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1;
+}
+
 function Payouts ({ className = '', isInElection, ownValidators }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const hasOwnValidators = useMemo(() => ownValidators.length !== 0, [ownValidators]);
-  const [myStashesIndex, setMyStashesIndex] = useState(() => (isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1);
+  const [myStashesIndex, setMyStashesIndex] = useState(() => getMyStashesIndex(api, hasOwnValidators));
   useEffect(() => {
-    setMyStashesIndex((isFunction(api.tx.staking.payoutStakers) && hasOwnValidators) ? 0 : 1);
+    setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
   }, [hasOwnValidators]);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
   const eraLength = useCall<BN>(api.derive.session.eraLength);

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -157,11 +157,11 @@ function getMyStashesIndex(api: ApiPromise, hasOwnValidators: boolean) {
 function Payouts ({ className = '', isInElection, ownValidators }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const [hasOwnValidators] = useState(() => ownValidators.length !== 0);
+  const hasOwnValidators = useMemo(() => ownValidators.length !== 0, [ownValidators]);
   const [myStashesIndex, setMyStashesIndex] = useState(() => getMyStashesIndex(api, hasOwnValidators));
-  // useEffect(() => {
-  //   setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
-  // }, [hasOwnValidators]);
+  useEffect(() => {
+    setMyStashesIndex(getMyStashesIndex(api, hasOwnValidators));
+  }, [hasOwnValidators]);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
   const eraLength = useCall<BN>(api.derive.session.eraLength);
   const historyDepth = useCall<BN>(api.query.staking.historyDepth);

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -52,7 +52,6 @@ export class PayoutsPage {
             }
           }
         },
-        //registry: { chainDecimals: [12], chainTokens: ['Unit'] },
         tx: {
           staking: {
             payoutStakers: () => {}

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -1,0 +1,172 @@
+// Copyright 2017-2021 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+
+import { ApiPromise } from '@polkadot/api';
+import { DeriveCollectiveProposal } from '@polkadot/api-derive/types';
+import { BountyApi } from '@polkadot/app-bounties/hooks';
+import { lightTheme } from '@polkadot/apps/themes';
+import { POLKADOT_GENESIS } from '@polkadot/apps-config';
+import { ApiContext } from '@polkadot/react-api';
+import { ApiProps } from '@polkadot/react-api/types';
+import { QueueProvider } from '@polkadot/react-components/Status/Context';
+import { PartialQueueTxExtrinsic, QueueProps, QueueTxExtrinsicAdd } from '@polkadot/react-components/Status/types';
+import { BountyFactory } from '@polkadot/test-support/creation/bounties/bountyFactory';
+import { TypeRegistry } from '@polkadot/types/create';
+import { Bounty, BountyIndex, BountyStatus } from '@polkadot/types/interfaces';
+
+import Payouts from '@polkadot/app-staking/Payouts';
+import BN from "bn.js";
+import registry from "@polkadot/react-api/typeRegistry";
+
+function aGenesisHash () {
+  return new TypeRegistry().createType('Hash', POLKADOT_GENESIS);
+}
+
+type FindOne = (match: string) => Promise<HTMLElement>;
+type FindManyWithMatcher = (match: string | ((match: string) => boolean)) => Promise<HTMLElement[]>
+type GetMany = (match: string) => HTMLElement[];
+
+class NotYetRendered extends Error {
+
+}
+
+let queueExtrinsic: (value: PartialQueueTxExtrinsic) => void;
+const propose = jest.fn().mockReturnValue('mockProposeExtrinsic');
+
+interface RenderedPayoutsPage {
+  findAllByTestId: FindManyWithMatcher;
+  findByText: FindOne;
+  findByRole: FindOne;
+  findByTestId: FindOne;
+  getAllByRole: GetMany;
+  queryAllByText: GetMany;
+}
+
+export class PayoutsPage {
+  aBounty: ({ status, value }?: Partial<Bounty>) => Bounty;
+  aBountyIndex: (index?: number) => BountyIndex;
+  aBountyStatus: (status: string) => BountyStatus;
+  bountyStatusWith: ({ curator, status }: { curator?: string, status?: string, }) => BountyStatus;
+  bountyWith: ({ status, value }: { status?: string, value?: number }) => Bounty;
+
+  findByRole?: FindOne;
+  findByText?: FindOne;
+  findByTestId?: FindOne;
+  getAllByRole?: GetMany;
+  findAllByTestId?: FindManyWithMatcher;
+  queryAllByText?: GetMany;
+
+  constructor (api: ApiPromise) {
+    ({ aBounty: this.aBounty, aBountyIndex: this.aBountyIndex, aBountyStatus: this.aBountyStatus, bountyStatusWith: this.bountyStatusWith, bountyWith: this.bountyWith } = new BountyFactory(api));
+  }
+
+  renderOne (bounty: Bounty, proposals: DeriveCollectiveProposal[] = [], description = '', index = this.aBountyIndex()): RenderedPayoutsPage {
+    return this.renderMany({ bounties: [{ bounty, description, index, proposals }] });
+  }
+
+  renderMany (bountyApi: Partial<BountyApi> = {}, { balance = 1 } = {}): RenderedPayoutsPage {
+    const { findAllByTestId, findByRole, findByTestId, findByText, getAllByRole, queryAllByText } = this.renderPayouts();
+
+    this.findByRole = findByRole;
+    this.findByText = findByText;
+    this.findByTestId = findByTestId;
+    this.getAllByRole = getAllByRole;
+    this.findAllByTestId = findAllByTestId;
+    this.queryAllByText = queryAllByText;
+
+    return { findAllByTestId, findByRole, findByTestId, findByText, getAllByRole, queryAllByText };
+  }
+
+  private renderPayouts () {
+    const mockApi: ApiProps = {
+      api: {
+        consts: {
+          staking: {
+            maxNominatorRewardedPerValidator: registry.createType('u32', 16)
+          }
+        },
+        derive: {
+          accounts: {
+            info: () => Promise.resolve(() => { /**/
+            })
+          },
+          session: {
+            eraLength: () => new BN(1000)
+          }
+        },
+        genesisHash: aGenesisHash(),
+        query: {
+          staking: {
+            historyDepth: () => new BN(1),
+            bonded: {
+              multi: () => [],
+            },
+            ledger: {
+              multi: () => []
+            }
+          }
+        },
+        registry: { chainDecimals: [12], chainTokens: ['Unit'] },
+        tx: {
+          council: {
+            propose
+          },
+          staking: {
+            payoutStakers: () => {}
+          }
+        }
+      },
+      systemName: 'substrate'
+    } as unknown as ApiProps;
+
+    queueExtrinsic = jest.fn() as QueueTxExtrinsicAdd;
+    const queue = {
+      queueExtrinsic
+    } as QueueProps;
+
+    return render(
+      <>
+        <div id='tooltips'/>
+        <Suspense fallback='...'>
+          <QueueProvider value={queue}>
+            <MemoryRouter>
+              <ThemeProvider theme={lightTheme}>
+                <ApiContext.Provider value={mockApi}>
+                  <Payouts ownValidators={[]}/>
+                </ApiContext.Provider>
+              </ThemeProvider>
+            </MemoryRouter>
+          </QueueProvider>
+        </Suspense>
+      </>
+    );
+  }
+
+  private assertRendered (): asserts this is RenderedPayoutsPage {
+    if (this.findByText === undefined) {
+      throw new NotYetRendered();
+    }
+  }
+
+  async expectText (expected: string): Promise<void> {
+    this.assertRendered();
+    expect(await this.findByText(expected)).toBeTruthy();
+  }
+
+  async expectMyValidators (expected: {isDisabled: boolean, isSelected: boolean}): Promise<void> {
+    this.assertRendered();
+    const validators = await this.findByText('My validators') as HTMLButtonElement;
+    expect(validators).toBeVisible();
+
+    if (expected.isDisabled)
+      expect(validators.classList).toContain('isDisabled');
+
+    if (expected.isSelected)
+      expect(validators.classList).toContain('isSelected');
+  }
+}

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -106,8 +106,16 @@ export class PayoutsPage {
 
     expect(validators).toBeVisible();
 
-    if (expected.isDisabled) { expect(validators.classList).toContain('isDisabled'); }
+    if (expected.isDisabled) {
+      expect(validators).toHaveClass('isDisabled');
+    } else {
+      expect(validators).not.toHaveClass('isDisabled');
+    }
 
-    if (expected.isSelected) { expect(validators.classList).toContain('isSelected'); }
+    if (expected.isSelected) {
+      expect(validators).toHaveClass('isSelected');
+    } else {
+      expect(validators).not.toHaveClass('isSelected');
+    }
   }
 }

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -1,35 +1,27 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { render } from '@testing-library/react';
-import React, { Suspense } from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
+import {render,RenderResult} from '@testing-library/react';
+import React, {Suspense} from 'react';
+import {MemoryRouter} from 'react-router-dom';
+import {ThemeProvider} from 'styled-components';
 
-import { ApiPromise } from '@polkadot/api';
-import { DeriveCollectiveProposal } from '@polkadot/api-derive/types';
-import { BountyApi } from '@polkadot/app-bounties/hooks';
-import { lightTheme } from '@polkadot/apps/themes';
-import { POLKADOT_GENESIS } from '@polkadot/apps-config';
-import { ApiContext } from '@polkadot/react-api';
-import { ApiProps } from '@polkadot/react-api/types';
-import { QueueProvider } from '@polkadot/react-components/Status/Context';
-import { PartialQueueTxExtrinsic, QueueProps, QueueTxExtrinsicAdd } from '@polkadot/react-components/Status/types';
-import { BountyFactory } from '@polkadot/test-support/creation/bounties/bountyFactory';
-import { TypeRegistry } from '@polkadot/types/create';
-import { Bounty, BountyIndex, BountyStatus } from '@polkadot/types/interfaces';
+import {lightTheme} from '@polkadot/apps/themes';
+import {POLKADOT_GENESIS} from '@polkadot/apps-config';
+import {ApiContext} from '@polkadot/react-api';
+import {ApiProps} from '@polkadot/react-api/types';
+import {QueueProvider} from '@polkadot/react-components/Status/Context';
+import {PartialQueueTxExtrinsic, QueueProps, QueueTxExtrinsicAdd} from '@polkadot/react-components/Status/types';
+import {TypeRegistry} from '@polkadot/types/create';
 
 import Payouts from '@polkadot/app-staking/Payouts';
 import BN from "bn.js";
 import registry from "@polkadot/react-api/typeRegistry";
+import {StakerState} from "@polkadot/react-hooks/types";
 
 function aGenesisHash () {
   return new TypeRegistry().createType('Hash', POLKADOT_GENESIS);
 }
-
-type FindOne = (match: string) => Promise<HTMLElement>;
-type FindManyWithMatcher = (match: string | ((match: string) => boolean)) => Promise<HTMLElement[]>
-type GetMany = (match: string) => HTMLElement[];
 
 class NotYetRendered extends Error {
 
@@ -38,51 +30,14 @@ class NotYetRendered extends Error {
 let queueExtrinsic: (value: PartialQueueTxExtrinsic) => void;
 const propose = jest.fn().mockReturnValue('mockProposeExtrinsic');
 
-interface RenderedPayoutsPage {
-  findAllByTestId: FindManyWithMatcher;
-  findByText: FindOne;
-  findByRole: FindOne;
-  findByTestId: FindOne;
-  getAllByRole: GetMany;
-  queryAllByText: GetMany;
-}
-
 export class PayoutsPage {
-  aBounty: ({ status, value }?: Partial<Bounty>) => Bounty;
-  aBountyIndex: (index?: number) => BountyIndex;
-  aBountyStatus: (status: string) => BountyStatus;
-  bountyStatusWith: ({ curator, status }: { curator?: string, status?: string, }) => BountyStatus;
-  bountyWith: ({ status, value }: { status?: string, value?: number }) => Bounty;
+  renderResult?: RenderResult;
 
-  findByRole?: FindOne;
-  findByText?: FindOne;
-  findByTestId?: FindOne;
-  getAllByRole?: GetMany;
-  findAllByTestId?: FindManyWithMatcher;
-  queryAllByText?: GetMany;
-
-  constructor (api: ApiPromise) {
-    ({ aBounty: this.aBounty, aBountyIndex: this.aBountyIndex, aBountyStatus: this.aBountyStatus, bountyStatusWith: this.bountyStatusWith, bountyWith: this.bountyWith } = new BountyFactory(api));
+  renderPage (ownValidators: StakerState[] = []) {
+    this.renderPayouts(ownValidators);
   }
 
-  renderOne (bounty: Bounty, proposals: DeriveCollectiveProposal[] = [], description = '', index = this.aBountyIndex()): RenderedPayoutsPage {
-    return this.renderMany({ bounties: [{ bounty, description, index, proposals }] });
-  }
-
-  renderMany (bountyApi: Partial<BountyApi> = {}, { balance = 1 } = {}): RenderedPayoutsPage {
-    const { findAllByTestId, findByRole, findByTestId, findByText, getAllByRole, queryAllByText } = this.renderPayouts();
-
-    this.findByRole = findByRole;
-    this.findByText = findByText;
-    this.findByTestId = findByTestId;
-    this.getAllByRole = getAllByRole;
-    this.findAllByTestId = findAllByTestId;
-    this.queryAllByText = queryAllByText;
-
-    return { findAllByTestId, findByRole, findByTestId, findByText, getAllByRole, queryAllByText };
-  }
-
-  private renderPayouts () {
+  private renderPayouts (ownValidators: StakerState[]) {
     const mockApi: ApiProps = {
       api: {
         consts: {
@@ -129,38 +84,46 @@ export class PayoutsPage {
       queueExtrinsic
     } as QueueProps;
 
-    return render(
-      <>
-        <div id='tooltips'/>
-        <Suspense fallback='...'>
-          <QueueProvider value={queue}>
-            <MemoryRouter>
-              <ThemeProvider theme={lightTheme}>
-                <ApiContext.Provider value={mockApi}>
-                  <Payouts ownValidators={[]}/>
-                </ApiContext.Provider>
-              </ThemeProvider>
-            </MemoryRouter>
-          </QueueProvider>
-        </Suspense>
-      </>
-    );
+    let content = <>
+      <div id='tooltips'/>
+      <Suspense fallback='...'>
+        <QueueProvider value={queue}>
+          <MemoryRouter>
+            <ThemeProvider theme={lightTheme}>
+              <ApiContext.Provider value={mockApi}>
+                <Payouts ownValidators={ownValidators}/>
+              </ApiContext.Provider>
+            </ThemeProvider>
+          </MemoryRouter>
+        </QueueProvider>
+      </Suspense>
+    </>;
+
+    if (!this.hasBeenRendered()) {
+      this.renderResult = render(content);
+    } else {
+      this.renderResult!.rerender(content);
+    }
   }
 
-  private assertRendered (): asserts this is RenderedPayoutsPage {
-    if (this.findByText === undefined) {
+  private hasBeenRendered () {
+    return this.renderResult !== undefined;
+  }
+
+  private assertRendered () {
+    if (!this.hasBeenRendered()) {
       throw new NotYetRendered();
     }
   }
 
   async expectText (expected: string): Promise<void> {
     this.assertRendered();
-    expect(await this.findByText(expected)).toBeTruthy();
+    expect(await this.renderResult!.findByText(expected)).toBeTruthy();
   }
 
   async expectMyValidators (expected: {isDisabled: boolean, isSelected: boolean}): Promise<void> {
     this.assertRendered();
-    const validators = await this.findByText('My validators') as HTMLButtonElement;
+    const validators = await this.renderResult!.findByText('My validators') as HTMLButtonElement;
     expect(validators).toBeVisible();
 
     if (expected.isDisabled)

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -21,11 +21,7 @@ class NotYetRendered extends Error {}
 export class PayoutsPage {
   renderResult?: RenderResult;
 
-  renderPage (ownValidators: StakerState[] = []) {
-    this.renderPayouts(ownValidators);
-  }
-
-  private renderPayouts (ownValidators: StakerState[]) {
+  renderPage (ownValidators: StakerState[] = []): void {
     const mockApi: ApiProps = {
       api: {
         consts: {
@@ -36,7 +32,8 @@ export class PayoutsPage {
         derive: {
           accounts: {
             info: () => {
-              return Promise.resolve(() => { /**/ });
+              return Promise.resolve(() => { /**/
+              });
             }
           },
           session: {
@@ -56,7 +53,8 @@ export class PayoutsPage {
         },
         tx: {
           staking: {
-            payoutStakers: () => { /**/ }
+            payoutStakers: () => { /**/
+            }
           }
         }
       },

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -81,15 +81,15 @@ export class PayoutsPage {
     if (!this.hasBeenRendered()) {
       this.renderResult = render(content);
     } else {
-      this.renderResult?.rerender(content);
+      this.renderResult.rerender(content);
     }
   }
 
-  private hasBeenRendered () {
+  private hasBeenRendered (): this is { renderResult: RenderResult; } {
     return this.renderResult !== undefined;
   }
 
-  private assertRendered () {
+  private assertRendered (): asserts this is { renderResult: RenderResult; } {
     if (!this.hasBeenRendered()) {
       throw new NotYetRendered();
     }

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -1,20 +1,20 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {render,RenderResult} from '@testing-library/react';
-import React, {Suspense} from 'react';
-import {MemoryRouter} from 'react-router-dom';
-import {ThemeProvider} from 'styled-components';
-import BN from "bn.js";
+import { render, RenderResult } from '@testing-library/react';
+import BN from 'bn.js';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
 
-import {lightTheme} from '@polkadot/apps/themes';
-import {ApiContext} from '@polkadot/react-api';
-import {ApiProps} from '@polkadot/react-api/types';
-import {QueueProvider} from '@polkadot/react-components/Status/Context';
-import {QueueProps, QueueTxExtrinsicAdd} from '@polkadot/react-components/Status/types';
 import Payouts from '@polkadot/app-staking/Payouts';
-import registry from "@polkadot/react-api/typeRegistry";
-import {StakerState} from "@polkadot/react-hooks/types";
+import { lightTheme } from '@polkadot/apps/themes';
+import { ApiContext } from '@polkadot/react-api';
+import registry from '@polkadot/react-api/typeRegistry';
+import { ApiProps } from '@polkadot/react-api/types';
+import { QueueProvider } from '@polkadot/react-components/Status/Context';
+import { QueueProps, QueueTxExtrinsicAdd } from '@polkadot/react-components/Status/types';
+import { StakerState } from '@polkadot/react-hooks/types';
 
 class NotYetRendered extends Error {}
 
@@ -35,7 +35,9 @@ export class PayoutsPage {
         },
         derive: {
           accounts: {
-            info: () => Promise.resolve(() => {})
+            info: () => {
+              return Promise.resolve(() => { /**/ });
+            }
           },
           session: {
             eraLength: () => new BN(1000)
@@ -43,10 +45,10 @@ export class PayoutsPage {
         },
         query: {
           staking: {
-            historyDepth: () => new BN(1),
             bonded: {
-              multi: () => [],
+              multi: () => []
             },
+            historyDepth: () => new BN(1),
             ledger: {
               multi: () => []
             }
@@ -54,16 +56,16 @@ export class PayoutsPage {
         },
         tx: {
           staking: {
-            payoutStakers: () => {}
+            payoutStakers: () => { /**/ }
           }
         }
       },
       systemName: 'substrate'
     } as unknown as ApiProps;
 
-    const queue = {queueExtrinsic: jest.fn() as QueueTxExtrinsicAdd} as QueueProps;
+    const queue = { queueExtrinsic: jest.fn() as QueueTxExtrinsicAdd } as QueueProps;
 
-    let content = <>
+    const content = <>
       <div id='tooltips'/>
       <Suspense fallback='...'>
         <QueueProvider value={queue}>
@@ -81,7 +83,7 @@ export class PayoutsPage {
     if (!this.hasBeenRendered()) {
       this.renderResult = render(content);
     } else {
-      this.renderResult!.rerender(content);
+      this.renderResult?.rerender(content);
     }
   }
 
@@ -97,18 +99,17 @@ export class PayoutsPage {
 
   async expectText (expected: string): Promise<void> {
     this.assertRendered();
-    expect(await this.renderResult!.findByText(expected)).toBeTruthy();
+    expect(await this.renderResult?.findByText(expected)).toBeTruthy();
   }
 
   async expectMyValidators (expected: {isDisabled: boolean, isSelected: boolean}): Promise<void> {
     this.assertRendered();
-    const validators = await this.renderResult!.findByText('My validators') as HTMLButtonElement;
+    const validators = await this.renderResult?.findByText('My validators') as HTMLButtonElement;
+
     expect(validators).toBeVisible();
 
-    if (expected.isDisabled)
-      expect(validators.classList).toContain('isDisabled');
+    if (expected.isDisabled) { expect(validators.classList).toContain('isDisabled'); }
 
-    if (expected.isSelected)
-      expect(validators.classList).toContain('isSelected');
+    if (expected.isSelected) { expect(validators.classList).toContain('isSelected'); }
   }
 }

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -5,30 +5,18 @@ import {render,RenderResult} from '@testing-library/react';
 import React, {Suspense} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import {ThemeProvider} from 'styled-components';
+import BN from "bn.js";
 
 import {lightTheme} from '@polkadot/apps/themes';
-import {POLKADOT_GENESIS} from '@polkadot/apps-config';
 import {ApiContext} from '@polkadot/react-api';
 import {ApiProps} from '@polkadot/react-api/types';
 import {QueueProvider} from '@polkadot/react-components/Status/Context';
-import {PartialQueueTxExtrinsic, QueueProps, QueueTxExtrinsicAdd} from '@polkadot/react-components/Status/types';
-import {TypeRegistry} from '@polkadot/types/create';
-
+import {QueueProps, QueueTxExtrinsicAdd} from '@polkadot/react-components/Status/types';
 import Payouts from '@polkadot/app-staking/Payouts';
-import BN from "bn.js";
 import registry from "@polkadot/react-api/typeRegistry";
 import {StakerState} from "@polkadot/react-hooks/types";
 
-function aGenesisHash () {
-  return new TypeRegistry().createType('Hash', POLKADOT_GENESIS);
-}
-
-class NotYetRendered extends Error {
-
-}
-
-let queueExtrinsic: (value: PartialQueueTxExtrinsic) => void;
-const propose = jest.fn().mockReturnValue('mockProposeExtrinsic');
+class NotYetRendered extends Error {}
 
 export class PayoutsPage {
   renderResult?: RenderResult;
@@ -47,14 +35,12 @@ export class PayoutsPage {
         },
         derive: {
           accounts: {
-            info: () => Promise.resolve(() => { /**/
-            })
+            info: () => Promise.resolve(() => {})
           },
           session: {
             eraLength: () => new BN(1000)
           }
         },
-        genesisHash: aGenesisHash(),
         query: {
           staking: {
             historyDepth: () => new BN(1),
@@ -66,11 +52,8 @@ export class PayoutsPage {
             }
           }
         },
-        registry: { chainDecimals: [12], chainTokens: ['Unit'] },
+        //registry: { chainDecimals: [12], chainTokens: ['Unit'] },
         tx: {
-          council: {
-            propose
-          },
           staking: {
             payoutStakers: () => {}
           }
@@ -79,10 +62,7 @@ export class PayoutsPage {
       systemName: 'substrate'
     } as unknown as ApiProps;
 
-    queueExtrinsic = jest.fn() as QueueTxExtrinsicAdd;
-    const queue = {
-      queueExtrinsic
-    } as QueueProps;
+    const queue = {queueExtrinsic: jest.fn() as QueueTxExtrinsicAdd} as QueueProps;
 
     let content = <>
       <div id='tooltips'/>

--- a/packages/page-staking/test/pages/payoutsPage.tsx
+++ b/packages/page-staking/test/pages/payoutsPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, RenderResult } from '@testing-library/react';
+import { render, RenderResult, screen } from '@testing-library/react';
 import BN from 'bn.js';
 import React, { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -97,12 +97,12 @@ export class PayoutsPage {
 
   async expectText (expected: string): Promise<void> {
     this.assertRendered();
-    expect(await this.renderResult?.findByText(expected)).toBeTruthy();
+    expect(await screen.findByText(expected)).toBeTruthy();
   }
 
   async expectMyValidators (expected: {isDisabled: boolean, isSelected: boolean}): Promise<void> {
     this.assertRendered();
-    const validators = await this.renderResult?.findByText('My validators') as HTMLButtonElement;
+    const validators = await screen.findByText('My validators') as HTMLButtonElement;
 
     expect(validators).toBeVisible();
 


### PR DESCRIPTION
Before: after page refresh and before accounts were loaded
validators collection was empty which resulted in 'My validators'
being disabled.

Now: toggle accessibility relies upon validators refresh and not just
single initial assignment.