### PR TITLE
change para id to 2112

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -113,7 +113,7 @@ export function createWestend (t: TFunction): EndpointOption {
       {
         info: 'westendPichiu',
         homepage: 'https://kylin.network/',
-        paraId: 2106,
+        paraId: 2112,
         text: t('westend.kylin-node.co.uk', 'Pichiu', { ns: 'apps-config' }),
         providers: {
           'Kylin Network': 'wss://westend.kylin-node.co.uk'


### PR DESCRIPTION
We got caught out by 
https://github.com/substrate-developer-hub/substrate-docs/issues/513

So had to create a new genesis/wasm with a new para id

Producing blocks now so hopefully no more changes! 