### PR TITLE
don't crash transfer model if balances is not available

### DIFF
--- a/packages/page-accounts/src/Sidebar/AccountMenuButtons.tsx
+++ b/packages/page-accounts/src/Sidebar/AccountMenuButtons.tsx
@@ -7,8 +7,9 @@ import styled from 'styled-components';
 import Transfer from '@polkadot/app-accounts/modals/Transfer';
 import { useTranslation } from '@polkadot/app-accounts/translate';
 import { Button } from '@polkadot/react-components';
-import { useToggle } from '@polkadot/react-hooks';
+import { useApi, useToggle } from '@polkadot/react-hooks';
 import { AddressFlags } from '@polkadot/react-hooks/types';
+import { isFunction } from '@polkadot/util';
 
 interface Props {
   className?: string;
@@ -28,6 +29,7 @@ interface Props {
 function AccountMenuButtons ({ className = '', flags, isEditing, isEditingName, onCancel, onForgetAddress, onSaveName, onSaveTags, onUpdateName, recipientId, toggleIsEditingName, toggleIsEditingTags }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [isTransferOpen, toggleIsTransferOpen] = useToggle();
+  const api = useApi();
 
   const _onForgetAddress = useCallback(
     (): void => {
@@ -85,12 +87,14 @@ function AccountMenuButtons ({ className = '', flags, isEditing, isEditingName, 
         )
         : (
           <Button.Group>
-            <Button
-              icon='paper-plane'
-              isDisabled={isEditing}
-              label={t<string>('Send')}
-              onClick={toggleIsTransferOpen}
-            />
+            {isFunction(api.api.tx.balances?.transfer) && (
+              <Button
+                icon='paper-plane'
+                isDisabled={isEditing}
+                label={t<string>('Send')}
+                onClick={toggleIsTransferOpen}
+              />
+            )}
             {!flags.isOwned && !flags.isInContacts && (
               <Button
                 icon='plus'

--- a/packages/page-accounts/src/modals/Transfer.tsx
+++ b/packages/page-accounts/src/modals/Transfer.tsx
@@ -58,18 +58,18 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
     const fromId = propSenderId || senderId as string;
     const toId = propRecipientId || recipientId as string;
 
-    if (balances && balances.accountId.eq(fromId) && fromId && toId && isFunction(api.rpc.payment?.queryInfo)) {
+    if (balances && balances.accountId?.eq(fromId) && fromId && toId && isFunction(api.rpc.payment?.queryInfo)) {
       setTimeout((): void => {
         try {
           api.tx.balances
-            .transfer(toId, balances.availableBalance)
+            ?.transfer(toId, balances.availableBalance)
             .paymentInfo(fromId)
             .then(({ partialFee }): void => {
               const adjFee = partialFee.muln(110).div(BN_HUNDRED);
               const maxTransfer = balances.availableBalance.sub(adjFee);
 
               setMaxTransfer(
-                maxTransfer.gt(api.consts.balances.existentialDeposit)
+                maxTransfer.gt(api.consts.balances?.existentialDeposit)
                   ? [maxTransfer, false]
                   : [null, true]
               );
@@ -95,7 +95,7 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
       ? accountInfo.refcount.isZero()
       : accountInfo.consumers.isZero()
     : true;
-  const canToggleAll = !isProtected && balances && balances.accountId.eq(propSenderId || senderId) && maxTransfer && noReference;
+  const canToggleAll = !isProtected && balances && balances.accountId?.eq(propSenderId || senderId) && maxTransfer && noReference;
 
   return (
     <Modal
@@ -165,7 +165,7 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
                     onChange={setAmount}
                   />
                   <InputBalance
-                    defaultValue={api.consts.balances.existentialDeposit}
+                    defaultValue={api.consts.balances?.existentialDeposit}
                     help={t<string>('The minimum amount that an account should have to be deemed active')}
                     isDisabled
                     label={t<string>('existential deposit')}
@@ -175,7 +175,7 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
             }
           </Modal.Columns>
           <Modal.Columns hint={t('With the keep-alive option set, the account is protected against removal due to low balances.')}>
-            {isFunction(api.tx.balances.transferKeepAlive) && (
+            {isFunction(api.tx.balances?.transferKeepAlive) && (
               <Toggle
                 className='typeToggle'
                 label={
@@ -213,17 +213,17 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
           onStart={onClose}
           params={
             canToggleAll && isAll
-              ? isFunction(api.tx.balances.transferAll)
+              ? isFunction(api.tx.balances?.transferAll)
                 ? [propRecipientId || recipientId, false]
                 : [propRecipientId || recipientId, maxTransfer]
               : [propRecipientId || recipientId, amount]
           }
           tx={
-            canToggleAll && isAll && isFunction(api.tx.balances.transferAll)
-              ? api.tx.balances.transferAll
+            canToggleAll && isAll && isFunction(api.tx.balances?.transferAll)
+              ? api.tx.balances?.transferAll
               : isProtected
-                ? api.tx.balances.transferKeepAlive
-                : api.tx.balances.transfer
+                ? api.tx.balances?.transferKeepAlive
+                : api.tx.balances?.transfer
           }
         />
       </Modal.Actions>


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

See #6780:

- handle if `tx.balances` or `consts.balances` are undefined on Accounts page and Transfer model
- don't show Send button on sidebar if `tx.balances` is undefined