### PR TITLE
Update litentry-rococo paraId

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -258,7 +258,7 @@ export function createRococo (t: TFunction): EndpointOption {
       {
         info: 'rococoLitentry',
         isDisabled: false,
-        paraId: 2002,
+        paraId: 2106,
         text: t('rpc.rococo.litentry', 'Litentry', { ns: 'apps-config' }),
         providers: {
           Litentry: 'wss://rpc.rococo-parachain-sg.litentry.io'


### PR DESCRIPTION
This PR updates the paraId of litentry-rococo to 2106 (the same as Litmus on kusama)
see https://github.com/paritytech/subport/issues/337