### PR TITLE
add dapps staking custom types to shiden network

### DIFF
--- a/packages/apps-config/src/api/spec/shiden.ts
+++ b/packages/apps-config/src/api/spec/shiden.ts
@@ -32,7 +32,8 @@ const definitions: OverrideBundleDefinition = {
         EraRewardAndStake: {
           rewards: 'Balance',
           staked: 'Balance'
-        }
+        },
+        EraIndex: 'u32'
       }
     }
   ]


### PR DESCRIPTION
Add custom types regarding the dapps staking pallet for Shiden network that was missing in https://github.com/polkadot-js/apps/commit/2c62a063ac5785c64fb6e57b1f706b9e71ca3a66