### PR TITLE
Update testingRelayRococo.ts / helixstreet ParaID 3025 ( formerly Arctic)

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -15,7 +15,6 @@ import { ROCOCO_GENESIS } from '../api/constants';
 //
 // IMPORTANT: Alphabetical based on text
 export const testParasRococo: EndpointOption[] = [
- 
   {
     info: 'rococoBajun',
     isUnreachable: true, // https://github.com/polkadot-js/apps/issues/7593

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -92,7 +92,6 @@ export const testParasRococo: EndpointOption[] = [
   },
   {
     info: 'helixstreet',
-    isUnreachable: true, 
     paraId: 3025,
     text: 'Helixstreet',
     providers: {

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -15,15 +15,7 @@ import { ROCOCO_GENESIS } from '../api/constants';
 //
 // IMPORTANT: Alphabetical based on text
 export const testParasRococo: EndpointOption[] = [
-  {
-    info: 'arctic',
-    isUnreachable: true, // https://github.com/polkadot-js/apps/issues/7420
-    paraId: 3025,
-    text: 'Arctic',
-    providers: {
-      Arctic: 'wss://arctic-rpc-parachain.icenetwork.io:9944'
-    }
-  },
+ 
   {
     info: 'rococoBajun',
     isUnreachable: true, // https://github.com/polkadot-js/apps/issues/7593
@@ -96,6 +88,15 @@ export const testParasRococo: EndpointOption[] = [
     text: 'GM Parachain',
     providers: {
       // 'GM or Die DAO': 'wss://rococo.gmordie.com' // https://github.com/polkadot-js/apps/issues/7716
+    }
+  },
+  {
+    info: 'helixstreet',
+    isUnreachable: true, 
+    paraId: 3025,
+    text: 'Helixstreet',
+    providers: {
+      Helixstreet: 'wss://rpc-rococo.helixstreet.io'
     }
   },
   {


### PR DESCRIPTION
Hi,

the ParaID 3025 is now registered for helixstreet (historically Arctic). The rpc-endpoint is live; the parachain didn't connect yet in the current slot due to issues with the genesis block - will recreate WASM and Genesis Files. 

The Arctic entry is here removed and the helixstreet entry entered alphabetically based on the text field.

Thx in advance.
Tom