### PR TITLE
fix: logo and theme for KILT chains

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -145,6 +145,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'jupiter-rococo': jupiterRococo,
   khala: phalaParachain,
   'kilt-parachain': kilt,
+  'kilt-spiritnet': kilt,
   konomi,
   kulupu,
   kylin,

--- a/packages/apps-config/src/ui/colors.ts
+++ b/packages/apps-config/src/ui/colors.ts
@@ -44,7 +44,7 @@ const chainPolkaFoundry = '#ff527c';
 const chainPolkaSmith = '#0DDDFB';
 const chainPontem = '#A92FAC';
 const chainPrism = 'linear-gradient(45deg, rgba(63,94,251,1) 0%, rgba(252,70,107,1) 100%)';
-const chainKilt = '#8c175b';
+const chainKilt = '#5ab9aa';
 const chainKonomi = '#007aff';
 const chainKusama = '#000000';
 const chainKylin = '#ed007e';
@@ -183,7 +183,9 @@ export const chainColors: Record<string, string> = [
   ['Jupiter A1', chainJupiter],
   ['Jupiter PC1', chainJupiter],
   ['Karura', chainKarura],
-  ['KILT Collator Rococo', chainKilt],
+  ['KILT', chainKilt],
+  ['KILT Local', chainKilt],
+  ['KILT Peregrine Testnet', chainKilt],
   ['KILT Testnet', chainKilt],
   ['Kylin Testnet', chainKylin],
   ['Khala', chainKhala],
@@ -256,6 +258,7 @@ export const chainColors: Record<string, string> = [
   ['Westmint Test', specWestmint],
   ['Westlake', chainWestlake],
   ['Whala', chainWhala],
+  ['WILT', chainKilt],
   ['Zenlink PC1', chainZenlink],
   ['ZERO.IO', chainZero]
 ].reduce((colors, [chain, color]): Record<string, string> => ({

--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -151,7 +151,10 @@ export const chainLogos: Record<string, unknown> = [
   ['IpseTestnet', nodeIpse],
   ['Jupiter A1', nodeJupiter],
   ['Jupiter PC1', nodeJupiter],
-  ['KILT PC1', nodeKilt],
+  ['KILT', nodeKilt],
+  ['KILT Local', nodeKilt],
+  ['KILT Peregrine Testnet', nodeKilt],
+  ['KILT Testnet', nodeKilt],
   ['Karura', chainKarura],
   ['Konomi', nodeKonomi],
   ['Kusama', chainKusama], // new name after CC3
@@ -210,7 +213,8 @@ export const chainLogos: Record<string, unknown> = [
   ['Web3games', nodeWeb3games],
   ['Westlake', nodeWestlake],
   ['Westmint', nodeStatemine],
-  ['Westmint Test', nodeStatemine]
+  ['Westmint Test', nodeStatemine],
+  ['WILT', nodeKilt]
 ].reduce((logos, [chain, logo]): Record<string, unknown> => ({
   ...logos,
   [(chain as string).toLowerCase()]: logo
@@ -263,8 +267,9 @@ export const nodeLogos: Record<string, unknown> = [
   ['Idavoll Node', nodeIdavoll],
   ['Khala', nodeKhala],
   ['Khala Node', nodeKhala],
-  ['KILT Node', nodeKilt],
-  ['KILT Collator', nodeKilt],
+  ['KILT', nodeKilt],
+  ['KILT Local', nodeKilt],
+  ['KILT Peregrine Testnet', nodeKilt],
   ['Kylin Node', nodeKylin],
   ['kulupu', nodeKulupu],
   ['Klug Dossier Node', nodeKlug],
@@ -335,6 +340,7 @@ export const nodeLogos: Record<string, unknown> = [
   ['Westmint Collator', nodeStatemine],
   ['Whala', nodeWhala],
   ['Whala Node', nodeWhala],
+  ['WILT', nodeKilt],
   ['Zenlink', nodeZenlink],
   ['Zenlink Collator', nodeZenlink],
   ['Zeitgeist Node', nodeZeitgeist],


### PR DESCRIPTION
We recently updated all working titles of our different chain types and realized some of them were never supported in the Polkadot Apps in terms of styling.