### PR TITLE
Restore slow tests

### DIFF
--- a/jest-slow.config.cjs
+++ b/jest-slow.config.cjs
@@ -6,6 +6,6 @@ const config = require('./jest.config.cjs');
 module.exports = {
   ...config,
   displayName: 'all-tests',
-  globalSetup: './jest/globalSetup.ts',
-  globalTeardown: './jest/globalTeardown.ts'
+  globalSetup: './jest/globalSetup.cjs',
+  globalTeardown: './jest/globalTeardown.cjs'
 };

--- a/jest/globalSetup.cjs
+++ b/jest/globalSetup.cjs
@@ -1,11 +1,7 @@
 // Copyright 2017-2021 @polkadot/apps authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { AlwaysPullPolicy, GenericContainer, Wait } from 'testcontainers';
-
-import { SubstrateTestsGlobal } from './substrateTestsGlobal';
-
-declare const global: SubstrateTestsGlobal;
+const { AlwaysPullPolicy, GenericContainer, Wait } = require('testcontainers');
 
 const startSubstrate = async () => {
   console.log('Substrate container starting...');
@@ -24,6 +20,6 @@ const startSubstrate = async () => {
   global.__SUBSTRATE__ = startedTestContainer;
 };
 
-export default async (): Promise<void> => {
+module.exports = async () => {
   await startSubstrate();
 };

--- a/jest/globalTeardown.cjs
+++ b/jest/globalTeardown.cjs
@@ -1,11 +1,7 @@
 // Copyright 2017-2021 @polkadot/apps authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { SubstrateTestsGlobal } from './substrateTestsGlobal';
-
-declare const global: SubstrateTestsGlobal;
-
-export default async (): Promise<void> => {
+module.exports = async () => {
   console.log('Shutting down Substrate container...');
 
   await global.__SUBSTRATE__.stop();

--- a/jest/substrateTestsGlobal.ts
+++ b/jest/substrateTestsGlobal.ts
@@ -1,9 +1,0 @@
-// Copyright 2017-2021 @polkadot/apps authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
-import { StartedTestContainer } from 'testcontainers';
-
-export interface SubstrateTestsGlobal extends NodeJS.Global {
-  __SUBSTRATE__: StartedTestContainer;
-  // You can declare anything you need.
-}

--- a/packages/page-accounts/src/CreateAccount.slow.spec.tsx
+++ b/packages/page-accounts/src/CreateAccount.slow.spec.tsx
@@ -43,7 +43,7 @@ const renderAccounts = () => {
   );
 };
 
-describe.only('--SLOW--: Account Create', () => {
+describe('--SLOW--: Account Create', () => {
   it('created account is added to list', async () => {
     const { findByTestId, findByText, queryByText } = renderAccounts();
 


### PR DESCRIPTION
Currently the slow (nightly) tests fail on first Typescript import statement (`import './Backend'` in `i18n`). Jest resolvers tries to fetch this module as `Backend.cjs` and obviously fails.

I confirmed it has nothing to do with what we do in the `globalSetup` file. Exporting an empty function gives the same result.

I didn't get to the bottom of the `jest` bug, but found a solution nonetheless. Changing module type from TypeScript to CommonJS for the `globalSetup` file apparently helps.