### PR TITLE
Fix typo in ID translation

### DIFF
--- a/packages/apps/public/locales/id/translation.json
+++ b/packages/apps/public/locales/id/translation.json
@@ -363,7 +363,7 @@
   "Nominate validators": "Nominasi validator",
   "Nominating": "Nominasi",
   "Nominations ({{count}})": "Nominasi",
-  "Nominator": "Nominatir",
+  "Nominator": "Nominator",
   "Nominators ({{count}})": "Nominasi ({{count}})",
   "Nominators can be selected automatically based on the current on-chain conditions or supplied manually as selected from the list of all currently available validators. In both cases, your favorites appear for the selection.": "Nominator dapat dipilih secara otomatis berdasarkan kondisi on-chain saat ini atau disediakan secara manual sebagaimana dipilih dari daftar semua validator yang tersedia saat ini. Dalam kedua kasus tersebut, favorit anda muncul untuk pemilihan.",
   "Nominators can be selected manually from the list of all currently available validators.": "Nominator dapat dipilih secara manual dari daftar semua validator yang tersedia saat ini.",


### PR DESCRIPTION
"Nominator" is still "Nominator" in Bahasa Indonesia.