### PR TITLE
Allow Crowdloan Dissolve by Anyone When Ended

### DIFF
--- a/packages/page-parachains/src/Crowdloan/Fund.tsx
+++ b/packages/page-parachains/src/Crowdloan/Fund.tsx
@@ -159,7 +159,7 @@ function Fund ({ bestHash, bestNumber, className = '', isOngoing, leasePeriod, v
             accountId={depositor}
             className='media--1400'
             icon='times'
-            isDisabled={!isDepositor}
+            isDisabled={!(isDepositor || hasEnded)}
             label={
               isEnded
                 ? t<string>('Close')


### PR DESCRIPTION
The logic in the crowdloan pallet is:

```rust
// Only allow dissolution when the raised funds goes to zero,
// and the caller is the fund creator or we are past the end date.
let permitted = who == fund.depositor || now >= fund.end;
let can_dissolve = permitted && fund.raised.is_zero();
ensure!(can_dissolve, Error::<T>::NotReadyToDissolve);
```

https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdloan/mod.rs#L559

As long as the fund `hasEnded`, anyone should be allowed to call "Close" to dissolve a crowdloan.