### PR TITLE
Fix sudo: check against lowercase sudo address

### DIFF
--- a/packages/react-hooks/src/useSudo.ts
+++ b/packages/react-hooks/src/useSudo.ts
@@ -21,7 +21,7 @@ export function useSudo (): UseSudo {
   const [hasSudoKey, setHasSudoKey] = useState(false);
 
   useEffect((): void => {
-    setHasSudoKey(!!sudoKey && !!allAccounts && allAccounts.some((key) => key === sudoKey));
+    setHasSudoKey(!!sudoKey && !!allAccounts && allAccounts.some((key) => key.toLowerCase() === sudoKey));
   }, [allAccounts, sudoKey]);
 
   return { allAccounts, hasSudoKey, sudoKey };


### PR DESCRIPTION
Because now the api returns non checksummed addresses (see https://github.com/polkadot-js/api/issues/4110)