### PR TITLE
Allow to upload a JSON file with the list of multisig signatories

### DIFF
--- a/packages/page-accounts/src/modals/MultisigCreate.tsx
+++ b/packages/page-accounts/src/modals/MultisigCreate.tsx
@@ -6,10 +6,22 @@ import type { ModalProps } from '../types';
 
 import React, { useCallback, useState } from 'react';
 
-import { Button, Input, InputAddressMulti, InputNumber, Modal } from '@polkadot/react-components';
+import {
+  AddressMini,
+  Button,
+  IconLink,
+  Input,
+  InputAddressMulti,
+  InputFile,
+  InputNumber,
+  Labelled,
+  MarkError,
+  Modal,
+} from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { keyring } from '@polkadot/ui-keyring';
-import { BN } from '@polkadot/util';
+import { assert, BN, u8aToString } from '@polkadot/util';
+import { validateAddress } from '@polkadot/util-crypto';
 
 import useKnownAddresses from '../Accounts/useKnownAddresses';
 import { useTranslation } from '../translate';
@@ -26,8 +38,40 @@ interface CreateOptions {
   tags?: string[];
 }
 
+interface UploadedFileData {
+  isUploadedFileValid: boolean;
+  uploadedFileError: string;
+  uploadedSignatories: string[];
+}
+
 const MAX_SIGNATORIES = 16;
 const BN_TWO = new BN(2);
+
+const acceptedFormats = ['application/json'].join(', ');
+
+function parseFile (file: Uint8Array): UploadedFileData {
+  let uploadError = '';
+  let items: string[];
+
+  try {
+    items = JSON.parse(u8aToString(file)) as string[];
+    assert(Array.isArray(items) && !!items.length, 'JSON file should contain an array of signatories');
+
+    items = items.filter(item => validateAddress(item));
+    items = [...new Set(items)]; // remove duplicates
+
+    assert(items.length <= MAX_SIGNATORIES, `Maximum you can have ${MAX_SIGNATORIES} signatories`);
+  } catch (error) {
+    items = [];
+    uploadError = (error as Error).message ? (error as Error).message : (error as Error).toString();
+  }
+
+  return {
+    isUploadedFileValid: !uploadError,
+    uploadedFileError: uploadError,
+    uploadedSignatories: items,
+  };
+}
 
 function createMultisig (signatories: string[], threshold: BN | number, { genesisHash, name, tags = [] }: CreateOptions, success: string): ActionStatus {
   // we will fill in all the details below
@@ -53,6 +97,11 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
   const { t } = useTranslation();
   const availableSignatories = useKnownAddresses();
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
+  const [{ isUploadedFileValid, uploadedFileError, uploadedSignatories }, setUploadedFile] = useState<UploadedFileData>({
+    uploadedFileError: '',
+    isUploadedFileValid: true,
+    uploadedSignatories: [],
+  });
   const [signatories, setSignatories] = useState<string[]>(['']);
   const [{ isThresholdValid, threshold }, setThreshold] = useState({ isThresholdValid: true, threshold: BN_TWO });
 
@@ -78,6 +127,38 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
     [signatories]
   );
 
+  const _onChangeFile = useCallback(
+    (file: Uint8Array) => {
+      const fileData = parseFile(file);
+
+      setUploadedFile(fileData);
+
+      if (fileData.isUploadedFileValid || uploadedSignatories.length) {
+        setSignatories(fileData.uploadedSignatories.length ? fileData.uploadedSignatories : ['']);
+      }
+    },
+    [uploadedSignatories]
+  );
+
+  const resetFileUpload = useCallback(
+    () => {
+      setUploadedFile({
+        uploadedFileError,
+        isUploadedFileValid,
+        uploadedSignatories: [],
+      });
+    },
+    [uploadedFileError, isUploadedFileValid]
+  );
+
+  const _onChangeAddressMulti = useCallback(
+    (items: string[]) => {
+      resetFileUpload();
+      setSignatories(items);
+    },
+    []
+  );
+
   const isValid = isNameValid && isThresholdValid;
 
   return (
@@ -88,23 +169,63 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
       size='large'
     >
       <Modal.Content>
-        <Modal.Columns
-          hint={
-            <>
-              <p>{t<string>('The signatories has the ability to create transactions using the multisig and approve transactions sent by others.Once the threshold is reached with approvals, the multisig transaction is enacted on-chain.')}</p>
-              <p>{t<string>('Since the multisig function like any other account, once created it is available for selection anywhere accounts are used and needs to be funded before use.')}</p>
-            </>
-          }
-        >
-          <InputAddressMulti
-            available={availableSignatories}
-            availableLabel={t<string>('available signatories')}
-            help={t<string>('The addresses that are able to approve multisig transactions. You can select up to {{maxHelpers}} trusted addresses.', { replace: { maxHelpers: MAX_SIGNATORIES } })}
-            maxCount={MAX_SIGNATORIES}
-            onChange={setSignatories}
-            value={signatories}
-            valueLabel={t<string>('selected signatories')}
+        {!uploadedSignatories.length && (
+          <Modal.Columns
+            hint={
+              <>
+                <p>{t<string>('The signatories has the ability to create transactions using the multisig and approve transactions sent by others.Once the threshold is reached with approvals, the multisig transaction is enacted on-chain.')}</p>
+                <p>{t<string>('Since the multisig function like any other account, once created it is available for selection anywhere accounts are used and needs to be funded before use.')}</p>
+              </>
+            }
+          >
+            <InputAddressMulti
+              available={availableSignatories}
+              availableLabel={t<string>('available signatories')}
+              help={t<string>('The addresses that are able to approve multisig transactions. You can select up to {{maxHelpers}} trusted addresses.', { replace: { maxHelpers: MAX_SIGNATORIES } })}
+              maxCount={MAX_SIGNATORIES}
+              onChange={_onChangeAddressMulti}
+              value={signatories}
+              valueLabel={t<string>('selected signatories')}
+            />
+          </Modal.Columns>
+        )}
+        <Modal.Columns hint={t<string>('Supply a JSON file with the list of signatories.')}>
+          <InputFile
+            accept={acceptedFormats}
+            className='full'
+            help={t<string>('Select a JSON key file with the list of signatories.')}
+            clearContent={!uploadedSignatories.length && isUploadedFileValid}
+            isError={!isUploadedFileValid}
+            label={t<string>('upload signatories list')}
+            onChange={_onChangeFile}
+            withLabel
           />
+          {!!uploadedSignatories.length && (
+            <Labelled
+              label={t<string>('Detected signatories')}
+              labelExtra={(
+                <IconLink
+                  icon='sync'
+                  label={t<string>('Reset')}
+                  onClick={resetFileUpload}
+                />
+              )}
+            >
+              <div className='ui--Static ui dropdown selection'>
+              {uploadedSignatories.map((address): React.ReactNode => (
+                <div key={address}>
+                  <AddressMini
+                    value={address}
+                    withSidebar={false}
+                  />
+                </div>
+              ))}
+              </div>
+            </Labelled>
+          )}
+          {uploadedFileError && (
+            <MarkError content={uploadedFileError} />
+          )}
         </Modal.Columns>
         <Modal.Columns hint={t<string>('The threshold for approval should be less or equal to the number of signatories for this multisig.')}>
           <InputNumber

--- a/packages/page-accounts/src/modals/MultisigCreate.tsx
+++ b/packages/page-accounts/src/modals/MultisigCreate.tsx
@@ -191,7 +191,7 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
           />
           {!!uploadedSignatories.length && (
             <Labelled
-              label={t<string>('Detected signatories')}
+              label={t<string>('found signatories')}
               labelExtra={(
                 <IconLink
                   icon='sync'

--- a/packages/page-accounts/src/modals/MultisigCreate.tsx
+++ b/packages/page-accounts/src/modals/MultisigCreate.tsx
@@ -6,18 +6,7 @@ import type { ModalProps } from '../types';
 
 import React, { useCallback, useState } from 'react';
 
-import {
-  AddressMini,
-  Button,
-  IconLink,
-  Input,
-  InputAddressMulti,
-  InputFile,
-  InputNumber,
-  Labelled,
-  MarkError,
-  Modal,
-} from '@polkadot/react-components';
+import { AddressMini, Button, IconLink, Input, InputAddressMulti, InputFile, InputNumber, Labelled, MarkError, Modal } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { keyring } from '@polkadot/ui-keyring';
 import { assert, BN, u8aToString } from '@polkadot/util';
@@ -57,7 +46,7 @@ function parseFile (file: Uint8Array): UploadedFileData {
     items = JSON.parse(u8aToString(file)) as string[];
     assert(Array.isArray(items) && !!items.length, 'JSON file should contain an array of signatories');
 
-    items = items.filter(item => validateAddress(item));
+    items = items.filter((item) => validateAddress(item));
     items = [...new Set(items)]; // remove duplicates
 
     assert(items.length <= MAX_SIGNATORIES, `Maximum you can have ${MAX_SIGNATORIES} signatories`);
@@ -69,7 +58,7 @@ function parseFile (file: Uint8Array): UploadedFileData {
   return {
     isUploadedFileValid: !uploadError,
     uploadedFileError: uploadError,
-    uploadedSignatories: items,
+    uploadedSignatories: items
   };
 }
 
@@ -98,9 +87,9 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
   const availableSignatories = useKnownAddresses();
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
   const [{ isUploadedFileValid, uploadedFileError, uploadedSignatories }, setUploadedFile] = useState<UploadedFileData>({
-    uploadedFileError: '',
     isUploadedFileValid: true,
-    uploadedSignatories: [],
+    uploadedFileError: '',
+    uploadedSignatories: []
   });
   const [signatories, setSignatories] = useState<string[]>(['']);
   const [{ isThresholdValid, threshold }, setThreshold] = useState({ isThresholdValid: true, threshold: BN_TWO });
@@ -143,9 +132,9 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
   const resetFileUpload = useCallback(
     () => {
       setUploadedFile({
-        uploadedFileError,
         isUploadedFileValid,
-        uploadedSignatories: [],
+        uploadedFileError,
+        uploadedSignatories: []
       });
     },
     [uploadedFileError, isUploadedFileValid]
@@ -156,7 +145,7 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
       resetFileUpload();
       setSignatories(items);
     },
-    []
+    [resetFileUpload]
   );
 
   const isValid = isNameValid && isThresholdValid;
@@ -193,8 +182,8 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
           <InputFile
             accept={acceptedFormats}
             className='full'
-            help={t<string>('Select a JSON key file with the list of signatories.')}
             clearContent={!uploadedSignatories.length && isUploadedFileValid}
+            help={t<string>('Select a JSON key file with the list of signatories.')}
             isError={!isUploadedFileValid}
             label={t<string>('upload signatories list')}
             onChange={_onChangeFile}
@@ -212,14 +201,14 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
               )}
             >
               <div className='ui--Static ui dropdown selection'>
-              {uploadedSignatories.map((address): React.ReactNode => (
-                <div key={address}>
-                  <AddressMini
-                    value={address}
-                    withSidebar={false}
-                  />
-                </div>
-              ))}
+                {uploadedSignatories.map((address): React.ReactNode => (
+                  <div key={address}>
+                    <AddressMini
+                      value={address}
+                      withSidebar={false}
+                    />
+                  </div>
+                ))}
               </div>
             </Labelled>
           )}

--- a/packages/page-accounts/src/modals/MultisigCreate.tsx
+++ b/packages/page-accounts/src/modals/MultisigCreate.tsx
@@ -5,8 +5,9 @@ import type { ActionStatus } from '@polkadot/react-components/Status/types';
 import type { ModalProps } from '../types';
 
 import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
 
-import { AddressMini, Button, IconLink, Input, InputAddressMulti, InputFile, InputNumber, Labelled, MarkError, Modal } from '@polkadot/react-components';
+import { AddressMini, Button, IconLink, Input, InputAddressMulti, InputFile, InputNumber, Labelled, MarkError, Modal, Toggle } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { keyring } from '@polkadot/ui-keyring';
 import { assert, BN, u8aToString } from '@polkadot/util';
@@ -92,6 +93,7 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
     uploadedSignatories: []
   });
   const [signatories, setSignatories] = useState<string[]>(['']);
+  const [showSignaturesUpload, setShowSignaturesUpload] = useState(false);
   const [{ isThresholdValid, threshold }, setThreshold] = useState({ isThresholdValid: true, threshold: BN_TWO });
 
   const _createMultisig = useCallback(
@@ -158,7 +160,15 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
       size='large'
     >
       <Modal.Content>
-        {!uploadedSignatories.length && (
+        <Modal.Columns>
+          <Toggle
+            className='signaturesFileToggle'
+            label={t<string>('Upload JSON file with signatories')}
+            onChange={setShowSignaturesUpload}
+            value={showSignaturesUpload}
+          />
+        </Modal.Columns>
+        {!showSignaturesUpload && (
           <Modal.Columns
             hint={
               <>
@@ -178,44 +188,46 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
             />
           </Modal.Columns>
         )}
-        <Modal.Columns hint={t<string>('Supply a JSON file with the list of signatories.')}>
-          <InputFile
-            accept={acceptedFormats}
-            className='full'
-            clearContent={!uploadedSignatories.length && isUploadedFileValid}
-            help={t<string>('Select a JSON key file with the list of signatories.')}
-            isError={!isUploadedFileValid}
-            label={t<string>('upload signatories list')}
-            onChange={_onChangeFile}
-            withLabel
-          />
-          {!!uploadedSignatories.length && (
-            <Labelled
-              label={t<string>('found signatories')}
-              labelExtra={(
-                <IconLink
-                  icon='sync'
-                  label={t<string>('Reset')}
-                  onClick={resetFileUpload}
-                />
-              )}
-            >
-              <div className='ui--Static ui dropdown selection'>
-                {uploadedSignatories.map((address): React.ReactNode => (
-                  <div key={address}>
-                    <AddressMini
-                      value={address}
-                      withSidebar={false}
-                    />
-                  </div>
-                ))}
-              </div>
-            </Labelled>
-          )}
-          {uploadedFileError && (
-            <MarkError content={uploadedFileError} />
-          )}
-        </Modal.Columns>
+        {showSignaturesUpload && (
+          <Modal.Columns hint={t<string>('Supply a JSON file with the list of signatories.')}>
+            <InputFile
+              accept={acceptedFormats}
+              className='full'
+              clearContent={!uploadedSignatories.length && isUploadedFileValid}
+              help={t<string>('Select a JSON key file with the list of signatories.')}
+              isError={!isUploadedFileValid}
+              label={t<string>('upload signatories list')}
+              onChange={_onChangeFile}
+              withLabel
+            />
+            {!!uploadedSignatories.length && (
+              <Labelled
+                label={t<string>('found signatories')}
+                labelExtra={(
+                  <IconLink
+                    icon='sync'
+                    label={t<string>('Reset')}
+                    onClick={resetFileUpload}
+                  />
+                )}
+              >
+                <div className='ui--Static ui dropdown selection'>
+                  {uploadedSignatories.map((address): React.ReactNode => (
+                    <div key={address}>
+                      <AddressMini
+                        value={address}
+                        withSidebar={false}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </Labelled>
+            )}
+            {uploadedFileError && (
+              <MarkError content={uploadedFileError} />
+            )}
+          </Modal.Columns>
+        )}
         <Modal.Columns hint={t<string>('The threshold for approval should be less or equal to the number of signatories for this multisig.')}>
           <InputNumber
             help={t<string>('The threshold for this multisig')}
@@ -249,4 +261,9 @@ function Multisig ({ className = '', onClose, onStatusChange }: Props): React.Re
   );
 }
 
-export default React.memo(Multisig);
+export default React.memo(styled(Multisig)`
+  .signaturesFileToggle {
+    width: 100%;
+    text-align: right;
+  }
+`);


### PR DESCRIPTION
This PR adds a new file upload field, so it could be possible to upload a list of multisig signatories

![image](https://user-images.githubusercontent.com/5252494/152006309-72957de5-3ff9-4180-b782-fb9313fb0022.png)

When the file gets uploaded it hides the current accounts selection row and displays found addresses in the provided JSON file.

![image](https://user-images.githubusercontent.com/5252494/152006517-2d6454f3-5da2-4efb-81f9-e59595e6e172.png)


