### PR TITLE
add altlayer's ethereum chain to `ethereumChains`

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -9,6 +9,8 @@ export const ethereumChains = [
   'moonbeam',
   'moonriver',
   'moonshadow',
+  'alt-producer',
+  'flash-layer',
   'armonia-eva',
   'armonia-wall-e'
 ];


### PR DESCRIPTION
we (altlayer) support two runtime spec-name for ethereum chain:
1. alt-producer
2. flash-layer