### PR TITLE
Fix electron qr scan issue on mac

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,6 +10,8 @@ mac:
   artifactName: Polkadot-JS-Apps-mac-${version}.${ext}
   category: public.app-category.finance
   entitlements: "./packages/apps-electron/appleEntitlements/entitlements.mac.plist"
+  extendInfo:
+    NSCameraUsageDescription: "This app requires camera access to capture account data on imports"
   hardenedRuntime: true
 directories:
   buildResources: "./packages/apps-electron/assets"


### PR DESCRIPTION
Apple requires explicit ask for permissions be configured in Info.plist.

See: https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc

Notes for the reviewer:
1. Testing: to easily remove camera binding for Polka Desktop: 
`sudo tccutil reset Camera com.polkadotjs.polkadotjs-apps`
2. `yarn packElectron:mac` did not work for me unless I pinned electron-builder to some specific version, see: https://github.com/electron-userland/electron-builder/issues/5668