### PR TITLE
Fix websocket and remove `isUnreachable` for bajun-kusama

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -27,7 +27,6 @@ export const prodParasKusama: EndpointOption[] = [
   },
   {
     info: 'bajun',
-    isUnreachable: true, // https://github.com/polkadot-js/apps/issues/7480
     homepage: 'https://ajuna.io',
     paraId: 2119,
     text: 'Bajun Network',


### PR DESCRIPTION
We had to resolve some certificate issues and `wss://rpc-parachain.bajun.network` is reachable now.

Thanks