### PR TITLE
Updated Moonbeam Foundation's Moonriver endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -253,7 +253,7 @@ export function createKusama (t: TFunction): EndpointOption {
         paraId: 2023,
         text: t('rpc.kusama.moonriver', 'Moonriver', { ns: 'apps-config' }),
         providers: {
-          'Moonbeam Foundation': 'wss://wss.moonriver.moonbeam.network',
+          'Moonbeam Foundation': 'wss://wss.api.moonriver.moonbeam.network',
           OnFinality: 'wss://moonriver.api.onfinality.io/public-ws',
           Pinknode: 'wss://rpc.pinknode.io/moonriver/explorer'
         }


### PR DESCRIPTION
The Moonbeam Foundation has recently changed their URL structure for public APIs. This change reflects that.