### PR TITLE
feat: add Polkassembly.network endpoint

### DIFF
--- a/packages/apps-config/src/links/index.ts
+++ b/packages/apps-config/src/links/index.ts
@@ -7,7 +7,7 @@ import Commonwealth from './commonwealth';
 import Dotreasury from './dotreasury';
 import DotScanner from './dotscanner';
 import Polkascan from './polkascan';
-import Polkassembly from './polkassembly';
+import { PolkassemblyIo, PolkassemblyNetwork } from './polkassembly';
 import Polkastats from './polkastats';
 import Statescan from './statescan';
 import Subscan from './subscan';
@@ -17,7 +17,8 @@ export const externalLinks: Record<string, ExternalDef> = {
   DotScanner,
   Dotreasury,
   Polkascan,
-  Polkassembly,
+  PolkassemblyIo,
+  PolkassemblyNetwork,
   Polkastats,
   Statescan,
   Subscan

--- a/packages/apps-config/src/links/polkassembly.ts
+++ b/packages/apps-config/src/links/polkassembly.ts
@@ -5,7 +5,7 @@ import type BN from 'bn.js';
 
 import { externalLogos } from '../ui/logos';
 
-export default {
+export const PolkassemblyIo = {
   chains: {
     Kusama: 'kusama',
     'Kusama CC3': 'kusama',
@@ -24,4 +24,18 @@ export default {
     treasury: 'treasury'
   },
   url: 'https://polkassembly.io/'
+};
+
+export const PolkassemblyNetwork = {
+  ...PolkassemblyIo,
+  chains: {
+    Bifrost: 'bifrost',
+    'KILT Spiritnet': 'kilt',
+    Karura: 'karura',
+    'Khala Network': 'khala',
+    Moonriver: 'moonriver'
+  },
+  create: (chain: string, path: string, data: BN | number | string): string =>
+    `https://${chain}.polkassembly.network/${path}/${data.toString()}`,
+  url: 'https://polkassembly.network/'
 };


### PR DESCRIPTION
Fixes https://github.com/polkadot-js/apps/issues/6124

* Replaces default export of Polkassembly with PolkassemblyIo
* Adds PolkassemblyNetwork endpoint for Bifrost, Karura, KILT, Khala, Moonriver parachains (tested at https://*.polkassembly.network)

cc @niklabh 