### PR TITLE
change width of line below the tab (active and hover)

### DIFF
--- a/packages/react-components/src/Tabs/Tab.tsx
+++ b/packages/react-components/src/Tabs/Tab.tsx
@@ -70,7 +70,7 @@ export default React.memo(styled(Tab)`
     &.tabLinkActive .tabLinkText::after {
       content: '';
       position: absolute;
-      width: 3.14rem;
+      width: 100%;
       height: 2px;
       bottom: -2px;
       left: 50%;

--- a/packages/react-components/src/Tabs/Tab.tsx
+++ b/packages/react-components/src/Tabs/Tab.tsx
@@ -61,15 +61,16 @@ export default React.memo(styled(Tab)`
     &:hover {
       color: #8B8B8B;
 
-      .tabLinkText::after{
+      &::after{
         background-color: #8B8B8B;
       }
     }
 
-    &:hover .tabLinkText::after,
-    &.tabLinkActive .tabLinkText::after {
+    &:hover::after,
+    &.tabLinkActive::after {
       content: '';
       position: absolute;
+      left: 0;
       width: 100%;
       height: 2px;
       bottom: -2px;

--- a/packages/react-components/src/Tabs/Tab.tsx
+++ b/packages/react-components/src/Tabs/Tab.tsx
@@ -73,8 +73,6 @@ export default React.memo(styled(Tab)`
       width: 100%;
       height: 2px;
       bottom: -2px;
-      left: 50%;
-      transform: translateX(-50%);
     }
 
   &.tabLinkActive {

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -310,7 +310,7 @@ export default createGlobalStyle<Props & ThemeProps>(({ theme, uiHighlight }: Pr
 
   .theme--dark,
   .theme--light {
-    .ui--Tabs .tabLinkActive .tabLinkText::after{
+    .ui--Tabs .tabLinkActive::after {
         background: ${getHighlight(uiHighlight)};
     }
 


### PR DESCRIPTION
The line below the Tab (both active and hover)) should have same width as the tab, otherwise it looks and feels too short.