### PR TITLE
Add max transfer bound to transfer modal

### DIFF
--- a/packages/page-accounts/src/modals/Transfer.tsx
+++ b/packages/page-accounts/src/modals/Transfer.tsx
@@ -160,6 +160,7 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
                     isError={!hasAvailable}
                     isZeroable
                     label={t<string>('amount')}
+                    maxValue={maxTransfer}
                     onChange={setAmount}
                   />
                   <InputBalance


### PR DESCRIPTION
Our users are complaining about accidentally making transfers that together with a fee are bigger than the account balance. Also currently it is inconvenient to check if a transfer together with a fee is lower than the balance. Because of that we thought about preventing users from making invalid transfers.

This PR passes `maxValue` prop for `InputBalance` set to `maxTransfer`. Now, when user tries to make a transfer that is too big the transfer button will be locked and the input field will be red. This will stop users from making this type of mistake and loosing fee in a process. Also now it is easier to check if a transfer is valid.

![Screenshot from 2021-08-18 13-18-08](https://user-images.githubusercontent.com/22624476/129900003-3fe6b70e-dd4b-40a3-a5da-43e64374e374.png)
