### PR TITLE
changing 'tense' of label, because funds are not yet 'bonded'

### DIFF
--- a/packages/page-staking/src/Actions/Account/BondExtra.tsx
+++ b/packages/page-staking/src/Actions/Account/BondExtra.tsx
@@ -73,7 +73,7 @@ function BondExtra ({ controllerId, onClose, stakingInfo, stashId }: Props): Rea
               defaultValue={startBalance}
               help={t<string>('Amount to add to the currently bonded funds. This is adjusted using the available funds on the account.')}
               isError={!!amountError?.error || !maxAdditional || maxAdditional.eqn(0)}
-              label={t<string>('additional bonded funds')}
+              label={t<string>('additional funds to bond')}
               labelExtra={
                 <BalanceFree
                   label={<span className='label'>{t<string>('balance')}</span>}


### PR DESCRIPTION
The label 
**additional bonded funds** 
is shown when users are about to bond additional funds. It suggests that the funds are already bonded which is not the case. Therefore, I propose to change the content of the label to 
**additional funds to bond**.