### PR TITLE
Align interlay derives with actual API (outdated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,42 @@
 
 ## master
 
+Contributed:
+
+- Enable Encointer <-> Kusama teleports (Thanks to https://github.com/brenzi)
+- Add Substrate IPFS files module (Thanks to https://github.com/badkk)
+- Hotfix for progress styles (Thanks to https://github.com/yashirooooo)
+- Add Ajuna network (Thanks to https://github.com/cowboy-bebug)
+- Adjust Crab config (Thanks to https://github.com/sxlwar)
+- Add Rococo Efinity (Thanks to https://github.com/stanly-johnson)
+- Add Rococo Moonsame (Thanks to https://github.com/kyilkhor)
+- Add Kusama Mangata network (Thanks to https://github.com/mateuszaaa)
+- Add Geminis parachain (Thanks to https://github.com/dm4)
+- Update Odyssey parachain (Thanks to https://github.com/jiyilanzhou)
+- Update Iterlay endpoints (Thanks to https://github.com/nud3l)
+- Update Opportunity endpoints (Thanks to https://github.com/firke)
+- Update Moonriver endpoints (Thanks to https://github.com/fxgamundi)
+- Update Bifrost testnet endpoints (Thanks to https://github.com/awesomepan)
+- Add OnFinality endpoint for Integritee (Thanks to https://github.com/mosonyi)
+- Add OnFinality endpoint for Pontem (Thanks to https://github.com/banananeko)
+- Add OnFinality endpoint for Crust (Thanks to https://github.com/banananeko)
+- Add Dwellir endpoint for Westend (Thanks to https://github.com/Maharacha)
+- Add Dwellir endpoints for Moonbeam/Moonriver (Thanks to https://github.com/Maharacha)
+- Adjust Subspace custom derives (Thanks to https://github.com/1devNdogs)
+- Adjust Russian i18n (Thanks to https://github.com/Gregog)
+
 Changes:
 
+- Display named reserves for reserved breakdown
+- Allow for population & submission of decoded extrinsics
+- Correct calculation for lease start (w/ leaseOffset usage)
 - Adjust teleport to only cater for latest XCM
 - Add blocktime latency tab to Explorer
 - Allow decoded extrinsics to populate submission
 - Disable unreachable endpoints
+- Cleanup Crowdloan types usage
+- Disable all unreachable endpoints
+- Display correct ss58 prefix for connected node (once changed)
 
 
 ## 0.106.1 Feb 14, 2022

--- a/packages/apps-config/src/api/spec/interbtc.ts
+++ b/packages/apps-config/src/api/spec/interbtc.ts
@@ -29,6 +29,7 @@ function defaultAccountBalance (): DeriveBalancesAll {
     freeBalance: balanceOf(0),
     lockedBalance: balanceOf(0),
     lockedBreakdown: [],
+    namedReserves: [],
     reservedBalance: balanceOf(0)
   } as any;
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/7065

Actually this whole derive as added needs a rip-out and re-do. This issue is because the code bypasses the type-checker with `any` it creates issues such as this. Where the type-checker can be of help is is helpless and invalid data structures are returned.