### PR TITLE
Add missing mangata-parachain types mapping

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -207,6 +207,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   laminar,
   litentry,
   mangata,
+  'mangata-parachain': mangata,
   'manta-node': manta,
   'mashnet-node': kilt,
   mathchain,


### PR DESCRIPTION
Not included as part of https://github.com/polkadot-js/apps/pull/7226
Closes https://github.com/polkadot-js/apps/issues/7227 (team-reported)