### PR TITLE
Update @snowfork/snowbridge-types to v0.2.6

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -23,7 +23,7 @@
     "@phala/typedefs": "0.2.28",
     "@polkadot/networks": "^7.4.1",
     "@polymathnetwork/polymesh-types": "0.0.2",
-    "@snowfork/snowbridge-types": "0.2.5",
+    "@snowfork/snowbridge-types": "0.2.6",
     "@sora-substrate/type-definitions": "1.6.9",
     "@subsocial/types": "0.6.2",
     "@zeitgeistpm/type-defs": "0.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,7 +2816,7 @@ __metadata:
     "@phala/typedefs": 0.2.28
     "@polkadot/networks": ^7.4.1
     "@polymathnetwork/polymesh-types": 0.0.2
-    "@snowfork/snowbridge-types": 0.2.5
+    "@snowfork/snowbridge-types": 0.2.6
     "@sora-substrate/type-definitions": 1.6.9
     "@subsocial/types": 0.6.2
     "@zeitgeistpm/type-defs": 0.2.10
@@ -3706,13 +3706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowfork/snowbridge-types@npm:0.2.5":
-  version: 0.2.5
-  resolution: "@snowfork/snowbridge-types@npm:0.2.5"
+"@snowfork/snowbridge-types@npm:0.2.6":
+  version: 0.2.6
+  resolution: "@snowfork/snowbridge-types@npm:0.2.6"
   dependencies:
     "@polkadot/keyring": ^7.1.1
     "@polkadot/types": ^5.3.2
-  checksum: 3e0c7755a6d4ee2aeb331808a37b0ea29f573acf2094b024b1b2ea2395fadd95ef633b1ac135ca36eefa682f8d4f0c60e548178c6e538eb65691f2211c0433a8
+  checksum: 29896c3d3a44d6fe3fd369413b2bb1249a65cc24065b49db322dd739763059526886690712b8c5ee7cafc058b77c04d4c4fb376c6340b2ad68875a65d6baa30d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the metadata types for the snowbridge parachain.

Tested the changes locally using `yarn start`, and browsing to our parachain.