### PR TITLE
Duplicate url check w/o trailing /

### DIFF
--- a/packages/apps-config/src/endpoints/index.spec.ts
+++ b/packages/apps-config/src/endpoints/index.spec.ts
@@ -62,34 +62,35 @@ describe('urls are sorted', (): void => {
 describe('urls are not duplicated', (): void => {
   let hasDevelopment = false;
   let lastHeader = '';
-  const filtered = allEndpoints.filter(({ isDisabled, isHeader, isUnreachable, text }): boolean => {
-    hasDevelopment = hasDevelopment || (!!isHeader && text === 'Development');
+  const map = allEndpoints
+    .filter(({ isDisabled, isHeader, isUnreachable, text }): boolean => {
+      hasDevelopment = hasDevelopment || (!!isHeader && text === 'Development');
 
-    return !hasDevelopment && !isDisabled && !isUnreachable;
-  });
-  const map: Record<string, string[]> = {};
-
-  filtered.forEach(({ isHeader, text, value }): void => {
-    if (isHeader) {
-      lastHeader = text as string;
-    } else {
-      const path = `${lastHeader} -> ${text as string}`;
-
-      if (!map[value]) {
-        map[value] = [path];
+      return !hasDevelopment && !isDisabled && !isUnreachable;
+    })
+    .reduce((map, { isHeader, text, value }): Record<string, string[]> => {
+      if (isHeader) {
+        lastHeader = text as string;
       } else {
-        map[value].push(path);
-      }
-    }
-  });
+        const path = `${lastHeader} -> ${text as string}`;
+        const key = value.endsWith('/')
+          ? value.substring(0, value.length - 1)
+          : value;
 
-  it('has no duplicates, e.g. parachain & live', (): void => {
-    expect(
-      Object
-        .entries(map)
-        .filter(([, paths]) => paths.length !== 1)
-    ).toEqual([]);
-  });
+        map[key] ||= [];
+        map[key].push(path);
+      }
+
+      return map;
+    }, {} as Record<string, string[]>);
+
+  Object
+    .entries(map)
+    .forEach(([url, paths]) =>
+      it(url, (): void => {
+        assert(paths.length === 1, `${url} appears multiple times - ${paths.map((p) => `\n\t"${p}"`).join('')}`);
+      })
+    );
 });
 
 describe('endpopints do not contain emojis or all uppercase', (): void => {


### PR DESCRIPTION
Adjust duplicate url check w/0 trailing / - this prevents issues such as https://github.com/polkadot-js/apps/issues/7620 which should have been caught as part of the test