### PR TITLE
Update Rococo parachain URLs and enable teleport

### DIFF
--- a/packages/apps-config/src/api/constants.ts
+++ b/packages/apps-config/src/api/constants.ts
@@ -21,7 +21,7 @@ export const KUSAMA_GENESIS = getGenesis('kusama');
 export const POLKADOT_GENESIS = getGenesis('polkadot');
 export const POLKADOT_DENOM_BLOCK = new BN(1248328);
 
-export const ROCOCO_GENESIS = '0xc196f81260cf1686172b47a79cf002120735d7cb0eb1474e8adce56618456fff';
+export const ROCOCO_GENESIS = '0x037f5f3c8e67b314062025fc886fcd6238ea25a4a9b45dce8d246815c9ebe770';
 
 export const WESTEND_GENESIS = '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e';
 

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -28,6 +28,7 @@ export function createRococo (t: TFunction): EndpointOption {
       // Pinknode: 'wss://rpc.pinknode.io/rococo/explorer' // After reset, syncs to old chain
       // 'Ares Protocol': 'wss://rococo.aresprotocol.com' // https://github.com/polkadot-js/apps/issues/5767
     },
+    teleport: [1000, 1002],
     linked: [
       // these are the base chains
       {
@@ -59,8 +60,18 @@ export function createRococo (t: TFunction): EndpointOption {
         paraId: 1000,
         text: t('rpc.rococo.statemint', 'Statemint', { ns: 'apps-config' }),
         providers: {
-          Parity: 'wss://statemint-rococo-rpc.parity.io'
-        }
+          Parity: 'wss://rococo-statemint-rpc.polkadot.io'
+        },
+        teleport: [-1]
+      },
+      {
+        info: 'rococoCanvas',
+        paraId: 1002,
+        text: t('rpc.rococo.canvas', 'Canvas', { ns: 'apps-config' }),
+        providers: {
+          Parity: 'wss://rococo-canvas-rpc.polkadot.io'
+        },
+        teleport: [-1]
       },
       // add any additional parachains here, alphabetical
       {


### PR DESCRIPTION
This should also let users teleport ROC to Statemint/Canvas. See for example, ROC to Canvas teleports as described in the [Canvas README](https://github.com/paritytech/canvas#rococo-deployment).

However in my tests, my changes fail to bring up the Teleport tab for the Rococo network.