### PR TITLE
Increase UI test timeouts and mark interBTC unreachable

### DIFF
--- a/jest/jest-setup.ts
+++ b/jest/jest-setup.ts
@@ -3,9 +3,13 @@
 
 import '@testing-library/jest-dom';
 
+import { configure } from '@testing-library/dom';
+
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 // eslint-disable-next-line no-global-assign
 CSS = { supports (): boolean {
   return false;
 } };
+
+configure({ asyncUtilTimeout: 10000 });

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -73,6 +73,7 @@ export function createWestend (t: TFunction): EndpointOption {
       },
       {
         info: 'interBTC',
+        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6230
         paraId: 2094,
         text: t('rpc.westend.interbtc', 'InterBTC', { ns: 'apps-config' }),
         providers: {

--- a/packages/page-accounts/src/CreateAccount.slow.spec.tsx
+++ b/packages/page-accounts/src/CreateAccount.slow.spec.tsx
@@ -47,7 +47,7 @@ describe('--SLOW--: Account Create', () => {
   it('created account is added to list', async () => {
     const { findByTestId, findByText, queryByText } = renderAccounts();
 
-    const addAccountButton = await findByText('Add account', {}, { timeout: 5000 });
+    const addAccountButton = await findByText('Add account', {});
 
     fireEvent.click(addAccountButton);
 
@@ -56,7 +56,7 @@ describe('--SLOW--: Account Create', () => {
 
     fireEvent.click(hiddenCheckbox);
 
-    const nextStepButton = await findByText('Next', {}, { timeout: 4000 });
+    const nextStepButton = await findByText('Next', {});
 
     fireEvent.click(nextStepButton);
 
@@ -72,11 +72,11 @@ describe('--SLOW--: Account Create', () => {
 
     fireEvent.change(passwordInput2, { target: { value: 'password' } });
 
-    const toStep3Button = await findByText('Next', {}, { timeout: 4000 });
+    const toStep3Button = await findByText('Next', {});
 
     fireEvent.click(toStep3Button);
 
-    const createAnAccountButton = await findByText('Save', {}, { timeout: 4000 });
+    const createAnAccountButton = await findByText('Save', {});
 
     fireEvent.click(createAnAccountButton);
 
@@ -88,19 +88,19 @@ describe('--SLOW--: Account Create', () => {
   it('gives an error message when entering invalid derivation path', async () => {
     const { findByTestId, findByText } = renderAccounts();
 
-    const addAccountButton = await findByText('Add account', {}, { timeout: 5000 });
+    const addAccountButton = await findByText('Add account', {});
 
     fireEvent.click(addAccountButton);
 
-    const showAdvancedOptionsButton = await findByText('Advanced creation options', {}, { timeout: 5000 });
+    const showAdvancedOptionsButton = await findByText('Advanced creation options', {});
 
     fireEvent.click(showAdvancedOptionsButton);
 
-    const derivationPathInput = await findByTestId('secret derivation path', {}, { timeout: 5000 });
+    const derivationPathInput = await findByTestId('secret derivation path', {});
 
     fireEvent.change(derivationPathInput, { target: { value: '//abc//' } });
 
-    const errorMsg = await findByText('Unable to match provided value to a secret URI', {}, { timeout: 5000 });
+    const errorMsg = await findByText('Unable to match provided value to a secret URI', {});
 
     expect(errorMsg).toBeTruthy();
   });


### PR DESCRIPTION
So here's another attempt to make the nightly tests pass 😄 

- I've marked interBTC unreachable as per #6230 
- I've increased the React Testing Library timeouts globally to 10 seconds. 5 seconds we had before was enough to make the test pass consistently on a laptop. Though it was a boundary value, eg. 4 seconds most often failed. As the GH actions tend to be slower than that, a global 10sec timeout for should help. 