### PR TITLE
Remove teleport destination fees

### DIFF
--- a/packages/page-parachains/src/Teleport.tsx
+++ b/packages/page-parachains/src/Teleport.tsx
@@ -11,7 +11,7 @@ import React, { useMemo, useState } from 'react';
 
 import { getTeleportWeight } from '@polkadot/apps-config';
 import { ChainImg, Dropdown, InputAddress, InputBalance, MarkWarning, Modal, Spinner, TxButton } from '@polkadot/react-components';
-import { useApi, useApiUrl, useTeleport, useWeightFee } from '@polkadot/react-hooks';
+import { useApi, useApiUrl, useTeleport } from '@polkadot/react-hooks';
 import { Available } from '@polkadot/react-query';
 import { BN_ZERO, isFunction } from '@polkadot/util';
 
@@ -80,7 +80,6 @@ function Teleport ({ onClose }: Props): React.ReactElement<Props> | null {
   );
 
   const destApi = useApiUrl(url);
-  const weightFee = useWeightFee(destWeight, destApi);
 
   const params = useMemo(
     () => {
@@ -111,7 +110,7 @@ function Teleport ({ onClose }: Props): React.ReactElement<Props> | null {
     [api, amount, call, destWeight, isParaTeleport, recipientId, recipientParaId]
   );
 
-  const hasAvailable = !!amount && amount.gte(weightFee);
+  const hasAvailable = !!amount;
 
   return (
     <Modal
@@ -171,11 +170,6 @@ function Teleport ({ onClose }: Props): React.ReactElement<Props> | null {
           {destApi
             ? (
               <>
-                <InputBalance
-                  defaultValue={weightFee}
-                  isDisabled
-                  label={t<string>('destination transfer fee')}
-                />
                 <InputBalance
                   defaultValue={destApi.consts.balances.existentialDeposit}
                   isDisabled

--- a/packages/page-parachains/src/index.tsx
+++ b/packages/page-parachains/src/index.tsx
@@ -1,6 +1,8 @@
 // Copyright 2017-2021 @polkadot/app-parachains authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import '@polkadot/api-augment';
+
 import type { ParaId } from '@polkadot/types/interfaces';
 
 import React, { useRef } from 'react';


### PR DESCRIPTION
As per https://github.com/polkadot-js/apps/issues/6742#issuecomment-1002043647

Since `limitedTeleport` it is not only the hard-coded values anymore, so it is overshooting the fees applied on the destination side - this is not the sending side, but rather the old 3b weight * the destination chain fee. Until we have xcm estimations on the receiving side (issue logged), we'd rather not confuse. 

(For older chains the value is still applicable, but as of now since all the relay chains have been updated, it makes more sense to remove it)