### PR TITLE
Enable Zeitgeist and Subsocial

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -379,7 +379,6 @@ export function createKusama (t: TFunction): EndpointOption {
       },
       {
         info: 'zeitgeist',
-        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6635
         homepage: 'https://zeitgeist.pm',
         paraId: 2101,
         text: t('rpc.kusama.zeitgeist', 'Zeitgeist', { ns: 'apps-config' }),

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -360,7 +360,6 @@ export function createKusama (t: TFunction): EndpointOption {
       },
       {
         info: 'subsocial',
-        isUnreachable: true, // https://github.com/polkadot-js/apps/issues/6550
         homepage: 'https://subsocial.network/',
         paraId: 2100,
         text: t('rpc.kusama.subsocial', 'Subsocial', { ns: 'apps-config' }),


### PR DESCRIPTION
This PR activates the ZeitgeistPM endpoint within the list of Kusama parachains.
The endpoint is reachable now: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.zeitgeist.pm#/explorer