### PR TITLE
Fix electron QR camera permission on mac

### DIFF
--- a/packages/apps-electron/appleEntitlements/entitlements.mac.plist
+++ b/packages/apps-electron/appleEntitlements/entitlements.mac.plist
@@ -8,5 +8,7 @@
 		<true/>
 		<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 		<true/>
+		<key>com.apple.security.device.camera</key>
+		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
Another attempt. This time extending the set of entitlements in use.