### PR TITLE
calamari endpoints: switch to load balancer

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -93,10 +93,7 @@ export function createKusama (t: TFunction): EndpointOption {
         paraId: 2084,
         text: t('rpc.calamari.systems', 'Calamari', { ns: 'apps-config' }),
         providers: {
-          'Calamari Falafel': 'wss://falafel.calamari.systems/',
-          'Calamari Fritti': 'wss://fritti.calamari.systems/',
-          'Calamari Pasta': 'wss://pasta.calamari.systems/',
-          'Calamari Smoothie': 'wss://smoothie.calamari.systems/',
+          'Manta Network': 'wss://ws.calamari.systems/',
           OnFinality: 'wss://calamari.api.onfinality.io/public-ws'
         }
       },


### PR DESCRIPTION
this change removes individual manta/calamari network nodes in favour of a latency based dns load-balancer url that automatically selects a healthy node with the lowest latency for the request client