### PR TITLE
correction to manta node names

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -118,13 +118,12 @@ export function createPolkadot (t: TFunction): EndpointOption {
       {
         info: 'manta',
         homepage: 'https://manta.network',
-        isUnreachable: true,
         paraId: 2015,
         text: t('rpc.polkadot.manta', 'Manta', { ns: 'apps-config' }),
         providers: {
-          'Manta 0': 'wss://falafel.manta.systems',
-          'Manta 1': 'wss://fritti.manta.systems',
-          'Manta 2': 'wss://smoothie.manta.systems'
+          'Manta Kuhlii': 'wss://kuhlii.manta.systems',
+          'Manta Munkiana': 'wss://munkiana.manta.systems',
+          'Manta Pectinata': 'wss://pectinata.manta.systems'
         }
       },
       {


### PR DESCRIPTION
- manta node names corrected
- removed `isUnreachable` flag as nodes are now deployed and accepting wss requests