### PR TITLE
Remove default zero from transfer Input Balance

### DIFF
--- a/packages/page-accounts/src/modals/Transfer.tsx
+++ b/packages/page-accounts/src/modals/Transfer.tsx
@@ -156,6 +156,7 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
                 <>
                   <InputBalance
                     autoFocus
+                    defaultValue={''}
                     help={t<string>('Type the amount you want to transfer. Note that you can select the unit on the right e.g sending 1 milli is equivalent to sending 0.001.')}
                     isError={!hasAvailable}
                     isZeroable

--- a/packages/react-components/src/InputBalance.tsx
+++ b/packages/react-components/src/InputBalance.tsx
@@ -43,7 +43,7 @@ const DEFAULT_BITLENGTH = BitLengthOption.CHAIN_SPEC as BitLength;
 
 function reformat (value?: string | BN, isDisabled?: boolean, siDecimals?: number): [string?, SiDef?] {
   if (!value) {
-    return [];
+    return [value];
   }
 
   const decimals = isUndefined(siDecimals)


### PR DESCRIPTION
In response to https://github.com/polkadot-js/apps/issues/5667

This is what shows up after opening Transfer modal
Before:
![Screenshot from 2021-08-18 12-59-51](https://user-images.githubusercontent.com/22624476/129886918-0783b01d-bafe-4fde-b96a-14e8840b6429.png)
After:
![Screenshot from 2021-08-18 12-58-44](https://user-images.githubusercontent.com/22624476/129886824-704adcca-9312-44c9-a2e6-6c9cdec01373.png)
