### PR TITLE
Set width to flags

### DIFF
--- a/packages/page-accounts/src/Sidebar/Sidebar.tsx
+++ b/packages/page-accounts/src/Sidebar/Sidebar.tsx
@@ -248,9 +248,6 @@ export default React.memo(styled(FullSidebar)`
   .ui--AddressMenu-tags,
   .ui--AddressMenu-flags {
     margin: 0.75rem 0 0;
-  }
-
-  .ui--AddressMenu-tags {
     width: 100%;
   }
 


### PR DESCRIPTION
These changes will add `width: 100%;` to flags in sidebar.
![image](https://user-images.githubusercontent.com/55240109/129725332-6c9c3b11-80f3-4e58-a6e6-448dfaaa57b2.png)
