### PR TITLE
Update Parachain ID of Zeitgeist

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -437,7 +437,7 @@ export function createRococo (t: TFunction): EndpointOption {
       },
       {
         info: 'rococoZeitgeist',
-        paraId: 2049,
+        paraId: 2050,
         text: t('rpc.rococo.zeitgeist', 'Zeitgeist PC', { ns: 'apps-config' }),
         providers: {
           Zeitgeist: 'wss://roc.zeitgeist.pm'


### PR DESCRIPTION
My apologies for the confusion. The last deployed WASM blob was non-deterministic due to the fact that the chain specification wasn't using a generated file and this situation could lead to bad future network updates.