### PR TITLE
Change parachain id of Zeitgeist

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -429,7 +429,7 @@ export function createRococo (t: TFunction): EndpointOption {
       },
       {
         info: 'rococoZeitgeist',
-        paraId: 2040,
+        paraId: 2049,
         text: t('rpc.rococo.zeitgeist', 'Zeitgeist PC', { ns: 'apps-config' }),
         providers: {
           Zeitgeist: 'wss://roc.zeitgeist.pm'


### PR DESCRIPTION
Had to de-register a parathread and as a consequence, the reserved parachain id was lost (it is not attached to my account anymore).

This PR reflects the new allocated ID.