### PR TITLE
Check for duplicate urls (eg parachain & production)

### DIFF
--- a/packages/apps-config/src/endpoints/index.spec.ts
+++ b/packages/apps-config/src/endpoints/index.spec.ts
@@ -56,3 +56,36 @@ describe('urls are sorted', (): void => {
     }
   });
 });
+
+describe('urls are not duplicated', (): void => {
+  let hasDevelopment = false;
+  let lastHeader = '';
+  const filtered = allEndpoints.filter(({ isHeader, text }): boolean => {
+    hasDevelopment = hasDevelopment || (!!isHeader && text === 'Development');
+
+    return !hasDevelopment;
+  });
+  const map: Record<string, string[]> = {};
+
+  filtered.forEach(({ isHeader, text, value }): void => {
+    if (isHeader) {
+      lastHeader = text as string;
+    } else {
+      const path = `${lastHeader} -> ${text as string}`;
+
+      if (!map[value]) {
+        map[value] = [path];
+      } else {
+        map[value].push(path);
+      }
+    }
+  });
+
+  it('has no duplicates, e.g. parachain & live', (): void => {
+    expect(
+      Object
+        .entries(map)
+        .filter(([, paths]) => paths.length !== 1)
+    ).toEqual([]);
+  });
+});

--- a/packages/apps-config/src/endpoints/index.spec.ts
+++ b/packages/apps-config/src/endpoints/index.spec.ts
@@ -60,10 +60,10 @@ describe('urls are sorted', (): void => {
 describe('urls are not duplicated', (): void => {
   let hasDevelopment = false;
   let lastHeader = '';
-  const filtered = allEndpoints.filter(({ isHeader, text }): boolean => {
+  const filtered = allEndpoints.filter(({ isDisabled, isHeader, isUnreachable, text }): boolean => {
     hasDevelopment = hasDevelopment || (!!isHeader && text === 'Development');
 
-    return !hasDevelopment;
+    return !hasDevelopment && !isDisabled && !isUnreachable;
   });
   const map: Record<string, string[]> = {};
 

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -73,6 +73,7 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
     },
     {
       info: 'crust',
+      isDisabled: true, // https://github.com/polkadot-js/apps/pull/6761
       text: t('rpc.prod.crust', 'Crust Network', { ns: 'apps-config' }),
       providers: {
         'Crust Network': 'wss://rpc.crust.network'
@@ -110,6 +111,7 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
     },
     {
       info: 'efinity',
+      isDisabled: true, // https://github.com/polkadot-js/apps/pull/6761
       text: t('rpc.prod.efinity', 'Efinity', { ns: 'apps-config' }),
       providers: {
         Efinity: 'wss://rpc.efinity.io'
@@ -228,6 +230,7 @@ export function createProduction (t: TFunction, firstOnly: boolean, withSort: bo
     },
     {
       info: 'robonomics',
+      isDisabled: true, // https://github.com/polkadot-js/apps/pull/6761
       text: t('rpc.prod.robonomics', 'Robonomics', { ns: 'apps-config' }),
       providers: {
         Airalab: 'wss://kusama.rpc.robonomics.network/'

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -121,6 +121,7 @@ export function createKusama (t: TFunction): EndpointOption {
       {
         info: 'genshiro',
         homepage: 'https://genshiro.equilibrium.io',
+        isUnreachable: true, // https://github.com/polkadot-js/apps/pull/6761
         paraId: 2024,
         text: t('rpc.kusama.genshiro', 'Genshiro', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -161,6 +161,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
       },
       {
         info: 'equilibrium',
+        isUnreachable: true, // https://github.com/polkadot-js/apps/pull/6761
         homepage: 'https://equilibrium.io/',
         paraId: 2011,
         text: t('rpc.polkadot.equilibrium', 'Equilibrium', { ns: 'apps-config' }),
@@ -261,6 +262,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
       {
         info: 'subgame',
         homepage: 'http://subgame.org/',
+        isUnreachable: true, // https://github.com/polkadot-js/apps/pull/6761
         paraId: 2017,
         text: t('rpc.polkadot.subgame', 'SubGame Gamma', { ns: 'apps-config' }),
         providers: {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -367,6 +367,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'pichiu',
+      isDisabled: true, // https://github.com/polkadot-js/apps/pull/6761
       text: t('rpc.test.kylin-node.co.uk', 'Pichiu Testnet', { ns: 'apps-config' }),
       providers: {
         'Kylin Network': 'wss://westend.kylin-node.co.uk'


### PR DESCRIPTION
Endpoints can only be one of a type, i.e. it is a parachain on Kusama or a production network, not both.

A number of duplicates have been added, this PR adds a test for them and then also removes the duplicated entries, e.g. if a parachain, keep it in parachains when duplicated elsewhere.