### PR TITLE
Add subsquare external links for Kusama

### DIFF
--- a/packages/apps-config/src/links/subsquare.ts
+++ b/packages/apps-config/src/links/subsquare.ts
@@ -11,8 +11,8 @@ export default {
     Bifrost: 'bifrost',
     Karura: 'karura',
     Khala: 'khala',
-    kintsugi: 'kintsugi',
-    Kusama: 'kusama'
+    Kusama: 'kusama',
+    kintsugi: 'kintsugi'
   },
   create: (chain: string, path: string, data: BN | number | string): string =>
     `https://${chain}.subsquare.io/${path}/${data.toString()}`,

--- a/packages/apps-config/src/links/subsquare.ts
+++ b/packages/apps-config/src/links/subsquare.ts
@@ -11,7 +11,8 @@ export default {
     Bifrost: 'bifrost',
     Karura: 'karura',
     Khala: 'khala',
-    kintsugi: 'kintsugi'
+    kintsugi: 'kintsugi',
+    Kusama: 'kusama'
   },
   create: (chain: string, path: string, data: BN | number | string): string =>
     `https://${chain}.subsquare.io/${path}/${data.toString()}`,

--- a/packages/apps-config/src/links/subsquare.ts
+++ b/packages/apps-config/src/links/subsquare.ts
@@ -21,6 +21,7 @@ export default {
   paths: {
     bounty: 'treasury/bounty',
     council: 'council/motion',
+    external: 'democracy/external',
     proposal: 'democracy/proposal',
     referendum: 'democracy/referendum',
     tip: 'treasury/tip',

--- a/packages/page-democracy/src/Overview/External.tsx
+++ b/packages/page-democracy/src/Overview/External.tsx
@@ -5,7 +5,7 @@ import type { DeriveProposalExternal } from '@polkadot/api-derive/types';
 
 import React from 'react';
 
-import { AddressMini, Button } from '@polkadot/react-components';
+import { AddressMini, Button, LinkExternal } from '@polkadot/react-components';
 import { useCollectiveMembers } from '@polkadot/react-hooks';
 import { FormatBalance } from '@polkadot/react-query';
 
@@ -48,6 +48,12 @@ function External ({ className = '', value: { image, imageHash, threshold } }: P
             />
           )}
         </Button.Group>
+      </td>
+      <td className='links media--1000'>
+        <LinkExternal
+          data={imageHash}
+          type='external'
+        />
       </td>
     </tr>
   );

--- a/packages/page-democracy/src/Overview/Externals.tsx
+++ b/packages/page-democracy/src/Overview/Externals.tsx
@@ -24,7 +24,8 @@ function Externals ({ className }: Props): React.ReactElement<Props> | null {
     [t('external'), 'start'],
     [t('proposer'), 'address'],
     [t('locked')],
-    []
+    [],
+    [undefined, 'media--1000']
   ]);
 
   return (


### PR DESCRIPTION
Happy to tell that we have implemented subsquare for kusama. https://kusama.subsquare.io/

Do you think we should also add external links for external proposals? We have links to the list and each item.