### PR TITLE
Add chain type to metadata

### DIFF
--- a/packages/page-settings/src/Metadata/NetworkSpecs.tsx
+++ b/packages/page-settings/src/Metadata/NetworkSpecs.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 // TODO-MOONBEAM: update NetworkSpecsStruct in @polkadot/ui-settings/types
 interface NetworkSpecsStructWithType extends NetworkSpecsStruct{
-  chainType:ChainType
+  chainType: ChainType
 }
 
 function getRandomColor (): string {
@@ -35,13 +35,13 @@ function getRandomColor (): string {
 }
 
 const initialState = {
+  chainType: 'substrate' as ChainType,
   color: '#FFFFFF',
   decimals: 0,
   genesisHash: '',
   prefix: 0,
   title: '',
-  unit: 'UNIT',
-  chainType:'substrate' as ChainType
+  unit: 'UNIT'
 };
 
 function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Props> {
@@ -65,13 +65,13 @@ function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Prop
 
   useEffect((): void => {
     chainInfo && setNetworkSpecs({
+      chainType: chainInfo.chainType,
       color: chainInfo.color || getRandomColor(),
       decimals: chainInfo.tokenDecimals,
       genesisHash: chainInfo.genesisHash,
       prefix: chainInfo.ss58Format,
       title: systemChain,
-      unit: chainInfo.tokenSymbol,
-      chainType:chainInfo.chainType
+      unit: chainInfo.tokenSymbol
     });
   }, [chainInfo, systemChain]);
 

--- a/packages/page-settings/src/Metadata/NetworkSpecs.tsx
+++ b/packages/page-settings/src/Metadata/NetworkSpecs.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { NetworkSpecsStruct } from '@polkadot/ui-settings/types';
-import type { ChainInfo } from '../types';
+import type { ChainInfo, ChainType } from '../types';
 
 import React, { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -16,6 +16,11 @@ import ChainColorIndicator from './ChainColorIndicator';
 interface Props {
   chainInfo: ChainInfo | null;
   className?: string;
+}
+
+// TODO-MOONBEAM: update NetworkSpecsStruct in @polkadot/ui-settings/types
+interface NetworkSpecsStructWithType extends NetworkSpecsStruct{
+  chainType:ChainType
 }
 
 function getRandomColor (): string {
@@ -35,16 +40,17 @@ const initialState = {
   genesisHash: '',
   prefix: 0,
   title: '',
-  unit: 'UNIT'
+  unit: 'UNIT',
+  chainType:'substrate' as ChainType
 };
 
 function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { isApiReady, systemChain } = useApi();
-  const [qrData, setQrData] = useState<NetworkSpecsStruct>(initialState);
+  const [qrData, setQrData] = useState<NetworkSpecsStructWithType>(initialState);
   const debouncedQrData = useDebounce(qrData, 500);
 
-  const reducer = (state: NetworkSpecsStruct, delta: Partial<NetworkSpecsStruct>): NetworkSpecsStruct => {
+  const reducer = (state: NetworkSpecsStructWithType, delta: Partial<NetworkSpecsStructWithType>): NetworkSpecsStructWithType => {
     const newState = {
       ...state,
       ...delta
@@ -64,7 +70,8 @@ function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Prop
       genesisHash: chainInfo.genesisHash,
       prefix: chainInfo.ss58Format,
       title: systemChain,
-      unit: chainInfo.tokenSymbol
+      unit: chainInfo.tokenSymbol,
+      chainType:chainInfo.chainType
     });
   }, [chainInfo, systemChain]);
 
@@ -188,6 +195,17 @@ function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Prop
             isDisabled
             label={t<string>('Decimals')}
             value={networkSpecs.decimals.toString()}
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <Input
+            className='full'
+            help={t<string>('Chain type (ethereum compatible or regular substrate)')}
+            isDisabled
+            label={t<string>('Chain Type')}
+            value={networkSpecs.chainType}
           />
         </td>
       </tr>

--- a/packages/page-settings/src/types.ts
+++ b/packages/page-settings/src/types.ts
@@ -3,7 +3,7 @@
 
 import type { MetadataDef } from '@polkadot/extension-inject/types';
 
-type ChainType = 'substrate' | 'ethereum';
+export type ChainType = 'substrate' | 'ethereum';
 
 export interface ChainInfo extends MetadataDef {
   color: string | undefined;


### PR DESCRIPTION
Both in the QR content and in the metadata UI.
Chaintype is either ethereum or substrate.
Necessary for the mobile app to create correct address type (as per paritytech/parity-signer#788)