### PR TITLE
fix: Opportunity chain re-enabled

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -332,7 +332,7 @@ export function createTesting (t: TFunction, firstOnly: boolean, withSort: boole
     },
     {
       info: 'opportunity',
-      isDisabled: true, // https://github.com/polkadot-js/apps/issues/6935
+      isDisabled: false,
       text: t('rpc.test.opportunity', 'Opportunity', { ns: 'apps-config' }),
       providers: {
         'Standard Protocol': 'wss://rpc.opportunity.standard.tech'


### PR DESCRIPTION
Node responsible for the RPC had additional heavy traffic, thus failing health-checks. This is load-balanced now, so should be good to reenable.