### PR TITLE
Add geometry labs endpoints for polkadot and kusama back

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -22,7 +22,7 @@ export function createKusama (t: TFunction): EndpointOption {
     providers: {
       Parity: 'wss://kusama-rpc.polkadot.io',
       OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
-      // 'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
+      'Geometry Labs (Dev)': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
       Dwellir: 'wss://kusama-rpc.dwellir.com',
       'light client': 'light://substrate-connect/kusama'
       // Pinknode: 'wss://rpc.pinknode.io/kusama/explorer' // https://github.com/polkadot-js/apps/issues/5721

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -22,7 +22,7 @@ export function createKusama (t: TFunction): EndpointOption {
     providers: {
       Parity: 'wss://kusama-rpc.polkadot.io',
       OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
-      'Geometry Labs (Dev)': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
+      'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
       Dwellir: 'wss://kusama-rpc.dwellir.com',
       'light client': 'light://substrate-connect/kusama'
       // Pinknode: 'wss://rpc.pinknode.io/kusama/explorer' // https://github.com/polkadot-js/apps/issues/5721

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -22,7 +22,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
     providers: {
       Parity: 'wss://rpc.polkadot.io',
       OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-      // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
+      'Geometry Labs (Dev)': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
       Dwellir: 'wss://polkadot-rpc.dwellir.com',
       'light client': 'light://substrate-connect/polkadot'
       // Pinknode: 'wss://rpc.pinknode.io/polkadot/explorer' // https://github.com/polkadot-js/apps/issues/5721

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -22,7 +22,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
     providers: {
       Parity: 'wss://rpc.polkadot.io',
       OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-      'Geometry Labs (Dev)': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
+      'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
       Dwellir: 'wss://polkadot-rpc.dwellir.com',
       'light client': 'light://substrate-connect/polkadot'
       // Pinknode: 'wss://rpc.pinknode.io/polkadot/explorer' // https://github.com/polkadot-js/apps/issues/5721


### PR DESCRIPTION
## Summary

We have worked to remedy the previous issues with the the Geometry Labs Kusama and Polkadot endpoints (as were brought to our attention via #6746, and as outlined below), and request that they be reenabled. We apologize for the inconvenience our faulty endpoints caused and have implemented measures to mitigate any future issues.

Even though our endpoints appear stable per our [status page](https://status.substrate.geometry.io/), we have listed them as `Geometry Labs (Dev)` until a little more time under real world load. While we have done load testing with json-rpc and websockets, we still want to see them used a bit more before removing the `(Dev)` label in another PR. 

## Post-mortem (in brief)

### Poor visibility

When the original PR to include the endpoints was merged, we had believed that the infrastructure would be able to handle the influx of traffic and things appeared to function through our testing. The checks used on the status page currently only function by checking the responses of JSON-RPC requests, however the routes involved were essentially the same, and no websocket liveliness checker was available for the status page builder. We had believed that this would have sufficiently given us visibility into the liveliness of the endpoints, but it did not.

A misconfiguration in our service mesh that was introduced after the PR merge had correctly routed the traffic to the JSON-RPC endpoints but did not route the websocket traffic, which went undetected by the status page. This misconfiguration has been corrected and traffic is now being routed for both types of services on both networks. Further, we are currently developing a compatible websocket monitor for the status page which will alert us to future incidents immediately.

### Bad websocket handling

As part of our collection of metrics, websocket connections are proxied through a container that extracts information about the various requests being made (date and time, RPC method, etc.). The code that handled the websocket connections between the container and the instances used an older Golang package that caused connections to frequently be reset causing a poor UX when using the endpoints in polkadot-js. We have since updated the websocket handling code and these errors no longer impact connections.

### Cascading/flapping health checks

As part of the aggregation of connections between and within regions, there are multiple points where instance health is checked. Due to a misconfiguration in the way these checks were handled, instances were aggressively removed and then subsequently readded to pools under higher load conditions. When the cluster-local health checks began to flap, connections were broken and migrated, but the incorrect health checks propagated up to our global load balancers, which subsequently disconnected entire regions. These health checks have now been properly configured and will no longer aggressively remove instances under load.

### Incorrect instance sizing

When originally selecting instance types for the nodes, we had originally had the intention of running individual networks on separate instances. The decision was made to aggregate the networks onto single instances, but the instance type was not changed appropriately to account for the increased connection load. Different instance types have been selected and the minimum resources have been increased.