### PR TITLE
Set Subscan link for Shiden Network

### DIFF
--- a/packages/apps-config/src/links/subscan.ts
+++ b/packages/apps-config/src/links/subscan.ts
@@ -24,6 +24,7 @@ export default {
     Plasm: 'plasm',
     Polkadot: 'polkadot',
     Rococo: 'rococo',
+    'Shiden Shell': 'shiden',
     Stafi: 'stafi',
     Westend: 'westend'
   },


### PR DESCRIPTION
**Description**

Just enable the link to Subscan for Shiden.
