### PR TITLE
Update Tick rococo rpc endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -35,7 +35,7 @@ export function createRococo (t: TFunction): EndpointOption {
         paraId: 100,
         text: t('rpc.rococo.tick', 'Tick', { ns: 'apps-config' }),
         providers: {
-          Parity: 'wss://tick-rpc.polkadot.io'
+          Parity: 'wss://tick-rococo-rpc.polkadot.io'
         }
       },
       {


### PR DESCRIPTION
Tick parachain was redeployed with new DNS name.


resolves https://github.com/polkadot-js/apps/issues/6656