### PR TITLE
Update the Aleph Zero testnet address

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -21,7 +21,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
       info: 'aleph',
       text: t('rpc.test.aleph', 'Aleph Zero Testnet', { ns: 'apps-config' }),
       providers: {
-        'Aleph Zero Foundation': 'wss://test-api.alephzero.org'
+        'Aleph Zero Foundation': 'wss://ws.test.azero.dev'
       }
     },
     {


### PR DESCRIPTION
We are migrating this address: https://alephzero.org/blog/migrating-to-new-infrastructure/. The new address is already operational.