### PR TITLE
Remove Bit Country RPC node

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -72,7 +72,6 @@ export const prodParasKusama: EndpointOption[] = [
     paraId: 2096,
     text: 'Bit.Country Pioneer',
     providers: {
-      'Bit.Country': 'wss://pioneer-1-rpc.bit.country',
       OnFinality: 'wss://pioneer.api.onfinality.io/public-ws'
     }
   },


### PR DESCRIPTION
We are removing our own rpc node and will use onFinality's rpc node for the time being.