### PR TITLE
Added / Modified Pinknode Endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -198,8 +198,8 @@ export const prodChains: EndpointOption[] = [
     text: 'Nodle',
     providers: {
       // Nodle: 'wss://main3.nodleprotocol.io', // https://github.com/polkadot-js/apps/issues/7652
-      OnFinality: 'wss://nodle.api.onfinality.io/public-ws'
-      // Pinknode: 'wss://rpc.pinknode.io/nodle/explorer' // https://github.com/polkadot-js/apps/issues/5721
+      OnFinality: 'wss://nodle.api.onfinality.io/public-ws',
+      Pinknode: 'wss://public-rpc.pinknode.io/nodle'
     }
   },
   {
@@ -214,7 +214,8 @@ export const prodChains: EndpointOption[] = [
     text: 'Polkadex',
     providers: {
       'Polkadex Team': 'wss://mainnet.polkadex.trade',
-      OnFinality: 'wss://polkadex.api.onfinality.io/public-ws'
+      OnFinality: 'wss://polkadex.api.onfinality.io/public-ws',
+      Pinknode: 'wss://public-rpc.pinknode.io/polkadex',
     }
   },
   {

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -198,8 +198,7 @@ export const prodChains: EndpointOption[] = [
     text: 'Nodle',
     providers: {
       // Nodle: 'wss://main3.nodleprotocol.io', // https://github.com/polkadot-js/apps/issues/7652
-      OnFinality: 'wss://nodle.api.onfinality.io/public-ws',
-      Pinknode: 'wss://public-rpc.pinknode.io/nodle'
+      OnFinality: 'wss://nodle.api.onfinality.io/public-ws'
     }
   },
   {

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -215,7 +215,7 @@ export const prodChains: EndpointOption[] = [
     providers: {
       'Polkadex Team': 'wss://mainnet.polkadex.trade',
       OnFinality: 'wss://polkadex.api.onfinality.io/public-ws',
-      Pinknode: 'wss://public-rpc.pinknode.io/polkadex',
+      Pinknode: 'wss://public-rpc.pinknode.io/polkadex'
     }
   },
   {

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -356,7 +356,7 @@ export const prodParasKusama: EndpointOption[] = [
     providers: {
       StakeTechnologies: 'wss://rpc.shiden.astar.network',
       OnFinality: 'wss://shiden.api.onfinality.io/public-ws',
-      Pinknode: 'wss://rpc.pinknode.io/shiden/explorer',
+      Pinknode: 'wss://public-rpc.pinknode.io/shiden',
       Dwellir: 'wss://shiden-rpc.dwellir.com'
     }
   },

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -167,7 +167,8 @@ export const prodParasKusama: EndpointOption[] = [
     providers: {
       Phala: 'wss://khala-api.phala.network/ws',
       OnFinality: 'wss://khala.api.onfinality.io/public-ws',
-      Dwellir: 'wss://khala-rpc.dwellir.com'
+      Dwellir: 'wss://khala-rpc.dwellir.com',
+      Pinknode: 'wss://public-rpc.pinknode.io/khala'
     }
   },
   {
@@ -270,7 +271,8 @@ export const prodParasKusama: EndpointOption[] = [
       'Moonbeam Foundation': 'wss://wss.api.moonriver.moonbeam.network',
       Blast: 'wss://moonriver.public.blastapi.io',
       Dwellir: 'wss://moonriver-rpc.dwellir.com',
-      OnFinality: 'wss://moonriver.api.onfinality.io/public-ws'
+      OnFinality: 'wss://moonriver.api.onfinality.io/public-ws',
+      Pinknode: 'wss://public-rpc.pinknode.io/moonriver'
       // Pinknode: 'wss://rpc.pinknode.io/moonriver/explorer' // https://github.com/polkadot-js/apps/issues/7058
     }
   },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -47,7 +47,8 @@ export const prodParasPolkadot: EndpointOption[] = [
     providers: {
       Astar: 'wss://rpc.astar.network',
       OnFinality: 'wss://astar.api.onfinality.io/public-ws',
-      Dwellir: 'wss://astar-rpc.dwellir.com'
+      Dwellir: 'wss://astar-rpc.dwellir.com',
+      Pinknode: 'wss://public-rpc.pinknode.io/astar'
     }
   },
   {
@@ -208,7 +209,8 @@ export const prodParasPolkadot: EndpointOption[] = [
       'Moonbeam Foundation': 'wss://wss.api.moonbeam.network',
       Blast: 'wss://moonbeam.public.blastapi.io',
       Dwellir: 'wss://moonbeam-rpc.dwellir.com',
-      OnFinality: 'wss://moonbeam.api.onfinality.io/public-ws'
+      OnFinality: 'wss://moonbeam.api.onfinality.io/public-ws',
+      Pinknode: 'wss://public-rpc.pinknode.io/moonbeam'
     }
   },
   {
@@ -218,7 +220,8 @@ export const prodParasPolkadot: EndpointOption[] = [
     text: 'Nodle',
     providers: {
       OnFinality: 'wss://nodle-parachain.api.onfinality.io/public-ws',
-      Dwellir: 'wss://eden-rpc.dwellir.com'
+      Dwellir: 'wss://eden-rpc.dwellir.com',
+      Pinknode: 'wss://public-rpc.pinknode.io/nodle'
     }
   },
   {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -335,8 +335,8 @@ export const testChains: EndpointOption[] = [
     providers: {
       'Moonbeam Foundation': 'wss://wss.api.moonbase.moonbeam.network',
       Blast: 'wss://moonbase-alpha.public.blastapi.io',
-      OnFinality: 'wss://moonbeam-alpha.api.onfinality.io/public-ws'
-      // Pinknode: 'wss://rpc.pinknode.io/alphanet/explorer' // https://github.com/polkadot-js/apps/issues/7058
+      OnFinality: 'wss://moonbeam-alpha.api.onfinality.io/public-ws',
+      Pinknode: 'wss://public-rpc.pinknode.io/alphanet'
     }
   },
   {
@@ -465,7 +465,8 @@ export const testChains: EndpointOption[] = [
     text: 'Shibuya',
     providers: {
       StakeTechnologies: 'wss://rpc.shibuya.astar.network',
-      Dwellir: 'wss://shibuya-rpc.dwellir.com'
+      Dwellir: 'wss://shibuya-rpc.dwellir.com',
+      Pinknode: 'wss://public-rpc.pinknode.io/shibuya'
     }
   },
   {


### PR DESCRIPTION
Pinknode endpoints for the following networks have been added or modified:

1) Astar
2) Shiden
3) Shibuya
4) Moonbeam
5) Moonriver
6) Moonbase Alpha
7) Polkadex
8) Khala
9) Nodle
