### PR TITLE
calldata hyperlink

### DIFF
--- a/packages/page-extrinsics/src/Decoder.tsx
+++ b/packages/page-extrinsics/src/Decoder.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubmittableExtrinsic, SubmittableExtrinsicFunction } from '@polkadot/api/types';
+import { useLocation } from 'react-router-dom';
 import type { Call } from '@polkadot/types/interfaces';
 import type { DecodedExtrinsic } from './types';
 
@@ -40,7 +41,9 @@ const DEFAULT_INFO: ExtrinsicInfo = {
   extrinsicHex: null
 };
 
-function Decoder ({ className, setLast, calldata }: Props): React.ReactElement<Props> {
+function Decoder({ className, setLast }: Props): React.ReactElement<Props> {
+  const location = useLocation();
+  const calldata = location?.search?.replace('?calldata=', '');
   const { t } = useTranslation();
   const { api } = useApi();
   const [{ decoded, extrinsic, extrinsicCall, extrinsicError, extrinsicFn }, setExtrinsicInfo] = useState<ExtrinsicInfo>(DEFAULT_INFO);
@@ -49,6 +52,7 @@ function Decoder ({ className, setLast, calldata }: Props): React.ReactElement<P
   const _setExtrinsicHex = useCallback(
     (extrinsicHex: string): void => {
       try {
+        console.log('got here' + extrinsicHex);
         assert(isHex(extrinsicHex), 'Expected a hex-encoded call');
 
         let extrinsicCall: Call;
@@ -79,6 +83,11 @@ function Decoder ({ className, setLast, calldata }: Props): React.ReactElement<P
     },
     [api, setLast]
   );
+
+  if (calldata && decoded === null) {   
+    // Seems the function needs forcing to run. might be a way to touch the input to trigger the onChange?
+    _setExtrinsicHex(calldata);
+  }
 
   return (
     <div className={className}>

--- a/packages/page-extrinsics/src/Decoder.tsx
+++ b/packages/page-extrinsics/src/Decoder.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubmittableExtrinsic, SubmittableExtrinsicFunction } from '@polkadot/api/types';
-import { useLocation } from 'react-router-dom';
 import type { Call } from '@polkadot/types/interfaces';
 import type { DecodedExtrinsic } from './types';
 
@@ -10,6 +9,7 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Call as CallDisplay, Input, InputAddress, InputExtrinsic, MarkError, TxButton } from '@polkadot/react-components';
+import { useLocation } from 'react-router-dom';
 import { useApi } from '@polkadot/react-hooks';
 import { BalanceFree } from '@polkadot/react-query';
 import { assert, isHex } from '@polkadot/util';
@@ -18,9 +18,9 @@ import Decoded from './Decoded';
 import { useTranslation } from './translate';
 
 interface Props {
+  calldata?: string;
   className?: string;
   setLast: (value: DecodedExtrinsic | null) => void;
-  calldata?: string;
 }
 
 interface ExtrinsicInfo {
@@ -52,7 +52,6 @@ function Decoder({ className, setLast }: Props): React.ReactElement<Props> {
   const _setExtrinsicHex = useCallback(
     (extrinsicHex: string): void => {
       try {
-        console.log('got here' + extrinsicHex);
         assert(isHex(extrinsicHex), 'Expected a hex-encoded call');
 
         let extrinsicCall: Call;
@@ -84,9 +83,9 @@ function Decoder({ className, setLast }: Props): React.ReactElement<Props> {
     [api, setLast]
   );
 
-  if (calldata && decoded === null) {   
+  if (calldata && decoded === null) {
     // Seems the function needs forcing to run. might be a way to touch the input to trigger the onChange?
-    _setExtrinsicHex(calldata);
+    _setExtrinsicHex( calldata );
   }
 
   return (

--- a/packages/page-extrinsics/src/Decoder.tsx
+++ b/packages/page-extrinsics/src/Decoder.tsx
@@ -6,10 +6,10 @@ import type { Call } from '@polkadot/types/interfaces';
 import type { DecodedExtrinsic } from './types';
 
 import React, { useCallback, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Button, Call as CallDisplay, Input, InputAddress, InputExtrinsic, MarkError, TxButton } from '@polkadot/react-components';
-import { useLocation } from 'react-router-dom';
 import { useApi } from '@polkadot/react-hooks';
 import { BalanceFree } from '@polkadot/react-query';
 import { assert, isHex } from '@polkadot/util';
@@ -41,7 +41,7 @@ const DEFAULT_INFO: ExtrinsicInfo = {
   extrinsicHex: null
 };
 
-function Decoder({ className, setLast }: Props): React.ReactElement<Props> {
+function Decoder ({ className, setLast }: Props): React.ReactElement<Props> {
   const location = useLocation();
   const calldata = location?.search?.replace('?calldata=', '');
   const { t } = useTranslation();
@@ -85,17 +85,17 @@ function Decoder({ className, setLast }: Props): React.ReactElement<Props> {
 
   if (calldata && decoded === null) {
     // Seems the function needs forcing to run. might be a way to touch the input to trigger the onChange?
-    _setExtrinsicHex( calldata );
+    _setExtrinsicHex(calldata);
   }
 
   return (
     <div className={className}>
       <Input
+        defaultValue={calldata}
         isError={!extrinsicFn}
         label={t<string>('hex-encoded call')}
         onChange={_setExtrinsicHex}
         placeholder={t<string>('0x...')}
-        defaultValue={calldata}
       />
       {extrinsicError && (
         <MarkError content={extrinsicError} />

--- a/packages/page-extrinsics/src/Decoder.tsx
+++ b/packages/page-extrinsics/src/Decoder.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from './translate';
 interface Props {
   className?: string;
   setLast: (value: DecodedExtrinsic | null) => void;
+  calldata?: string;
 }
 
 interface ExtrinsicInfo {
@@ -39,7 +40,7 @@ const DEFAULT_INFO: ExtrinsicInfo = {
   extrinsicHex: null
 };
 
-function Decoder ({ className, setLast }: Props): React.ReactElement<Props> {
+function Decoder ({ className, setLast, calldata }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const [{ decoded, extrinsic, extrinsicCall, extrinsicError, extrinsicFn }, setExtrinsicInfo] = useState<ExtrinsicInfo>(DEFAULT_INFO);
@@ -86,6 +87,7 @@ function Decoder ({ className, setLast }: Props): React.ReactElement<Props> {
         label={t<string>('hex-encoded call')}
         onChange={_setExtrinsicHex}
         placeholder={t<string>('0x...')}
+        defaultValue={calldata}
       />
       {extrinsicError && (
         <MarkError content={extrinsicError} />

--- a/packages/page-extrinsics/src/index.tsx
+++ b/packages/page-extrinsics/src/index.tsx
@@ -24,6 +24,7 @@ function ExtrinsicsApp ({ basePath }: Props): React.ReactElement<Props> {
       text: t<string>('Submission')
     },
     {
+      hasParams: true,
       name: 'decode',
       text: t<string>('Decode')
     }
@@ -36,8 +37,11 @@ function ExtrinsicsApp ({ basePath }: Props): React.ReactElement<Props> {
         items={itemsRef.current}
       />
       <Switch>
-        <Route path={`${basePath}/decode`}>
-          <Decoder setLast={setDecoded} />
+        <Route path={[`${basePath}/decode/:value`, `${basePath}/decode`]}>
+          <Decoder
+            defaultValue={decoded && decoded.hex}
+            setLast={setDecoded}
+          />
         </Route>
         <Route>
           <Submission defaultValue={decoded} />

--- a/packages/page-extrinsics/src/types.ts
+++ b/packages/page-extrinsics/src/types.ts
@@ -3,8 +3,10 @@
 
 import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import type { Call } from '@polkadot/types/interfaces';
+import type { HexString } from '@polkadot/util/types';
 
 export interface DecodedExtrinsic {
   call: Call;
+  hex: HexString;
   fn: SubmittableExtrinsicFunction<'promise'>;
 }

--- a/packages/react-components/src/Input.tsx
+++ b/packages/react-components/src/Input.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2022 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Input as SUIInput } from 'semantic-ui-react';
 
 import { isFunction, isUndefined } from '@polkadot/util';
@@ -94,6 +94,11 @@ let counter = 0;
 
 function Input ({ autoFocus = false, children, className, defaultValue, help, icon, inputClassName, isAction = false, isDisabled = false, isDisabledError = false, isEditable = false, isError = false, isFull = false, isHidden = false, isInPlaceEditor = false, isReadOnly = false, isWarning = false, label, labelExtra, max, maxLength, min, name, onBlur, onChange, onEnter, onEscape, onKeyDown, onKeyUp, onPaste, placeholder, tabIndex, type = 'text', value, withEllipsis, withLabel }: Props): React.ReactElement<Props> {
   const [stateName] = useState(() => `in_${counter++}_at_${Date.now()}`);
+  const [initialValue] = useState(() => defaultValue);
+
+  useEffect((): void => {
+    initialValue && onChange && onChange(initialValue);
+  }, [initialValue, onChange]);
 
   const _onBlur = useCallback(
     () => onBlur && onBlur(),


### PR DESCRIPTION
Why: there are many locations where you want to tee up a transaction for submission. There are many testing situations where this would make a lot of integrations slicker. Arguably POST could be accepted as well as GET because some call datas could be long but the vast majority are not and ease of use is important (so even if POST was allowed I would still like GET to work).