### PR TITLE
Clarify conviction locking

### DIFF
--- a/packages/apps/public/locales/ar/translation.json
+++ b/packages/apps/public/locales/ar/translation.json
@@ -133,7 +133,7 @@
   "Confirm contract removal": "تأكيد إزالة العقد",
   "Constants": "ثوابت",
   "Continue": "إكمال",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": ".إن أقفال الإقناع تتداخل وتضاف، وهذا يعني أن الأموال التي يتم تأمينها أثناء التصويت السابق يمكن تأمينها مرة أخرى",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": ".إن أقفال الإقناع تتداخل وتضاف، وهذا يعني أن الأموال التي يتم تأمينها أثناء التصويت السابق يمكن تأمينها مرة أخرى",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "انسخ السلسلة أعلاه وقم بتوقيع معاملة إيثريوم مع الحساب الذي استخدمته أثناء عملية البيع المسبق في محفظة من اختيارك، باستخدام السلسلة كحمولة صافية، ثم الصق توقيع المعاملة المذكورة أدناه",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": ":انسخ السلسلة التالية وقم بالتوقيع عليها باستخدام حساب أثيريوم الذي استخدمته أثناء عملية البيع المسبق في محفظة من اختيارك، باستخدام السلسلة كحمولة صافية، ثم الصق توقيع المعاملة المذكورة أدناه",
   "Council": "مجلس",

--- a/packages/apps/public/locales/en/app-democracy.json
+++ b/packages/apps/public/locales/en/app-democracy.json
@@ -1,6 +1,6 @@
 {
   "Aye {{count}}": "Aye {{count}}",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.",
   "Dispatch": "Dispatch",
   "Fast track": "Fast track",
   "Fast track proposal": "Fast track proposal",

--- a/packages/apps/public/locales/es/translation.json
+++ b/packages/apps/public/locales/es/translation.json
@@ -104,7 +104,7 @@
   "Confirm contract removal": "Confirmar la eliminación del contrato",
   "Constants": "Constantes",
   "Continue": "Continuar",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Los bloqueos de sentencias se superponen y son acumulativos, lo que significa que los fondos bloqueados durante una votación anterior pueden ser bloqueados de nuevo.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Los bloqueos de sentencias se superponen y son acumulativos, lo que significa que los fondos bloqueados durante una votación anterior pueden ser bloqueados de nuevo.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Copie la secuencia anterior y firme una transacción de Ethereum con la cuenta que utilizó durante la preventa en la cartera de su elección, utilizando la secuencia como fuente, y luego pegue la firma de la transacción a continuación",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Copie la siguiente secuencia y fírmela con la cuenta Ethereum que utilizó durante la preventa en la cartera de su elección, utilizando la secuencia como fuente, y luego pegue la firma de la transacción a continuación:",
   "Council": "Council",

--- a/packages/apps/public/locales/fr/translation.json
+++ b/packages/apps/public/locales/fr/translation.json
@@ -155,7 +155,7 @@
   "Continue": "Continuer",
   "Contracts": "Contrats",
   "Controller account": "Compte contrôleur",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Les verrous de condamnation se chevauchent et sont additifs, ce qui signifie que les fonds verrouillés lors d'un vote précédent peuvent être à nouveau verrouillés.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Les verrous de condamnation se chevauchent et sont additifs, ce qui signifie que les fonds verrouillés lors d'un vote précédent peuvent être à nouveau verrouillés.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Copiez la chaîne de caractères ci-dessus et signez une transaction Ethereum avec le compte que vous avez utilisé lors de la pré-vente dans le portefeuille de votre choix, en utilisant la chaîne de caractères  comme contenu, puis collez la signature de la transaction ci-dessous",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Copiez la chaîne de caractères suivante et signez-la avec le compte Ethereum que vous avez utilisé lors de la pré-vente dans le portefeuille de votre choix, en utilisant la chaîne comme message, puis collez l'objet de signature de transaction ci-dessous:",
   "Council": "Conseil",

--- a/packages/apps/public/locales/id/translation.json
+++ b/packages/apps/public/locales/id/translation.json
@@ -152,7 +152,7 @@
   "Continue": "Teruskan",
   "Contracts": "Kontrak",
   "Controller account": "Akun pengontrol",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Kunci keyakinan memang tumpang tindih dan bersifat aditif, artinya dana yang dikunci selama pemungutan suara sebelumnya dapat dikunci lagi.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Kunci keyakinan memang tumpang tindih dan bersifat aditif, artinya dana yang dikunci selama pemungutan suara sebelumnya dapat dikunci lagi.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Salin string di atas dan tanda tangani transaksi Ethereum dengan akun yang anda gunakan selama pra-penjualan di dompet pilihan anda, gunakan string sebagai muatan, lalu tempel objek tanda tangan transaksi di bawah",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Salin string berikut dan tandatangani dengan akun Ethereum yang anda gunakan selama pra-penjualan di dompet pilihan anda, gunakan string sebagai muatan, lalu tempel objek tanda tangan transaksi di bawah ini:",
   "Council": "Dewan",

--- a/packages/apps/public/locales/it/translation.json
+++ b/packages/apps/public/locales/it/translation.json
@@ -159,7 +159,7 @@
   "Continue": "Continua",
   "Contracts": "Contratti",
   "Controller account": "Controller account",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "I fondi bloccati per un voto con moltiplicatore si sovrappongono e si aggiungono, ciò significa che i fondi bloccati durante il voto precedente possono essere ri-bloccati di nuovo.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "I fondi bloccati per un voto con moltiplicatore si sovrappongono e si aggiungono, ciò significa che i fondi bloccati durante il voto precedente possono essere ri-bloccati di nuovo.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Copia la stringa di cui sopra e firma una transazione Ethereum con l'account che hai usato durante la prevendita, sfruttando la stringa, e poi incolla la firma della tx qui sotto:",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Copia la seguente stringa e firmala con il conto Ethereum che hai usato durante la prevendita, sfruttando la stringa, e poi incolla la firma della tx qui sotto:",
   "Council": "Consiglio",

--- a/packages/apps/public/locales/ko/translation.json
+++ b/packages/apps/public/locales/ko/translation.json
@@ -148,7 +148,7 @@
   "Continue": "계속",
   "Contracts": "계약서들",
   "Controller account": "콘트롤러 계정",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "컨빅션 록은 겹치며 부가적이다, 이어서 전 투표에서 잠긴 펀드는 또 다시 잠길 수 있습니다.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "컨빅션 록은 겹치며 부가적이다, 이어서 전 투표에서 잠긴 펀드는 또 다시 잠길 수 있습니다.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "위 문자열을 복붙하고 프리세일에 참가했던 이더리움 지갑으로 사인한 다음에, 사인한 디지털 서명값을 아래 오브젝트에 붙여주세요.",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "이 문자열을 복붙하고 프리세일에 참가했던 이더리움 지갑으로 사인한 다음에, 사인한 디지털 서명값을 아래 오브젝트에 붙여주세요.",
   "Council": "위원회",

--- a/packages/apps/public/locales/pt/translation.json
+++ b/packages/apps/public/locales/pt/translation.json
@@ -104,7 +104,7 @@
   "Confirm contract removal": "Confirmar remoção do contrato",
   "Constants": "Constantes",
   "Continue": "Continuar",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Os bloqueios por condenação se sobrepõem e são aditivos, o que significa que os fundos bloqueados durante uma votação anterior podem ser bloqueados novamente.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Os bloqueios por condenação se sobrepõem e são aditivos, o que significa que os fundos bloqueados durante uma votação anterior podem ser bloqueados novamente.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Copie a sequência acima e assine uma transação do Ethereum com a conta usada durante a pré-venda na carteira de sua escolha, usando a sequência como carga útil e cole o objeto de assinatura da transação abaixo",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Copie a seguinte string e assine-a na conta Ethereum usada durante a pré-venda na carteira de sua escolha, usando a string como carga útil e cole o objeto de assinatura da transação abaixo:",
   "Council": "Conselho",

--- a/packages/apps/public/locales/ru/translation.json
+++ b/packages/apps/public/locales/ru/translation.json
@@ -105,7 +105,7 @@
   "Confirm contract removal": "Подтвердить удаление контракта",
   "Constants": "Константы",
   "Continue": "Продолжить",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "Голосование возможно также и токенами, которые уже выделены под голосование по другому вопросу.",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "Голосование возможно также и токенами, которые уже выделены под голосование по другому вопросу.",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "Скопируйте строку выше и подпишите ее с помощью транзакции в сети Ethereum с учетной записи, которую Вы использовали в предпродаже，используя строку как \\рayload\\. Затем вставьте обьект подписи транзакции ниже",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "Скопируйте следующую строку и подпишите ее учетной записью Ethereum, которую Вы использовали во время предпродажи, используя строку как \\payload\\. Вставьте полученную подпись ниже:",
   "Council": "Совет",

--- a/packages/apps/public/locales/zh/translation.json
+++ b/packages/apps/public/locales/zh/translation.json
@@ -143,7 +143,7 @@
   "Constants": "常数",
   "Continue": "继续",
   "Contracts": "合约",
-  "Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.": "信念值锁定确实会重叠，而且是累加性的，这意味着在前一次投票中锁定的资金可以再次锁定。",
+  "Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.": "信念值锁定确实会重叠，而且是累加性的，这意味着在前一次投票中锁定的资金可以再次锁定。",
   "Copy the above string and sign an Ethereum transaction with the account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below": "在钱包中选择预售阶段你使用的以太坊账户，复制上面的字符串，并且使用你的以太坊账户把字符串作为内容签名交易, 并且粘贴交易签名对象到下面",
   "Copy the following string and sign it with the Ethereum account you used during the pre-sale in the wallet of your choice, using the string as the payload, and then paste the transaction signature object below:": "复制以下字符串，并使用您在预售期间使用的以太坊帐户在您选择的钱包中进行签名，使用该字符串作为有效负载，然后将交易签名对象粘贴到下面",
   "Council": "理事会",

--- a/packages/page-democracy/src/Overview/Voting.tsx
+++ b/packages/page-democracy/src/Overview/Voting.tsx
@@ -58,7 +58,7 @@ function Voting ({ proposal, referendumId }: Props): React.ReactElement<Props> |
               hint={
                 <>
                   <p>{t<string>('The balance associated with the vote will be locked as per the conviction specified and will not be available for transfer during this period.')}</p>
-                  <p>{t<string>('Conviction locks do overlap and is additive, meaning that funds locked during a previous vote can be locked again.')}</p>
+                  <p>{t<string>('Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.')}</p>
                 </>
               }
             >


### PR DESCRIPTION
This PR fixes a self-contradictory description to clarify how conviction locking works.

The original description,`Conviction locks do overlap and are not additive, meaning that funds locked during a previous vote can be locked again.` makes three claims regarding conviction locks:
* They do  overlap
* They is (are) additive
* funds locked during a previous vote can be locked again

The first and third claim are correct and consistent with one another, but the second is opposite. If locks were additive then previously locked tokens could not vote again.