### PR TITLE
Add Integritee Live Mainnet

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -117,19 +117,19 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
       }
     },
     {
-      info: 'integritee',
-      text: t('rpc.prod.integritee', 'Integritee Network', { ns: 'apps-config' }),
-      providers: {
-        Integritee: 'wss://api.solo.integritee.io'
-      }
-    },
-    {
       info: 'snakenet',
       text: t('rpc.prod.hydra', 'HydraDX', { ns: 'apps-config' }),
       providers: {
         HydraDX: 'wss://rpc-01.snakenet.hydradx.io',
         'Galactic Council': 'wss://rpc-02.snakenet.hydradx.io',
         Archives: 'wss://archive.snakenet.hydradx.io'
+      }
+    },
+    {
+      info: 'integritee',
+      text: t('rpc.prod.integritee', 'Integritee Network', { ns: 'apps-config' }),
+      providers: {
+        Integritee: 'wss://api.solo.integritee.io'
       }
     },
     {

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -117,6 +117,13 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
       }
     },
     {
+      info: 'integritee',
+      text: t('rpc.prod.integritee', 'Integritee Network', { ns: 'apps-config' }),
+      providers: {
+        Integritee: 'wss://api.solo.integritee.io'
+      }
+    },
+    {
       info: 'snakenet',
       text: t('rpc.prod.hydra', 'HydraDX', { ns: 'apps-config' }),
       providers: {

--- a/packages/apps-config/src/ui/colors.ts
+++ b/packages/apps-config/src/ui/colors.ts
@@ -377,6 +377,7 @@ export const nodeColors = Object.entries({
   'GamePower Node': nodeGamePower,
   GEEK: nodeGeek,
   'Integritee Collator': nodeIntegritee,
+  'Integritee Node': nodeIntegritee,
   IpseTestnet: nodeIpse,
   'Klug Dossier Node': nodeKlug,
   'Konomi Collator': nodeKonomi,

--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -357,6 +357,7 @@ export const nodeLogos = Object.entries({
   hanonycash: nodeHanonycash,
   'Idavoll Node': nodeIdavoll,
   'Integritee Collator': nodeIntegritee,
+  'Integritee Node': nodeIntegritee,
   IpseTestnet: nodeIpse,
   Khala: nodeKhala,
   'Khala Node': nodeKhala,


### PR DESCRIPTION
Integritee has launched their mainnet as solochain today.
This PR lists Integritee under Live Networks