### PR TITLE
Fix contract trapped

### DIFF
--- a/packages/page-contracts/src/Codes/Upload.tsx
+++ b/packages/page-contracts/src/Codes/Upload.tsx
@@ -92,7 +92,7 @@ function Upload ({ onClose }: Props): React.ReactElement {
         ? code.tx[contractAbi.constructors[constructorIndex].method]({
           gasLimit: weight.weight,
           storageDepositLimit: null,
-          value
+          value: contractAbi?.constructors[constructorIndex].isPayable ? value : undefined
         }, ...params)
         : null;
     } catch (e) {
@@ -200,14 +200,17 @@ function Upload ({ onClose }: Props): React.ReactElement {
               params={contractAbi.constructors[constructorIndex].args}
               registry={contractAbi.registry}
             />
-            <InputBalance
-              help={t<string>('The balance to transfer from the `origin` to the newly created contract.')}
-              isError={!isValueValid}
-              isZeroable={hasStorageDeposit}
-              label={t<string>('value')}
-              onChange={setValue}
-              value={value}
-            />
+            {contractAbi.constructors[constructorIndex].isPayable && (
+              <InputBalance
+                help={t<string>('The balance to transfer from the `origin` to the newly created contract.')}
+                isError={!isValueValid}
+                isZeroable={hasStorageDeposit}
+                label={t<string>('value')}
+                onChange={setValue}
+                value={value}
+              />
+            )
+            }
             <InputMegaGas
               help={t<string>('The maximum amount of gas that can be used by this deployment, if the code requires more, the deployment will fail')}
               weight={weight}

--- a/packages/page-contracts/src/Contracts/Deploy.tsx
+++ b/packages/page-contracts/src/Contracts/Deploy.tsx
@@ -86,7 +86,7 @@ function Deploy ({ codeHash, constructorIndex = 0, onClose, setConstructorIndex 
               ? salt
               : null,
             storageDepositLimit: null,
-            value
+            value: contractAbi?.constructors[constructorIndex].isPayable ? value : undefined
           }, ...params);
         } catch (error) {
           return null;
@@ -172,14 +172,16 @@ function Deploy ({ codeHash, constructorIndex = 0, onClose, setConstructorIndex 
             />
           </>
         )}
-        <InputBalance
-          help={t<string>('The balance to transfer from the `origin` to the newly created contract.')}
-          isError={!isValueValid}
-          isZeroable={hasStorageDeposit}
-          label={t<string>('value')}
-          onChange={setValue}
-          value={value}
-        />
+        {contractAbi?.constructors[constructorIndex].isPayable && (
+          <InputBalance
+            help={t<string>('The balance to transfer from the `origin` to the newly created contract.')}
+            isError={!isValueValid}
+            isZeroable={hasStorageDeposit}
+            label={t<string>('value')}
+            onChange={setValue}
+            value={value}
+          />
+        )}
         <Input
           help={t<string>('A hex or string value that acts as a salt for this deployment.')}
           isDisabled={!withSalt}


### PR DESCRIPTION
Constructors are not payable by default so the instantiation was failing with `ContractTrapped` when passing any value (endowment)
Fixes https://substrate.stackexchange.com/questions/120/polkadot-canvas-testnet-contract-deploy-error-contracts-contracttrapped


The instantiation still fails with `NewContractNotFunded` because Canvas needs an update (coming soon)
Not sure this PR is needed though, the error might be fixed with the Canvas update.
