### PR TITLE
make encointer teleporter on westend

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -28,7 +28,7 @@ export function createWestend (t: TFunction): EndpointOption {
       'light client': 'light://substrate-connect/westend'
       // 'NodeFactory(Vedran)': 'wss://westend.vedran.nodefactory.io/ws', // https://github.com/polkadot-js/apps/issues/5580
     },
-    teleport: [1000],
+    teleport: [1000, 1001],
     linked: [
       // (1) system parachains (none available yet)
       // ...
@@ -39,6 +39,15 @@ export function createWestend (t: TFunction): EndpointOption {
         text: t('rpc.westend.shell', 'Westmint', { ns: 'apps-config' }),
         providers: {
           Parity: 'wss://westmint-rpc.polkadot.io'
+        },
+        teleport: [-1]
+      },
+      {
+        info: 'encointer',
+        paraId: 1001,
+        text: t('rpc.westend.encointer', 'Encointer Network', { ns: 'apps-config' }),
+        providers: {
+          'Encointer Association': 'wss://api.westend.encointer.org'
         },
         teleport: [-1]
       },
@@ -60,14 +69,6 @@ export function createWestend (t: TFunction): EndpointOption {
         text: t('rpc.westend.charcoal', 'Charcoal', { ns: 'apps-config' }),
         providers: {
           Centrifuge: 'wss://fullnode-collator.charcoal.centrifuge.io'
-        }
-      },
-      {
-        info: 'encointer',
-        paraId: 1001,
-        text: t('rpc.westend.encointer', 'Encointer Network', { ns: 'apps-config' }),
-        providers: {
-          'Encointer Association': 'wss://api.westend.encointer.org'
         }
       },
       {


### PR DESCRIPTION
since runtime 9016, Encointer is a trusted teleporter. This PR adds UI functionality for this

https://github.com/paritytech/polkadot/blob/41ab002d7451766324a9f314fee11c9c53314350/runtime/westend/src/xcm_config.rs#L75-L85