### PR TITLE
[encointer] remove westend

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -43,15 +43,6 @@ export function createWestend (t: TFunction): EndpointOption {
         },
         teleport: [-1]
       },
-      {
-        info: 'encointer',
-        paraId: 1001,
-        text: t('rpc.westend.encointer', 'Encointer Network', { ns: 'apps-config' }),
-        providers: {
-          'Encointer Association': 'wss://api.westend.encointer.org'
-        },
-        teleport: [-1]
-      },
       // (3) parachains with id, see Rococo (info here maps to the actual "named icon")
       //
       // NOTE: Added alphabetical based on chain name

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -29,7 +29,7 @@ export function createWestend (t: TFunction): EndpointOption {
       'light client': 'light://substrate-connect/westend'
       // 'NodeFactory(Vedran)': 'wss://westend.vedran.nodefactory.io/ws', // https://github.com/polkadot-js/apps/issues/5580
     },
-    teleport: [1000, 1001],
+    teleport: [1000],
     linked: [
       // (1) system parachains (none available yet)
       // ...


### PR DESCRIPTION
We have stopped our westend ( api.westend.encointer.org ), therefore deleted from config.