### PR TITLE
fix: kintsugi labs hosted parachain URL

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -164,12 +164,11 @@ export function createKusama (t: TFunction): EndpointOption {
       },
       {
         info: 'kintsugi',
-        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6101
         homepage: 'https://kintsugi.interlay.io/',
         paraId: 2092,
         text: t('rpc.kusama.kintsugi', 'Kintsugi BTC', { ns: 'apps-config' }),
         providers: {
-          'Kintsugi Labs': 'wss://api-kin.interlay.io/parachain',
+          'Kintsugi Labs': 'wss://api-kusama.interlay.io/parachain',
           OnFinality: 'wss://kintsugi.api.onfinality.io/public-ws'
         }
       },


### PR DESCRIPTION
Bring up kintsugi labs hosted endpoints. Addresses #6101