### PR TITLE
Fix provider name

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -157,7 +157,7 @@ export function createKusama (t: TFunction): EndpointOption {
         paraId: 2023,
         text: t('rpc.kusama.moonriver', 'Moonriver', { ns: 'apps-config' }),
         providers: {
-          Purestake: 'wss://wss.moonriver.moonbeam.network',
+          PureStake: 'wss://wss.moonriver.moonbeam.network',
           OnFinality: 'wss://moonriver.api.onfinality.io/public-ws'
         }
       },

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -67,7 +67,7 @@ export function createWestend (t: TFunction): EndpointOption {
         paraId: 2002,
         text: t('rpc.westend.moonshadow', 'Moonshadow', { ns: 'apps-config' }),
         providers: {
-          Purestake: 'wss://wss.moonshadow.testnet.moonbeam.network'
+          PureStake: 'wss://wss.moonshadow.testnet.moonbeam.network'
         }
       },
       {


### PR DESCRIPTION
Small fix on the provider name, from "Purestake" to "PureStake".