### PR TITLE
add `armonia-eva` and `armonia-wall-e` for ethereumChains

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -7,5 +7,7 @@ export const ethereumChains = [
   'moonbase',
   'moonbeam',
   'moonriver',
-  'moonshadow'
+  'moonshadow',
+  'armonia-eva',
+  'armonia-wall-e'
 ];


### PR DESCRIPTION
we need those two armonia-eva` and `armonia-wall-e` as running Ethereum-liked chain in apps.