### PR TITLE
Re-enable Altair endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -46,7 +46,6 @@ export function createKusama (t: TFunction): EndpointOption {
       // NOTE: Added alphabetical based on chain name
       {
         info: 'altair',
-        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/5730
         homepage: 'https://centrifuge.io/altair',
         paraId: 2021,
         text: t('rpc.kusama.altair', 'Altair', { ns: 'apps-config' }),


### PR DESCRIPTION
The endpoint is now up (See https://polkadot.js.org/apps/?rpc=wss://fullnode.altair.centrifuge.io#/explorer), so this can be marked as online now.