### PR TITLE
Update types and endpoint for Snowbridge testnet

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -22,7 +22,7 @@
     "@phala/typedefs": "0.2.5",
     "@polkadot/networks": "^7.1.1",
     "@polymathnetwork/polymesh-types": "0.0.2",
-    "@snowfork/snowbridge-types": "0.2.3",
+    "@snowfork/snowbridge-types": "0.2.5",
     "@sora-substrate/type-definitions": "1.4.1",
     "@subsocial/types": "0.5.9-dev.2",
     "@zeitgeistpm/type-defs": "0.2.5",

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -371,6 +371,13 @@ export function createTesting (t: TFunction, firstOnly?: boolean): LinkOption[] 
       }
     },
     {
+      info: 'snowbridge',
+      text: t('rpc.test.snowbridge', 'Snowbridge', { ns: 'apps-config' }),
+      providers: {
+        Snowfork: 'wss://parachain-rpc.snowbridge.network'
+      }
+    },
+    {
       info: 'sora-substrate',
       text: t('rpc.test.sora-substrate-staging', 'SORA-staging', { ns: 'apps-config' }),
       providers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,7 +2589,7 @@ __metadata:
     "@phala/typedefs": 0.2.5
     "@polkadot/networks": ^7.1.1
     "@polymathnetwork/polymesh-types": 0.0.2
-    "@snowfork/snowbridge-types": 0.2.3
+    "@snowfork/snowbridge-types": 0.2.5
     "@sora-substrate/type-definitions": 1.4.1
     "@subsocial/types": 0.5.9-dev.2
     "@zeitgeistpm/type-defs": 0.2.5
@@ -3478,10 +3478,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowfork/snowbridge-types@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@snowfork/snowbridge-types@npm:0.2.3"
-  checksum: 52acef540aa695451153fdff1598f2cff79a5e093d5afc478b36c8a18e0f15303b82087c678b78de5e595e4cd16e671f374e8c961c15333b6abbb047162e41cf
+"@snowfork/snowbridge-types@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@snowfork/snowbridge-types@npm:0.2.5"
+  dependencies:
+    "@polkadot/keyring": ^7.1.1
+    "@polkadot/types": ^5.3.2
+  checksum: 3e0c7755a6d4ee2aeb331808a37b0ea29f573acf2094b024b1b2ea2395fadd95ef633b1ac135ca36eefa682f8d4f0c60e548178c6e538eb65691f2211c0433a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes:
* Update dependency `@snowfork/snowbridge-types` in `packages/apps-config`
* Add endpoint for our testnet: `wss://parachain-rpc.snowbridge.network`

The changes have been tested using a local build of PolkadotJS-Apps. No type decoding errors were seen in the console after running our E2E tests against the parachain.