### PR TITLE
Fix Typo in Accounts/Account.tsx

### DIFF
--- a/packages/page-accounts/src/Accounts/Account.tsx
+++ b/packages/page-accounts/src/Accounts/Account.tsx
@@ -428,7 +428,7 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
                       hover={
                         <div>
                           <p>{t<string>('This account is available on all networks. It is recommended to link to a specific network via the account options ("only this network" option) to limit availability. For accounts from an extension, set the network on the extension.')}</p>
-                          <p>{t<string>('This does not send any transaction, rather is only sets the genesis in the account JSON.')}</p>
+                          <p>{t<string>('This does not send any transaction, rather it only sets the genesis in the account JSON.')}</p>
                         </div>
                       }
                       icon='exclamation-triangle'


### PR DESCRIPTION
"is only sets" is probably wrong and should be "it only sets"