### PR TITLE
Dedupe into ExpanderScroll

### DIFF
--- a/packages/page-democracy/src/Overview/Proposal.tsx
+++ b/packages/page-democracy/src/Overview/Proposal.tsx
@@ -6,7 +6,7 @@ import type { DeriveProposal } from '@polkadot/api-derive/types';
 import React from 'react';
 import styled from 'styled-components';
 
-import { AddressMini, Button, Expander, LinkExternal, Table } from '@polkadot/react-components';
+import { AddressMini, Button, ExpanderScroll, LinkExternal } from '@polkadot/react-components';
 import { FormatBalance } from '@polkadot/react-query';
 import { formatNumber } from '@polkadot/util';
 
@@ -39,27 +39,20 @@ function Proposal ({ className = '', value: { balance, image, imageHash, index, 
       </td>
       <td className='expand'>
         {seconding.length !== 0 && (
-          <Expander summary={t<string>('Endorsed ({{count}})', { replace: { count: seconding.length } })}>
-            <div className='endorsementsTable'>
-              <Table
-                empty={seconding && t<string>('No endorsements')}
-              >
-                <tr className='expand'>
-                  <td>
-                    {seconding.map((address, count): React.ReactNode => (
-                      <AddressMini
-                        className='identityIcon'
-                        key={`${count}:${address.toHex()}`}
-                        value={address}
-                        withBalance={false}
-                        withShrink
-                      />
-                    ))}
-                  </td>
-                </tr>
-              </Table>
-            </div>
-          </Expander>
+          <ExpanderConstained
+            empty={seconding && t<string>('No endorsements')}
+            summary={t<string>('Endorsed ({{count}})', { replace: { count: seconding.length } })}
+          >
+            {seconding.map((address, count): React.ReactNode => (
+              <AddressMini
+                className='identityIcon'
+                key={`${count}:${address.toHex()}`}
+                value={address}
+                withBalance={false}
+                withShrink
+              />
+            ))}
+          </ExpanderScroll>
         )}
       </td>
       <td className='button'>
@@ -95,13 +88,5 @@ export default React.memo(styled(Proposal)`
     &:last-child {
       margin-bottom: 4px;
     }
-  }
-  
-  div.endorsementsTable {
-    overflow-y: scroll;
-    display: block;
-    min-height: 50px;
-    max-height: 200px;
-    overflow-x: hidden;
   }
 `);

--- a/packages/page-democracy/src/Overview/Proposal.tsx
+++ b/packages/page-democracy/src/Overview/Proposal.tsx
@@ -3,8 +3,7 @@
 
 import type { DeriveProposal } from '@polkadot/api-derive/types';
 
-import React from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useMemo } from 'react';
 
 import { AddressMini, Button, ExpanderScroll, LinkExternal } from '@polkadot/react-components';
 import { FormatBalance } from '@polkadot/react-query';
@@ -22,7 +21,23 @@ interface Props {
 
 function Proposal ({ className = '', value: { balance, image, imageHash, index, proposer, seconds } }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const seconding = seconds.filter((_address, index) => index !== 0);
+
+  const seconding = useMemo(
+    () => seconds.filter((_address, index) => index !== 0),
+    [seconds]
+  );
+
+  const renderSeconds = useCallback(
+    () => seconding.map((address, count): React.ReactNode => (
+      <AddressMini
+        key={`${count}:${address.toHex()}`}
+        value={address}
+        withBalance={false}
+        withShrink
+      />
+    )),
+    [seconding]
+  );
 
   return (
     <tr className={className}>
@@ -41,18 +56,9 @@ function Proposal ({ className = '', value: { balance, image, imageHash, index, 
         {seconding.length !== 0 && (
           <ExpanderScroll
             empty={seconding && t<string>('No endorsements')}
+            renderChildren={renderSeconds}
             summary={t<string>('Endorsed ({{count}})', { replace: { count: seconding.length } })}
-          >
-            {seconding.map((address, count): React.ReactNode => (
-              <AddressMini
-                className='identityIcon'
-                key={`${count}:${address.toHex()}`}
-                value={address}
-                withBalance={false}
-                withShrink
-              />
-            ))}
-          </ExpanderScroll>
+          />
         )}
       </td>
       <td className='button'>
@@ -79,14 +85,4 @@ function Proposal ({ className = '', value: { balance, image, imageHash, index, 
   );
 }
 
-export default React.memo(styled(Proposal)`
-  .identityIcon {
-    &:first-child {
-      padding-top: 0;
-    }
-
-    &:last-child {
-      margin-bottom: 4px;
-    }
-  }
-`);
+export default React.memo(Proposal);

--- a/packages/page-democracy/src/Overview/Proposal.tsx
+++ b/packages/page-democracy/src/Overview/Proposal.tsx
@@ -39,7 +39,7 @@ function Proposal ({ className = '', value: { balance, image, imageHash, index, 
       </td>
       <td className='expand'>
         {seconding.length !== 0 && (
-          <ExpanderConstained
+          <ExpanderScroll
             empty={seconding && t<string>('No endorsements')}
             summary={t<string>('Endorsed ({{count}})', { replace: { count: seconding.length } })}
           >

--- a/packages/page-democracy/src/Overview/Proposals.tsx
+++ b/packages/page-democracy/src/Overview/Proposals.tsx
@@ -36,7 +36,6 @@ function Proposals ({ className }: Props): React.ReactElement<Props> {
     >
       {proposals?.map((proposal): React.ReactNode => (
         <ProposalDisplay
-          help={t<string>('launch period')}
           key={proposal.index.toString()}
           value={proposal}
         />

--- a/packages/page-democracy/src/Overview/ReferendumVotes.tsx
+++ b/packages/page-democracy/src/Overview/ReferendumVotes.tsx
@@ -5,9 +5,8 @@ import type { DeriveReferendumVote } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import React, { useMemo } from 'react';
-import styled from 'styled-components';
 
-import { Expander, Table } from '@polkadot/react-components';
+import { ExpanderScroll } from '@polkadot/react-components';
 import { FormatBalance } from '@polkadot/react-query';
 import { BN_TEN, formatNumber } from '@polkadot/util';
 
@@ -39,8 +38,9 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
   );
 
   return (
-    <Expander
+    <ExpanderScroll
       className={className}
+      empty={votes && t<string>('No voters')}
       help={change.gtn(0) && (
         <>
           <FormatBalance value={change} />
@@ -61,30 +61,14 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
         </>
       }
     >
-      <div className='votersTable'>
-        <Table empty={votes && t<string>('No voters')}>
-          <tr className='expand'>
-            <td>
-              {sorted.map((vote) =>
-                <ReferendumVote
-                  key={vote.accountId.toString()}
-                  vote={vote}
-                />
-              )}
-            </td>
-          </tr>
-        </Table>
-      </div>
-    </Expander>
+      {sorted.map((vote) =>
+        <ReferendumVote
+          key={vote.accountId.toString()}
+          vote={vote}
+        />
+      )}
+    </ExpanderScroll>
   );
 }
 
-export default React.memo(styled(ReferendumVotes)`
-  div.votersTable {
-    overflow-y: scroll;
-    display: block;
-    min-height: 50px;
-    max-height: 200px;
-    overflow-x: hidden;
-  }
-`);
+export default React.memo(ReferendumVotes);

--- a/packages/page-democracy/src/Overview/ReferendumVotes.tsx
+++ b/packages/page-democracy/src/Overview/ReferendumVotes.tsx
@@ -62,7 +62,7 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
         </>
       )}
       helpIcon={isWinning ? 'arrow-circle-down' : 'arrow-circle-up'}
-      renderChildren={renderVotes}
+      renderChildren={votes.length ? renderVotes : undefined}
       summary={
         <>
           {isAye

--- a/packages/page-democracy/src/Overview/ReferendumVotes.tsx
+++ b/packages/page-democracy/src/Overview/ReferendumVotes.tsx
@@ -4,7 +4,7 @@
 import type { DeriveReferendumVote } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { ExpanderScroll } from '@polkadot/react-components';
 import { FormatBalance } from '@polkadot/react-query';
@@ -27,6 +27,7 @@ const LOCKS = [1, 10, 20, 30, 40, 50, 60];
 
 function ReferendumVotes ({ change, className, count, isAye, isWinning, total, votes }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
+
   const sorted = useMemo(
     () => votes.sort((a, b) => {
       const ta = a.balance.muln(LOCKS[a.vote.conviction.toNumber()]).div(BN_TEN);
@@ -35,6 +36,16 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
       return tb.cmp(ta);
     }),
     [votes]
+  );
+
+  const renderVotes = useCallback(
+    () => sorted.map((vote) => (
+      <ReferendumVote
+        key={vote.accountId.toString()}
+        vote={vote}
+      />
+    )),
+    [sorted]
   );
 
   return (
@@ -51,6 +62,7 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
         </>
       )}
       helpIcon={isWinning ? 'arrow-circle-down' : 'arrow-circle-up'}
+      renderChildren={renderVotes}
       summary={
         <>
           {isAye
@@ -60,14 +72,7 @@ function ReferendumVotes ({ change, className, count, isAye, isWinning, total, v
           <div><FormatBalance value={total} /></div>
         </>
       }
-    >
-      {sorted.map((vote) =>
-        <ReferendumVote
-          key={vote.accountId.toString()}
-          vote={vote}
-        />
-      )}
-    </ExpanderScroll>
+    />
   );
 }
 

--- a/packages/react-components/src/ExpanderScroll.tsx
+++ b/packages/react-components/src/ExpanderScroll.tsx
@@ -3,7 +3,7 @@
 
 import type { Props as ExpanderProps } from './Expander';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 import Expander from './Expander';
@@ -15,27 +15,33 @@ interface Props extends ExpanderProps {
 
 // TODO Not 100% convinced we need a table here since we only have a single row,
 // however at this point we convert as-is, but it should probably get a re-look
-function ExpanderScroll ({ children, className, empty, help, helpIcon, summary }: Props): React.ReactElement<Props> {
-  return (
-    <Expander
-      className={className}
-      help={help}
-      helpIcon={helpIcon}
-      summary={summary}
-    >
+function ExpanderScroll ({ children, className, empty, help, helpIcon, renderChildren, summary }: Props): React.ReactElement<Props> {
+  const innerRender = useCallback(
+    (): React.ReactNode => (
       <div className='tableContainer'>
         <Table
           empty={empty}
           isInline
         >
-          {children && (
+          {(renderChildren || children) && (
             <tr className='expand'>
-              <td>{children}</td>
+              <td>{renderChildren ? renderChildren() : children}</td>
             </tr>
           )}
         </Table>
       </div>
-    </Expander>
+    ),
+    [children, empty, renderChildren]
+  );
+
+  return (
+    <Expander
+      className={className}
+      help={help}
+      helpIcon={helpIcon}
+      renderChildren={innerRender}
+      summary={summary}
+    />
   );
 }
 

--- a/packages/react-components/src/ExpanderScroll.tsx
+++ b/packages/react-components/src/ExpanderScroll.tsx
@@ -1,0 +1,50 @@
+// Copyright 2017-2022 @polkadot/react-components authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Props as ExpanderProps } from './Expander';
+
+import React from 'react';
+import styled from 'styled-components';
+
+import Expander from './Expander';
+import Table from './Table';
+
+interface Props extends ExpanderProps {
+  empty?: string;
+}
+
+// TODO Not 100% convinced we need a table here since we only have a single row,
+// however at this point we convert as-is, but it should probably get a re-look
+function ExpanderScroll ({ children, className, empty, help, helpIcon, summary }: Props): React.ReactElement<Props> {
+  return (
+    <Expander
+      className={className}
+      help={help}
+      helpIcon={helpIcon}
+      summary={summary}
+    >
+      <div className='tableContainer'>
+        <Table
+          empty={empty}
+          isInline
+        >
+          {children && (
+            <tr className='expand'>
+              <td>{children}</td>
+            </tr>
+          )}
+        </Table>
+      </div>
+    </Expander>
+  );
+}
+
+export default React.memo(styled(ExpanderScroll)`
+  .tableContainer {
+    overflow-y: scroll;
+    display: block;
+    min-height: 50px;
+    max-height: 200px;
+    overflow-x: hidden;
+  }
+`);

--- a/packages/react-components/src/ExpanderScroll.tsx
+++ b/packages/react-components/src/ExpanderScroll.tsx
@@ -17,17 +17,15 @@ interface Props extends ExpanderProps {
 // however at this point we convert as-is, but it should probably get a re-look
 function ExpanderScroll ({ children, className, empty, help, helpIcon, renderChildren, summary }: Props): React.ReactElement<Props> {
   const innerRender = useCallback(
-    (): React.ReactNode => (
+    (): React.ReactNode => (renderChildren || children) && (
       <div className='tableContainer'>
         <Table
           empty={empty}
           isInline
         >
-          {(renderChildren || children) && (
-            <tr className='expand'>
-              <td>{renderChildren ? renderChildren() : children}</td>
-            </tr>
-          )}
+          <tr className='expand'>
+            <td>{renderChildren ? renderChildren() : children}</td>
+          </tr>
         </Table>
       </div>
     ),

--- a/packages/react-components/src/ExpanderScroll.tsx
+++ b/packages/react-components/src/ExpanderScroll.tsx
@@ -3,7 +3,7 @@
 
 import type { Props as ExpanderProps } from './Expander';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
 import Expander from './Expander';
@@ -16,6 +16,11 @@ interface Props extends ExpanderProps {
 // TODO Not 100% convinced we need a table here since we only have a single row,
 // however at this point we convert as-is, but it should probably get a re-look
 function ExpanderScroll ({ children, className, empty, help, helpIcon, renderChildren, summary }: Props): React.ReactElement<Props> {
+  const hasContent = useMemo(
+    () => !!(renderChildren || children),
+    [children, renderChildren]
+  );
+
   const innerRender = useCallback(
     (): React.ReactNode => (renderChildren || children) && (
       <div className='tableContainer'>
@@ -37,7 +42,7 @@ function ExpanderScroll ({ children, className, empty, help, helpIcon, renderChi
       className={className}
       help={help}
       helpIcon={helpIcon}
-      renderChildren={innerRender}
+      renderChildren={hasContent ? innerRender : undefined}
       summary={summary}
     />
   );

--- a/packages/react-components/src/Table/index.tsx
+++ b/packages/react-components/src/Table/index.tsx
@@ -17,6 +17,7 @@ interface TableProps {
   footer?: React.ReactNode;
   header?: [React.ReactNode?, string?, number?, (() => void)?][];
   isFixed?: boolean;
+  isInline?: boolean;
   legend?: React.ReactNode;
   noBodyTag?: boolean;
   withCollapsibleRows: boolean;
@@ -33,13 +34,13 @@ function extractBodyChildren (children: React.ReactNode): [boolean, React.ReactN
   return [isEmpty, isEmpty ? null : kids];
 }
 
-function Table ({ children, className = '', empty, emptySpinner, filter, footer, header, isFixed, legend, noBodyTag, withCollapsibleRows = false }: TableProps): React.ReactElement<TableProps> {
+function Table ({ children, className = '', empty, emptySpinner, filter, footer, header, isFixed, isInline, legend, noBodyTag, withCollapsibleRows = false }: TableProps): React.ReactElement<TableProps> {
   const [isEmpty, bodyChildren] = extractBodyChildren(children);
 
   return (
     <div className={`ui--Table ${className}`}>
       {legend}
-      <table className={`${(isFixed && !isEmpty) ? 'isFixed' : 'isNotFixed'} highlight--bg-faint${withCollapsibleRows ? ' withCollapsibleRows' : ''}`}>
+      <table className={`${(isFixed && !isEmpty) ? 'isFixed' : 'isNotFixed'} ${isInline ? 'isInline' : ''} highlight--bg-faint${withCollapsibleRows ? ' withCollapsibleRows' : ''}`}>
         <Head
           filter={filter}
           header={header}
@@ -62,7 +63,6 @@ function Table ({ children, className = '', empty, emptySpinner, filter, footer,
 }
 
 export default React.memo(styled(Table)`
-  margin-bottom: 1.5rem;
   max-width: 100%;
   width: 100%;
 
@@ -76,6 +76,10 @@ export default React.memo(styled(Table)`
 
     &.isFixed {
       table-layout: fixed;
+    }
+
+    &:not(.isInline) {
+      margin-bottom: 1.5rem;
     }
 
     tr {

--- a/packages/react-components/src/index.tsx
+++ b/packages/react-components/src/index.tsx
@@ -37,6 +37,7 @@ export { default as Editor } from './Editor';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as Event } from './Event';
 export { default as Expander } from './Expander';
+export { default as ExpanderScroll } from './ExpanderScroll';
 export { default as Extrinsic } from './Extrinsic';
 export { default as FilterOverlay } from './FilterOverlay';
 export { default as Flag } from './Flag';


### PR DESCRIPTION
Dedupe new scrollable expander introduced in https://github.com/polkadot-js/apps/pull/7360 into `ExpanderScroll` - this allows actual application of it inside all areas where the address list is displayed (e.g. council voting, staking, etc.)