### PR TITLE
chore: Update semgrep.yml with deployment id

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           auditOn: push
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: 1395
+          publishDeployment: ${{ secrets.SEMGREP_APP_DEPLOYMENT_ID }}


### PR DESCRIPTION
Some projects may use a fork of polkadot-js/apps. They cannot use deployment id 1395. They need to setup their own semgrep configuration that has a unique deployment id and token to pass CI checks. Suggest having the associated deployment id also stored in secrets of the Github repo. So for polkadot-js/apps an additional secret name of `SEMGREP_APP_DEPLOYMENT_ID ` with value of `1395` would be added to https://github.com/polkadot-js/apps/settings/secrets/actions, whilst those using a fork would create their own Semgrep name and api token here https://semgrep.dev/manage/settings and add it to their Github settings at https://github.com/<FORK_USER>/apps/settings/secrets/actions