### PR TITLE
Updates the ss58 prefix long description to align with substrate (u16)

### DIFF
--- a/packages/apps/public/locales/ar/translation.json
+++ b/packages/apps/public/locales/ar/translation.json
@@ -360,7 +360,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "{{الرقم الموجب أكبر من أو يساوي {{التعريف الحرالقادم",
   "Potential dispatch of referendum {{id}} (if passed)": "(إمكانية إرسال الإستفتاء(إذا تم قبوله {{id}}",
   "Pre-sale ethereum address": "عنوان إيثيريوم مسبق البيع",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "البادئة تشير إلى فورمة عنوان إس إس58 في هذه الشبكة، هو رقم بين 0 ~ 255 يصف الفورما الدقيقة لوحدات بايت العنوان",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "البادئة تشير إلى فورمة عنوان إس إس58 في هذه الشبكة، هو رقم بين 0 ~ 255 يصف الفورما الدقيقة لوحدات بايت العنوان",
   "Preimage": "الصورة الأولية",
   "Preparing QR for signing": "إعداد ريال قطري للتوقيع",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": ".تقديم رمز الاستجابة السريعة الذي يحتوي على التوقيع إلى ىواجهة المستخدم. بمجرد فحصه ، سيتم تقديمه للمعالجة والتنفيذ على السلسلة",

--- a/packages/apps/public/locales/en/app-settings.json
+++ b/packages/apps/public/locales/en/app-settings.json
@@ -25,7 +25,7 @@
   "No open tips": "No open tips",
   "Override the default identity icon display with a specific theme": "Override the default identity icon display with a specific theme",
   "Override the default ss58 prefix for address generation": "Override the default ss58 prefix for address generation",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address",
   "Reset": "Reset",
   "Save": "Save",
   "Save & Reload": "Save & Reload",

--- a/packages/apps/public/locales/es/translation.json
+++ b/packages/apps/public/locales/es/translation.json
@@ -295,7 +295,7 @@
   "Positive number between 1 and {{memberCount}}": "Número positivo entre 1 y {{memberCount}}",
   "Positive number greater than or equal to {{nextFreeId}}": "Número positivo mayor o igual a {{nextFreeId}}",
   "Pre-sale ethereum address": "Dirección de Ethereum de la preventa",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "El prefijo indica el formato de la dirección ss58 en esta red, es un número entre 0 ~ 255 que describe el formato preciso de los bytes de la dirección",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "El prefijo indica el formato de la dirección ss58 en esta red, es un número entre 0 ~ 255 que describe el formato preciso de los bytes de la dirección",
   "Preimage": "Preimagen",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Presente el código QR que contiene la firma a la UI. Una vez escaneado, será presentado para su procesamiento y ejecución en cadena.",
   "Proposal can either be to approve or reject this spend. One approved, the change is applied by either removing the proposal or scheduling payout.": "La propuesta puede ser la aprobación o el rechazo de este gasto. Una vez aprobada, el cambio se aplica ya sea quitando la propuesta o programando el pago.",

--- a/packages/apps/public/locales/fr/translation.json
+++ b/packages/apps/public/locales/fr/translation.json
@@ -419,7 +419,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "Nombre positif supérieur ou égal à {{ nextFreeId}}",
   "Potential dispatch of referendum {{id}} (if passed)": "Envoi potentiel du référendum {{id}} (si adopté)",
   "Pre-sale ethereum address": "Collez le message signé dans le champ ci-dessous. Le texte par défaut est là pour indiquer à quoi devrait ressembler le message:",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "Prefix indique le format de l'adresse ss58 dans ce réseau, c'est un nombre entre 0 ~ 255 qui décrit le format précis des octets de l'adresse",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "Prefix indique le format de l'adresse ss58 dans ce réseau, c'est un nombre entre 0 ~ 255 qui décrit le format précis des octets de l'adresse",
   "Preimage": "Preimage",
   "Preparing QR for signing": "Préparation du Code QR pour la signature",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Affiche le Code QR contenant la signature de l'interface utilisateur. Une fois numérisée, elle sera soumise pour un traitement et exécution.",

--- a/packages/apps/public/locales/hi/translation.json
+++ b/packages/apps/public/locales/hi/translation.json
@@ -294,7 +294,7 @@
   "Positive number between 1 and {{memberCount}}": " 1 और {{memberCount}} के बीच सकारात्मक संख्या ",
   "Positive number greater than or equal to {{nextFreeId}}": " {{nextFreeId}} से अधिक या बराबर सकारात्मक संख्या",
   "Pre-sale ethereum address": "प्री-सेल एथोरम पता",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "उपसर्ग इस नेटवर्क पर ss58 पते के प्रारूप को इंगित करता है, यह 0 ~ 255 के बीच एक संख्या है जो पते के बाइट के सटीक प्रारूप का वर्णन करता है",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "उपसर्ग इस नेटवर्क पर ss58 पते के प्रारूप को इंगित करता है, यह 0 ~ 255 के बीच एक संख्या है जो पते के बाइट के सटीक प्रारूप का वर्णन करता है",
   "Preimage": "प्रीइमेज",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "यूआई को हस्ताक्षर युक्त क्यूआर कोड प्रस्तुत करें। एक बार स्कैन होने के बाद, इसे एक श्रृंखला पर प्रसंस्करण और निष्पादन के लिए प्रस्तुत किया जाएगा।",
   "Proposal can either be to approve or reject this spend. One approved, the change is applied by either removing the proposal or scheduling payout.": "प्रस्ताव इस खर्च की मंजूरी या अस्वीकृति हो सकती है । एक बार मंजूरी मिलने के बाद, परिवर्तन या तो प्रस्ताव को हटाकर या भुगतान का समय निर्धारित करके लागू किया जाता है ।",

--- a/packages/apps/public/locales/id/translation.json
+++ b/packages/apps/public/locales/id/translation.json
@@ -411,7 +411,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "Angka positif lebih besar dari atau sama dengan {{nextFreeId}}",
   "Potential dispatch of referendum {{id}} (if passed)": "Potensi pengiriman referendum {{id}} (jika lolos)",
   "Pre-sale ethereum address": "Alamat pre-sale ethereum",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "Awalan menunjukkan format alamat ss58 di jaringan ini, ini adalah angka antara 0 ~ 255 yang menjelaskan format yang tepat dari byte alamat",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "Awalan menunjukkan format alamat ss58 di jaringan ini, ini adalah angka antara 0 ~ 255 yang menjelaskan format yang tepat dari byte alamat",
   "Preimage": "Preimage",
   "Preparing QR for signing": "Mempersiapkan QR untuk penandatanganan",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Sajikan kode QR yang berisi tanda tangan ke UI. Setelah dipindai, itu akan dikirim untuk pemrosesan dan eksekusi on-chain.",

--- a/packages/apps/public/locales/it/translation.json
+++ b/packages/apps/public/locales/it/translation.json
@@ -530,7 +530,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "Numero positivo maggiore o uguale a {{nextFreeId}}",
   "Potential dispatch of referendum {{id}} (if passed)": "Potenziale inoltro del referendum {{id}} (se approvato)",
   "Pre-sale ethereum address": "Indirizzo ethereum di pre-vendita",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "Il prefisso indica il formato dell'indrizzo ss58 presente in questo network, ed è un numero incluso fra 0 ~ 255 che caratterizza il formato preciso del totale dei bytes dell'indirizzo",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "Il prefisso indica il formato dell'indrizzo ss58 presente in questo network, ed è un numero incluso fra 0 ~ 255 che caratterizza il formato preciso del totale dei bytes dell'indirizzo",
   "Preimage": "Proposta",
   "Preparing QR for signing": "Prepara il codice QR per la firma",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Mostra il QR Code contenente la firma alla interfaccia utente. Una volta scansionata, sarà inoltrata per l'esecuzione on-chain",

--- a/packages/apps/public/locales/ko/translation.json
+++ b/packages/apps/public/locales/ko/translation.json
@@ -406,7 +406,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "양수는 크거나 같아요 {{nextFreeId}}",
   "Potential dispatch of referendum {{id}} (if passed)": "잠재적인 국민 투표 디스패치 {{id}} (통과될 경우)",
   "Pre-sale ethereum address": "프리세일에 참가한 이더리움 주소",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "프리픽스는 이 네트워크의 ss58 주소 종류를 표시하며, 0 부터 ~ 255 로 숫자이며  주소 바이트의 정확한 종류를 설명한다",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "프리픽스는 이 네트워크의 ss58 주소 종류를 표시하며, 0 부터 ~ 255 로 숫자이며  주소 바이트의 정확한 종류를 설명한다",
   "Preimage": "프리이미지",
   "Preparing QR for signing": "QR를 서명하기 위해 준비합니다",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "서명이 포함되어있는 QR코드를 UI에게 전달하세요. 스캔 후에는 온-체인 프로세싱 및 실행 대상으로 제출합니다",

--- a/packages/apps/public/locales/pt/translation.json
+++ b/packages/apps/public/locales/pt/translation.json
@@ -295,7 +295,7 @@
   "Positive number between 1 and {{memberCount}}": "Número positivo entre 1 e {{memberCount}}",
   "Positive number greater than or equal to {{nextFreeId}}": "Número positivo maior ou igual a {{nextFreeId}}",
   "Pre-sale ethereum address": "Endereço ethereum de pré-venda",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "O prefixo indica o formato do endereço ss58 nesta rede; é um número entre 0 e 255 que descreve o formato preciso dos bytes do endereço",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "O prefixo indica o formato do endereço ss58 nesta rede; é um número entre 0 e 255 que descreve o formato preciso dos bytes do endereço",
   "Preimage": "Pré-imagem",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Apresente o código QR que contém a assinatura para a interface do usuário. Depois de digitalizado, ele será enviado para processamento e execução em cadeia.",
   "Proposal can either be to approve or reject this spend. One approved, the change is applied by either removing the proposal or scheduling payout.": "A proposta pode ser para aprovar ou rejeitar esses gastos. Uma vez aprovada, a alteração é aplicada removendo a proposta ou agendando o pagamento.",

--- a/packages/apps/public/locales/ru/translation.json
+++ b/packages/apps/public/locales/ru/translation.json
@@ -520,7 +520,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "Положительное число большее или равно {{nextFreeId}}",
   "Potential dispatch of referendum {{id}} (if passed)": "",
   "Pre-sale ethereum address": "Адрес Ethereum, используемый на предпродаже",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "Префикс обозначает, что в этой сети используется формат ss58 для адресов. Это число между 0 и 255, оно описивает точный формат байтов адреса",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "Префикс обозначает, что в этой сети используется формат ss58 для адресов. Это число между 0 и 255, оно описивает точный формат байтов адреса",
   "Preimage": "Прообраз",
   "Preparing QR for signing": "",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "Предьявите QR код с подписью. После сканирования транзакция будет запущена для исполнения в сети",

--- a/packages/apps/public/locales/ur/translation.json
+++ b/packages/apps/public/locales/ur/translation.json
@@ -395,7 +395,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "مثبت نمبر {{nextFreeId}} سے بڑا یا اس کے برابر",
   "Potential dispatch of referendum {{id}} (if passed)": "ریفرنڈم کی ممکنہ ترسیل {{id}} (اگر منظور ہو)",
   "Pre-sale ethereum address": "قبل از فروخت ایتھیریم کا پتہ",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "پری فکس اس نیٹ ورک میں ss58 ایڈریس فارمیٹ کی نشاندہی کرتا ہے، یہ 0 ~ 255 کے درمیان ایک نمبر ہے جو ایڈریس کے بائٹس کی درست شکل بیان کرتا ہے",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "پری فکس اس نیٹ ورک میں ss58 ایڈریس فارمیٹ کی نشاندہی کرتا ہے، یہ 0 ~ 255 کے درمیان ایک نمبر ہے جو ایڈریس کے بائٹس کی درست شکل بیان کرتا ہے",
   "Preimage": "پری امیج",
   "Preparing QR for signing": "دستخط کے لیے کیو آر کی تیاری",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "یو آئی کے لیئے دستخط پر مشتمل کیو آر کوڈ پیش کریں۔ ایک بار اسکین کرنے کے بعد اسے آن چین پروسیسنگ اور عملدرآمد کے لیے جمع کیا جائے گا۔",

--- a/packages/apps/public/locales/zh/translation.json
+++ b/packages/apps/public/locales/zh/translation.json
@@ -395,7 +395,7 @@
   "Positive number greater than or equal to {{nextFreeId}}": "大于或等于{{nextFreeId}}的正数",
   "Potential dispatch of referendum {{id}} (if passed)": "公投{{id}}的潜在调度(如果通过)",
   "Pre-sale ethereum address": "预售以太坊地址",
-  "Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address": "地址前缀用0~255的数来来表示SS58地址的编码格式",
+  "Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address": "地址前缀用0~255的数来来表示SS58地址的编码格式",
   "Preimage": "原像",
   "Preparing QR for signing": "准备 QR 签名",
   "Present the QR code containing the signature to the UI. Once scanned it will be submitted for on-chain processing and execution.": "将包含签名的二维码呈现给 UI。一旦扫描，它将提交到链上处理和执行。",

--- a/packages/page-settings/src/Metadata/NetworkSpecs.tsx
+++ b/packages/page-settings/src/Metadata/NetworkSpecs.tsx
@@ -185,7 +185,7 @@ function NetworkSpecs ({ chainInfo, className }: Props): React.ReactElement<Prop
         <td>
           <Input
             className='full'
-            help={t<string>('Prefix indicates the ss58 address format in this network, it is a number between 0 ~ 255 that describes the precise format of the bytes of the address')}
+            help={t<string>('Prefix indicates the ss58 address format in this network, it is a 16 bit unsigned integer that describes the precise format of the bytes of the address')}
             isDisabled
             label={t<string>('Address Prefix')}
             value={networkSpecs.prefix.toString()}


### PR DESCRIPTION
Related to issue https://github.com/polkadot-js/apps/issues/7251

The current long text is not aligned with the SS58 Prefix type used in substrate, cumulus and parachains. 

The text update only affects the English version and translated versions will have to be updated by the community.