### PR TITLE
update singular url to singular v2

### DIFF
--- a/packages/apps-config/src/links/singular.ts
+++ b/packages/apps-config/src/links/singular.ts
@@ -19,11 +19,11 @@ export default {
     Kusama: 'kusama',
     Statemine: 'statemine'
   },
-  create: (_chain: string, _path: string, data: BN | number | string): string => `https://singular.rmrk.app/space/${getNetwork(_chain)}${data.toString()}`,
+  create: (_chain: string, _path: string, data: BN | number | string): string => `https://singular.app/space/${getNetwork(_chain)}${data.toString()}`,
   isActive: true,
   logo: externalLogos.singular as string,
   paths: {
     address: 'account'
   },
-  url: 'https://singular.rmrk.app'
+  url: 'https://singular.app'
 };


### PR DESCRIPTION
Issue: Singular app domain name was changed after the release of RMRK 2.0 and singular.rmrk.app being sunsetted and uniques will soon be available only on singular.app

Change: update Singular app URL to latest version for both Kusama (rmrk nfts) and Statemine (uniques)
<img width="283" alt="Screenshot 2022-07-18 at 18 55 29" src="https://user-images.githubusercontent.com/7943522/179563200-26cc4af9-1321-4a49-96f5-4ffd6246a51a.png">
