### PR TITLE
Remove Patract from avaiable Polkadot Nodes

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -22,7 +22,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
     providers: {
       Parity: 'wss://rpc.polkadot.io',
       OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-      'Patract Elara': 'wss://pub.elara.patract.io/polkadot',
+      // 'Patract Elara': 'wss://pub.elara.patract.io/polkadot',
       // Dwellir: 'wss://polkadot-rpc.dwellir.com',
       'light client': 'light://substrate-connect/polkadot'
       // Pinknode: 'wss://rpc.pinknode.io/polkadot/explorer' // https://github.com/polkadot-js/apps/issues/5721


### PR DESCRIPTION
I have had consistent issues when connecting to Patract node when going on the Polkadot JS Apps page.

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/1860335/132386454-46969a9f-783a-4b66-895b-be184912e944.png">

I suggest we remove them for now, until they can prove their nodes are more stable.
