### PR TITLE
Clarify Teleport transaction fee message

### DIFF
--- a/packages/page-parachains/src/Teleport.tsx
+++ b/packages/page-parachains/src/Teleport.tsx
@@ -155,8 +155,8 @@ function Teleport ({ onClose }: Props): React.ReactElement<Props> | null {
         <Modal.Columns
           hint={
             <>
-              <p>{t<string>('If the recipient account is new, the balance needs to be more than the existential deposit on the recipient chain.')}</p>
-              <p>{t<string>('The amount deposited to the recipient will be net the calculated cross-chain fee.')}</p>
+              <p>{t<string>('This is the amount to be teleported to the destination chain and does not account for the source or the destination transfer fee')}</p>
+              <p>{t<string>('The amount deposited to the recipient will be net the calculated cross-chain fee. If the recipient address is new, the amount deposited should be greater than the Existential Deposit')}</p>
             </>
           }
         >


### PR DESCRIPTION
As the destination transfer fee estimate is removed in https://github.com/polkadot-js/apps/pull/6745/ , it is resourceful to update the message mentioning that the teleported amount is subject to destination transfer fees along with the transfer fees at the source (and the balance should be above Existential Deposit, if the recipient's account is new