### PR TITLE
Add support of light client to Rococo

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -22,7 +22,8 @@ export function createRococo (t: TFunction): EndpointOption {
     info: 'rococo',
     text: t('rpc.rococo', 'Rococo', { ns: 'apps-config' }),
     providers: {
-      Parity: 'wss://rococo-rpc.polkadot.io'
+      Parity: 'wss://rococo-rpc.polkadot.io',
+      'light client': 'light://substrate-connect/rococo'
       // OnFinality: 'wss://rococo.api.onfinality.io/public-ws', // After reset, node misses host functions
       // Pinknode: 'wss://rpc.pinknode.io/rococo/explorer' // After reset, syncs to old chain
       // 'Ares Protocol': 'wss://rococo.aresprotocol.com' // https://github.com/polkadot-js/apps/issues/5767


### PR DESCRIPTION
This will work only after [Substrate connect fix](https://github.com/polkadot-js/apps/pull/7362) is merged