### PR TITLE
Dwellir is removing support for Parallel and Parallel Heiko RPC

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -283,8 +283,7 @@ export const prodParasKusama: EndpointOption[] = [
     text: 'Parallel Heiko',
     providers: {
       OnFinality: 'wss://parallel-heiko.api.onfinality.io/public-ws',
-      Parallel: 'wss://heiko-rpc.parallel.fi',
-      Dwellir: 'wss://heiko-rpc.dwellir.com'
+      Parallel: 'wss://heiko-rpc.parallel.fi'
     }
   },
   {

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -241,8 +241,7 @@ export const prodParasPolkadot: EndpointOption[] = [
     text: 'Parallel',
     providers: {
       OnFinality: 'wss://parallel.api.onfinality.io/public-ws',
-      Parallel: 'wss://rpc.parallel.fi',
-      Dwellir: 'wss://parallel-rpc.dwellir.com'
+      Parallel: 'wss://rpc.parallel.fi'
     }
   },
   {


### PR DESCRIPTION
Dwellir is removing support for Parallel and Parallel Heiko RPC endpoints. Before doing so it's important we remove them publicly from Polkadot.js.org