### PR TITLE
Disable unreachable networks.

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -329,7 +329,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'phoenix',
-      isDisabled: true, // Timeout connecting to wss://phoenix-ws.coinid.pro/
+      isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
       text: t('rpc.test.phoenix', 'Phoenix Mashnet', { ns: 'apps-config' }),
       providers: {
         'phoenix Protocol': 'wss://phoenix-ws.coinid.pro/'

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -372,7 +372,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'riochain',
-      isDisabled: true, // Timeout connecting to wss://node.v1.staging.riochain.io
+      isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
       text: t('rpc.test.riochain', 'RioChain', { ns: 'apps-config' }),
       providers: {
         'RioChain Staging': 'wss://node.v1.staging.riochain.io'

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -329,6 +329,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'phoenix',
+      isDisabled: true, // Timeout connecting to wss://phoenix-ws.coinid.pro/
       text: t('rpc.test.phoenix', 'Phoenix Mashnet', { ns: 'apps-config' }),
       providers: {
         'phoenix Protocol': 'wss://phoenix-ws.coinid.pro/'
@@ -371,6 +372,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'riochain',
+      isDisabled: true, // Timeout connecting to wss://node.v1.staging.riochain.io
       text: t('rpc.test.riochain', 'RioChain', { ns: 'apps-config' }),
       providers: {
         'RioChain Staging': 'wss://node.v1.staging.riochain.io'

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -276,7 +276,7 @@ export function createRococo (t: TFunction): EndpointOption {
       },
       {
         info: 'rococoLoomNetwork',
-        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
+        isDisabled: true, // Rococo reset
         paraId: 2043,
         text: t('rpc.rococo.loomnetwork', 'Loom Network', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -276,7 +276,7 @@ export function createRococo (t: TFunction): EndpointOption {
       },
       {
         info: 'rococoLoomNetwork',
-        isDisabled: true, // Timeout connecting to wss://rococo.dappchains.com
+        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
         paraId: 2043,
         text: t('rpc.rococo.loomnetwork', 'Loom Network', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -276,6 +276,7 @@ export function createRococo (t: TFunction): EndpointOption {
       },
       {
         info: 'rococoLoomNetwork',
+        isDisabled: true, // Timeout connecting to wss://rococo.dappchains.com
         paraId: 2043,
         text: t('rpc.rococo.loomnetwork', 'Loom Network', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -99,7 +99,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'whala',
-        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
+        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6181
         paraId: 2013,
         text: t('rpc.westend.whala', 'Whala', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -81,7 +81,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'moonshadow',
-        isDisabled: true, // No DNS entry for wss.moonshadow.testnet.moonbeam.network
+        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
         paraId: 2002,
         text: t('rpc.westend.moonshadow', 'Moonshadow', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -99,7 +99,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'whala',
-        isDisabled: true, // Timeout connecting to wss://whala.phala.network/ws
+        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
         paraId: 2013,
         text: t('rpc.westend.whala', 'Whala', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -81,7 +81,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'moonshadow',
-        isDisabled: true, // https://github.com/polkadot-js/apps/issues/6181
+        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6181
         paraId: 2002,
         text: t('rpc.westend.moonshadow', 'Moonshadow', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -81,6 +81,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'moonshadow',
+        isDisabled: true, // No DNS entry for wss.moonshadow.testnet.moonbeam.network
         paraId: 2002,
         text: t('rpc.westend.moonshadow', 'Moonshadow', { ns: 'apps-config' }),
         providers: {
@@ -98,6 +99,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'whala',
+        isDisabled: true, // Timeout connecting to wss://whala.phala.network/ws
         paraId: 2013,
         text: t('rpc.westend.whala', 'Whala', { ns: 'apps-config' }),
         providers: {


### PR DESCRIPTION
Disable the networks that are currently not reachable, as reported by the nightly test run.

Closes https://github.com/polkadot-js/apps/issues/6181