### PR TITLE
Enable GM Parachain's endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -123,7 +123,6 @@ export const prodParasKusama: EndpointOption[] = [
   },
   {
     info: 'gm',
-    isUnreachable: true,
     homepage: 'https://gmordie.com',
     paraId: 2123,
     text: 'GM',


### PR DESCRIPTION
The GM parachain was already in the apps ui, but it was set to unreachable because the endpoint wasn't up yet, now it's been deployed, and it should be reachable.