### PR TITLE
Fix docker build script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:18.04 as builder
 
 # Install any needed packages
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y curl git gnupg
+  apt-get install --no-install-recommends -y curl git gnupg ca-certificates
 
 # install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install --no-install-recommends -y nodejs npm && \
+RUN apt-get install --no-install-recommends -y nodejs && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 RUN npm install yarn -g


### PR DESCRIPTION
The current Dockerfile script doesn't seem to be able to build successfully from the ground up. This PR fixes it:

* Install `ca-certificates`. Without it, it seems that every SSL requests would fail -- nodesource can't be fetched, npm can't install.
* Remove duplicate `nodejs` and `npm` package installation. `nodejs` comes from `nodesource` which includes the `npm` executable, and `npm` comes from Ubuntu. They conflict.