### PR TITLE
Update Polkadex para id

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -272,7 +272,7 @@ export function createPolkadot (t: TFunction): EndpointOption {
       {
         info: 'polkadex',
         homepage: 'https://polkadex.trade/',
-        paraId: 2036,
+        paraId: 2040,
         text: t('rpc.polkadot.polkadex', 'Polkadex', { ns: 'apps-config' }),
         providers: {
           'Polkadex Team': 'wss://mainnet.polkadex.trade/',


### PR DESCRIPTION
Polkadex is changing our para id from 2036 to 2040 for the upcoming crowdloan. 