### PR TITLE
Fix broken substrate connect light client

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -205,15 +205,7 @@ async function createApi (apiUrl: string, signer: ApiSigner, onError: (error: un
   const isLight = apiUrl.startsWith('light://');
 
   try {
-    let provider: WsProvider | ScProvider;
-
-    if (isLight) {
-      const url = apiUrl.replace('light://substrate-connect/', '');
-
-      provider = new ScProvider(getWellKnownChain(url));
-    } else {
-      provider = new WsProvider(apiUrl);
-    }
+    const provider = isLight ? new ScProvider(getWellKnownChain(apiUrl.replace('light://substrate-connect/', ''))) : new WsProvider(apiUrl);
 
     api = new ApiPromise({
       provider,

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -187,14 +187,15 @@ function getWellKnownChain (chain = 'polkadot') {
   switch (chain) {
     case 'kusama':
       return WellKnownChain.ksmcc3;
-  case 'polkadot':
-    return WellKnownChain.polkadot;
-  case 'rococo':
-    return WellKnownChain.rococo_v2_1;
-  case 'westend':
-    return WellKnownChain.westend2;
-  default:
-    throw new Error(`Unable to construct light chain ${chain}`);
+    case 'polkadot':
+      return WellKnownChain.polkadot;
+    case 'rococo':
+      return WellKnownChain.rococo_v2_1;
+    case 'westend':
+      return WellKnownChain.westend2;
+    default:
+      throw new Error(`Unable to construct light chain ${chain}`);
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -203,7 +203,9 @@ async function createApi (apiUrl: string, signer: ApiSigner, onError: (error: un
   const isLight = apiUrl.startsWith('light://');
 
   try {
-    const provider = isLight ? new ScProvider(getWellKnownChain(apiUrl.replace('light://substrate-connect/', ''))) : new WsProvider(apiUrl);
+    const provider = isLight
+      ? new ScProvider(getWellKnownChain(apiUrl.replace('light://substrate-connect/', '')))
+      : new WsProvider(apiUrl);
 
     api = new ApiPromise({
       provider,

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -18,7 +18,7 @@ import { TokenUnit } from '@polkadot/react-components/InputNumber';
 import { StatusContext } from '@polkadot/react-components/Status';
 import { useApiUrl, useEndpoint } from '@polkadot/react-hooks';
 import ApiSigner from '@polkadot/react-signer/signers/ApiSigner';
-import { ScProvider } from '@polkadot/rpc-provider/substrate-connect';
+import { ScProvider, WellKnownChain } from '@polkadot/rpc-provider/substrate-connect';
 import { keyring } from '@polkadot/ui-keyring';
 import { settings } from '@polkadot/ui-settings';
 import { formatBalance, isNumber, isTestChain, objectSpread, stringify } from '@polkadot/util';
@@ -183,15 +183,37 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
   };
 }
 
+function getWellKnownChain (chain = 'polkadot') {
+  if (chain === 'kusama') {
+    return WellKnownChain.ksmcc3;
+  }
+
+  if (chain === 'westend') {
+    return WellKnownChain.westend2;
+  }
+
+  if (chain === 'rococo') {
+    return WellKnownChain.rococo_v2_1;
+  }
+
+  return WellKnownChain.polkadot;
+}
+
 // eslint-disable-next-line @typescript-eslint/require-await
 async function createApi (apiUrl: string, signer: ApiSigner, onError: (error: unknown) => void): Promise<Record<string, Record<string, string>>> {
   const types = getDevTypes();
   const isLight = apiUrl.startsWith('light://');
 
   try {
-    const provider = isLight
-      ? new ScProvider(apiUrl.replace('light://substrate-connect/', '') as 'polkadot')
-      : new WsProvider(apiUrl);
+    let provider: WsProvider | ScProvider;
+
+    if (isLight) {
+      const url = apiUrl.replace('light://substrate-connect/', '');
+
+      provider = new ScProvider(getWellKnownChain(url));
+    } else {
+      provider = new WsProvider(apiUrl);
+    }
 
     api = new ApiPromise({
       provider,

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -184,19 +184,17 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
 }
 
 function getWellKnownChain (chain = 'polkadot') {
-  if (chain === 'kusama') {
-    return WellKnownChain.ksmcc3;
-  }
-
-  if (chain === 'westend') {
-    return WellKnownChain.westend2;
-  }
-
-  if (chain === 'rococo') {
+  switch (chain) {
+    case 'kusama':
+      return WellKnownChain.ksmcc3;
+  case 'polkadot':
+    return WellKnownChain.polkadot;
+  case 'rococo':
     return WellKnownChain.rococo_v2_1;
-  }
-
-  return WellKnownChain.polkadot;
+  case 'westend':
+    return WellKnownChain.westend2;
+  default:
+    throw new Error(`Unable to construct light chain ${chain}`);
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,6 +3274,7 @@ __metadata:
     "@polkadot/extension-compat-metamask": ^0.43.1
     "@polkadot/extension-dapp": ^0.43.1
     "@polkadot/rpc-provider": ^8.0.1
+    "@substrate/connect": ^0.7.2
     fflate: ^0.7.3
     rxjs: ^7.5.5
   languageName: unknown
@@ -4006,7 +4007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.2":
+"@substrate/connect@npm:0.7.2, @substrate/connect@npm:^0.7.2":
   version: 0.7.2
   resolution: "@substrate/connect@npm:0.7.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,7 +3274,6 @@ __metadata:
     "@polkadot/extension-compat-metamask": ^0.43.1
     "@polkadot/extension-dapp": ^0.43.1
     "@polkadot/rpc-provider": ^8.0.1
-    "@substrate/connect": ^0.7.2
     fflate: ^0.7.3
     rxjs: ^7.5.5
   languageName: unknown
@@ -4007,7 +4006,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.2, @substrate/connect@npm:^0.7.2":
+"@substrate/connect@npm:0.7.2":
   version: 0.7.2
   resolution: "@substrate/connect@npm:0.7.2"
   dependencies:


### PR DESCRIPTION
Susbtrate light client is not working due to wrong parameter provided in `ScProvider`.
Since latest API changes, ScProvider should either receive a `WellKnownChain` or a stringified chainspec