### PR TITLE
Add "Copy" icon to the User Sidebar

### DIFF
--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -71,7 +71,7 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
               <Button.Group>
                 <Button
                   icon={isCopyShown ? 'check' : 'copy'}
-                  label={t<string>('Copy')}
+                  label={wasCopied ? t<string>('Copy') : t<string>('Copy')}
                   onClick={toggle}
                   onMouseLeave={isCopyShown ? toggle : donothing }
                 />

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -21,8 +21,8 @@ interface Props {
 
 function AddressSection ({ accountIndex, defaultValue, editingName, flags, onChange, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [isCopyShown, toggle] = useToggle();
-  const [wasCopied, donothing] = useToggle(false);
+  const [isCopyShown, toggleIsCopyShown] = useToggle();
+  const [, donothing] = useToggle(false);
 
   return (
     <div className='ui--AddressSection'>
@@ -71,9 +71,9 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
               <Button.Group>
                 <Button
                   icon={isCopyShown ? 'check' : 'copy'}
-                  label={wasCopied ? t<string>('Copy') : t<string>('Copy')}
-                  onClick={toggle}
-                  onMouseLeave={isCopyShown ? toggle : donothing }
+                  label={isCopyShown ? t<string>('Copied') : t<string>('Copy')}
+                  onClick={isCopyShown ? donothing : toggleIsCopyShown }
+                  onMouseLeave={isCopyShown ? toggleIsCopyShown : donothing }
                 />
               </Button.Group>
             </span>

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -22,7 +22,7 @@ interface Props {
 function AddressSection ({ accountIndex, defaultValue, editingName, flags, onChange, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [isCopyShown, toggleIsCopyShown] = useToggle();
-  const [, donothing] = useToggle(false);
+  const NOOP = () => undefined;
 
   return (
     <div className='ui--AddressSection'>
@@ -72,8 +72,8 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
                 <Button
                   icon={isCopyShown ? 'check' : 'copy'}
                   label={isCopyShown ? t<string>('Copied') : t<string>('Copy')}
-                  onClick={isCopyShown ? donothing : toggleIsCopyShown }
-                  onMouseLeave={isCopyShown ? toggleIsCopyShown : donothing }
+                  onClick={isCopyShown ? NOOP : toggleIsCopyShown }
+                  onMouseLeave={isCopyShown ? toggleIsCopyShown : NOOP }
                 />
               </Button.Group>
             </span>

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -1,12 +1,17 @@
 // Copyright 2017-2022 @polkadot/page-accounts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+//import React from 'react';
+import React, { useState } from 'react';
+
+import { Button } from '@polkadot/react-components';
 
 import { AccountName, IdentityIcon, Input } from '@polkadot/react-components';
 import { AddressFlags } from '@polkadot/react-hooks/types';
 
 import { useTranslation } from '../translate';
+import {CopyToClipboard} from 'react-copy-to-clipboard';
+
 
 interface Props {
   value: string,
@@ -17,10 +22,20 @@ interface Props {
   accountIndex: string | undefined,
 }
 
+
+
 function AddressSection ({ accountIndex, defaultValue, editingName, flags, onChange, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
+  // Declare a new state variable, which we'll call "count"
+  const [countCopied, setCountCopied] = useState(0);
+
+
+  
   return (
+
+
+    
     <div className='ui--AddressSection'>
       <IdentityIcon
         size={80}
@@ -46,14 +61,35 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
           value={value}
           withSidebar={false}
         />
+       
         <div className='ui--AddressMenu-addr'>
           {value}
         </div>
+        
         {accountIndex && (
           <div className='ui--AddressMenu-index'>
             <label>{t<string>('index')}:</label> {accountIndex}
           </div>
         )}
+      </div>
+
+      <div className='ui--AddressSection__CopyColumn'>
+        <div className='ui--AddressMenu-copyaddr'>         
+          <CopyToClipboard text={value}
+          onCopy={() => setCountCopied(countCopied + 1)}
+          >
+            <span >
+              <Button.Group> 
+                <Button  
+                    icon={countCopied ? 'check' : 'copy'}   
+                    label={t<string>('Copy')} 
+                    onClick={() => setCountCopied(countCopied + 1) }
+                    onMouseLeave={() => setCountCopied(0) } 
+                  /> 
+              </Button.Group>
+            </span>
+          </CopyToClipboard>
+        </div>
       </div>
     </div>
   );

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -30,9 +30,6 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
   const [countCopied, setCountCopied] = useState(0);
   
   return (
-
-
-    
     <div className='ui--AddressSection'>
       <IdentityIcon
         size={80}

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2022 @polkadot/page-accounts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//import React from 'react';
 import React, { useState } from 'react';
 
 import { Button } from '@polkadot/react-components';

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -28,8 +28,6 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
 
   // Declare a new state variable, which we'll call "count"
   const [countCopied, setCountCopied] = useState(0);
-
-
   
   return (
 

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -1,16 +1,14 @@
 // Copyright 2017-2022 @polkadot/page-accounts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState } from 'react';
+import React from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
-import { Button } from '@polkadot/react-components';
-
-import { AccountName, IdentityIcon, Input } from '@polkadot/react-components';
+import { AccountName, Button, IdentityIcon, Input } from '@polkadot/react-components';
+import { useToggle } from '@polkadot/react-hooks';
 import { AddressFlags } from '@polkadot/react-hooks/types';
 
 import { useTranslation } from '../translate';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
-
 
 interface Props {
   value: string,
@@ -21,14 +19,11 @@ interface Props {
   accountIndex: string | undefined,
 }
 
-
-
 function AddressSection ({ accountIndex, defaultValue, editingName, flags, onChange, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const [isCopyShown, toggle] = useToggle();
+  const [wasCopied, donothing] = useToggle(false);
 
-  // Declare a new state variable, which we'll call "count"
-  const [countCopied, setCountCopied] = useState(0);
-  
   return (
     <div className='ui--AddressSection'>
       <IdentityIcon
@@ -55,11 +50,11 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
           value={value}
           withSidebar={false}
         />
-       
+
         <div className='ui--AddressMenu-addr'>
           {value}
         </div>
-        
+
         {accountIndex && (
           <div className='ui--AddressMenu-index'>
             <label>{t<string>('index')}:</label> {accountIndex}
@@ -68,18 +63,18 @@ function AddressSection ({ accountIndex, defaultValue, editingName, flags, onCha
       </div>
 
       <div className='ui--AddressSection__CopyColumn'>
-        <div className='ui--AddressMenu-copyaddr'>         
-          <CopyToClipboard text={value}
-          onCopy={() => setCountCopied(countCopied + 1)}
+        <div className='ui--AddressMenu-copyaddr'>
+          <CopyToClipboard
+            text={value}
           >
-            <span >
-              <Button.Group> 
-                <Button  
-                    icon={countCopied ? 'check' : 'copy'}   
-                    label={t<string>('Copy')} 
-                    onClick={() => setCountCopied(countCopied + 1) }
-                    onMouseLeave={() => setCountCopied(0) } 
-                  /> 
+            <span>
+              <Button.Group>
+                <Button
+                  icon={isCopyShown ? 'check' : 'copy'}
+                  label={t<string>('Copy')}
+                  onClick={toggle}
+                  onMouseLeave={isCopyShown ? toggle : donothing }
+                />
               </Button.Group>
             </span>
           </CopyToClipboard>

--- a/packages/page-accounts/src/Sidebar/AddressSection.tsx
+++ b/packages/page-accounts/src/Sidebar/AddressSection.tsx
@@ -9,7 +9,7 @@ import { AccountName, IdentityIcon, Input } from '@polkadot/react-components';
 import { AddressFlags } from '@polkadot/react-hooks/types';
 
 import { useTranslation } from '../translate';
-import {CopyToClipboard} from 'react-copy-to-clipboard';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 
 interface Props {

--- a/packages/page-accounts/src/Sidebar/Sidebar.tsx
+++ b/packages/page-accounts/src/Sidebar/Sidebar.tsx
@@ -110,6 +110,15 @@ export default React.memo(styled(FullSidebar)`
         overflow: hidden;
       }
     }
+
+    .ui--AddressSection__CopyColumn {
+      margin-left: 1rem;
+
+      .ui--AccountName {
+        max-width: 10rem;
+        overflow: hidden;
+      }
+    }
   }
 
   .ui--AddressMenu-addr,
@@ -125,6 +134,21 @@ export default React.memo(styled(FullSidebar)`
     margin: 0.571rem 0;
     color: var(--color-label);
   }
+
+  .ui--AddressMenu-copyaddr,
+  .ui--AddressMenu-index {
+    font: var(--font-mono);
+    text-align: left;
+    font-size: 0.857rem;
+  }
+
+  .ui--AddressMenu-copyaaddr {
+    word-break: break-all;
+    width: 10ch;
+    margin: 0.371rem 0;
+    color: var(--color-label);
+  }
+
 
   .ui--AddressMenu-index {
     display: flex;

--- a/packages/page-accounts/src/Sidebar/Sidebar.tsx
+++ b/packages/page-accounts/src/Sidebar/Sidebar.tsx
@@ -130,7 +130,7 @@ export default React.memo(styled(FullSidebar)`
 
   .ui--AddressMenu-addr {
     word-break: break-all;
-    width: 26ch;
+    width: 24ch;
     margin: 0.571rem 0;
     color: var(--color-label);
   }
@@ -144,7 +144,7 @@ export default React.memo(styled(FullSidebar)`
 
   .ui--AddressMenu-copyaaddr {
     word-break: break-all;
-    width: 10ch;
+    width: 12ch;
     margin: 0.371rem 0;
     color: var(--color-label);
   }


### PR DESCRIPTION
Closes #7209 

Added the copy icon in the sidebar, on the right side of the address.

<img width="1284" alt="Screenshot 2022-03-24 at 19 02 28" src="https://user-images.githubusercontent.com/28502710/160187333-3be18276-ecdd-4fb8-9172-b4a1ccd41c32.png">

When the user copies the icon changes to a "check" icon until the user leaves the button area.