### PR TITLE
Multi-Architecture Docker Builds

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -38,6 +38,10 @@ jobs:
     name: docker
     runs-on: ubuntu-latest
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1.2.0
+    - name: Install Buildx
+      uses: docker/setup-buildx-action@v1.6.0
     - uses: actions/checkout@v2
     - name: docker
       env:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,4 @@
-FROM ubuntu:18.04 as builder
-
-# Install any needed packages
-RUN apt-get update && \
-  apt-get install --no-install-recommends -y curl git gnupg ca-certificates
-
-# install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install --no-install-recommends -y nodejs && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-RUN npm install yarn -g
+FROM node:14 as builder
 
 WORKDIR /apps
 COPY . .


### PR DESCRIPTION
Leverage Docker Buildx to build a multi-architecture docker image for `amd64`, `armv7`, and `arm64`.

Edit:
Largest caeveat is that it significantly increases build time.
Using a VM on my M1 MBP (2020) simulating the Github Build Instance resources (2vCPU, 7GiB Memory) it takes ±30 minutes to build.