### PR TITLE
Update Robonomics ParaID

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -272,7 +272,7 @@ export function createKusama (t: TFunction): EndpointOption {
       {
         info: 'robonomics',
         homepage: 'http://robonomics.network/',
-        paraId: 2077,
+        paraId: 2048,
         text: t('rpc.kusama.robonomics', 'Robonomics', { ns: 'apps-config' }),
         providers: {
           Airalab: 'wss://kusama.rpc.robonomics.network/'


### PR DESCRIPTION
**Description**

New Robonomics Network ParaID used because of new Polkadot 0.9.12 based runtime.