### PR TITLE
Fix "évennement" -> "événement"

### DIFF
--- a/packages/apps/public/locales/fr/translation.json
+++ b/packages/apps/public/locales/fr/translation.json
@@ -1162,7 +1162,7 @@
   "name": "nom",
   "nav.accounts": "Comptes",
   "nav.addresses": "Carnet d'adresses",
-  "nav.calendar": "Calendrier d'évennements",
+  "nav.calendar": "Calendrier d'événements",
   "nav.claims": "Percevoir ses tokens",
   "nav.contracts": "Contrats",
   "nav.council": "Conseil",


### PR DESCRIPTION
This word is spelled either "événement" and sometimes "évènement", but certainly not "évennement"