### PR TITLE
Improving UX when making balance transfers

### DIFF
--- a/packages/page-accounts/src/modals/Transfer.tsx
+++ b/packages/page-accounts/src/modals/Transfer.tsx
@@ -69,9 +69,9 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
               const maxTransfer = balances.availableBalance.sub(adjFee);
 
               setMaxTransfer(
-                maxTransfer.gt(api.consts.balances.existentialDeposit)
+                maxTransfer.gt(BN_ZERO)
                   ? [maxTransfer, false]
-                  : [null, true]
+                  : [null, false]
               );
             })
             .catch(console.error);
@@ -79,8 +79,6 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
           console.error((error as Error).message);
         }
       }, 0);
-    } else {
-      setMaxTransfer([null, false]);
     }
   }, [api, balances, propRecipientId, propSenderId, recipientId, senderId]);
 


### PR DESCRIPTION
Although the front end can stop the user from sending a transaction by checking if the balance transfer will kill the account, it sends it to the network! 

Here is an instance that shows how detrimental it is for UX - https://polkadot.subscan.io/account/15vzAirFFFWcEgF74jxLoCTQxh11caDYgBrdQpUAnSEaDkrz

With some additional code logic, this can be averted. Also, the corner case for the second issue mentioned here is not handled well - https://github.com/polkadot-js/apps/issues/4931

This PR will take some time to finish. Need to understand how things work, before any changes are pushed to the PR.