### PR TITLE
feat: add KILT to Westend

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -122,11 +122,10 @@ export function createKusama (t: TFunction): EndpointOption {
       {
         info: 'kilt',
         homepage: 'https://www.kilt.io/',
-        isUnreachable: true,
         paraId: 2005,
-        text: t('rpc.kusama.kilt', 'KILT Mainnet', { ns: 'apps-config' }),
+        text: t('rpc.kusama.kilt', 'KILT Spiritnet', { ns: 'apps-config' }),
         providers: {
-          'KILT Protocol': 'wss://mainnet.kilt.io/'
+          'KILT Protocol': 'wss://spiritnet.kilt.io/'
         }
       },
       {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -71,6 +71,15 @@ export function createWestend (t: TFunction): EndpointOption {
         }
       },
       {
+        info: 'kilt',
+        homepage: 'https://www.kilt.io/',
+        paraId: 2009,
+        text: t('rpc.kusama.kilt', 'WILT', { ns: 'apps-config' }),
+        providers: {
+          'KILT Protocol': 'wss://westend.kilt.io:9977'
+        }
+      },
+      {
         info: 'whala',
         paraId: 2013,
         text: t('rpc.westend.whala', 'Whala', { ns: 'apps-config' }),

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -74,7 +74,7 @@ export function createWestend (t: TFunction): EndpointOption {
         info: 'kilt',
         homepage: 'https://www.kilt.io/',
         paraId: 2009,
-        text: t('rpc.kusama.kilt', 'WILT', { ns: 'apps-config' }),
+        text: t('rpc.westend.kilt', 'WILT', { ns: 'apps-config' }),
         providers: {
           'KILT Protocol': 'wss://westend.kilt.io:9977'
         }


### PR DESCRIPTION
We want to test the KILT Spiritnet release candidate on Westend and will most likely be onboarded tomorrow. This PR
* Adds WILT to Westend 
* Renames KILT Mainnet to KILT Spiritnet
* Fixes unavailable WS address of Spiritnet to an available one