### PR TITLE
Update logion types

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -26,7 +26,7 @@
     "@interlay/interbtc-types": "1.9.0",
     "@kiltprotocol/type-definitions": "^0.2.0",
     "@laminar/type-definitions": "0.3.1",
-    "@logion/node-api": "^0.4.1",
+    "@logion/node-api": "^0.5.0-2",
     "@mangata-finance/types": "^0.8.0",
     "@metaverse-network-sdk/type-definitions": "^0.0.1-13",
     "@parallel-finance/type-definitions": "1.7.9",

--- a/packages/apps-config/src/api/spec/logion.ts
+++ b/packages/apps-config/src/api/spec/logion.ts
@@ -191,7 +191,115 @@ const defaultTypesUpTo111 = {
   }
 };
 
+const defaultTypesUpTo116 = {
+  Address: 'MultiAddress',
+  LookupSource: 'MultiAddress',
+  OpaquePeerId: 'Vec<u8>',
+  AccountInfo: 'AccountInfoWithDualRefCount',
+  TAssetBalance: 'u128',
+  AssetId: 'u64',
+  AssetDetails: {
+    owner: 'AccountId',
+    issuer: 'AccountId',
+    admin: 'AccountId',
+    freezer: 'AccountId',
+    supply: 'Balance',
+    deposit: 'DepositBalance',
+    max_zombies: 'u32',
+    min_balance: 'Balance',
+    zombies: 'u32',
+    accounts: 'u32',
+    is_frozen: 'bool'
+  },
+  AssetMetadata: {
+    deposit: 'DepositBalance',
+    name: 'Vec<u8>',
+    symbol: 'Vec<u8>',
+    decimals: 'u8'
+  },
+  LocId: 'u128',
+  LegalOfficerCaseOf: {
+    owner: 'AccountId',
+    requester: 'Requester',
+    metadata: 'Vec<MetadataItem>',
+    files: 'Vec<File>',
+    closed: 'bool',
+    loc_type: 'LocType',
+    links: 'Vec<LocLink>',
+    void_info: 'Option<LocVoidInfo<LocId>>',
+    replacer_of: 'Option<LocId>',
+    collection_last_block_submission: 'Option<BlockNumber>',
+    collection_max_size: 'Option<CollectionSize>',
+    collection_can_upload: 'bool'
+  },
+  MetadataItem: {
+    name: 'Vec<u8>',
+    value: 'Vec<u8>',
+    submitter: 'AccountId'
+  },
+  LocType: {
+    _enum: [
+      'Transaction',
+      'Identity',
+      'Collection'
+    ]
+  },
+  LocLink: {
+    id: 'LocId',
+    nature: 'Vec<u8>'
+  },
+  File: {
+    hash: 'Hash',
+    nature: 'Vec<u8>',
+    submitter: 'AccountId'
+  },
+  LocVoidInfo: {
+    replacer: 'Option<LocId>'
+  },
+  StorageVersion: {
+    _enum: [
+      'V1',
+      'V2MakeLocVoid',
+      'V3RequesterEnum',
+      'V4ItemSubmitter',
+      'V5Collection',
+      'V6ItemUpload',
+      'V7ItemToken'
+    ]
+  },
+  Requester: {
+    _enum: {
+      None: null,
+      Account: 'AccountId',
+      Loc: 'LocId'
+    }
+  },
+  CollectionSize: 'u32',
+  CollectionItemId: 'Hash',
+  CollectionItem: {
+    description: 'Vec<u8>',
+    files: 'Vec<CollectionItemFile<Hash>>',
+    token: 'Option<CollectionItemToken>',
+    restricted_delivery: 'bool'
+  },
+  CollectionItemFile: {
+    name: 'Vec<u8>',
+    content_type: 'Vec<u8>',
+    fileSize: 'u32',
+    hash: 'Hash'
+  },
+  CollectionItemToken: {
+    token_type: 'Vec<u8>',
+    token_id: 'Vec<u8>'
+  }
+};
+
 const definitions: OverrideBundleDefinition = {
+  alias: {
+    loAuthorityList: {
+      StorageVersion: 'LoAuthorityListStorageVersion'
+    }
+  },
   types: [
     {
       minmax: [0, 109],
@@ -208,8 +316,15 @@ const definitions: OverrideBundleDefinition = {
       }
     },
     {
+      minmax: [112, 116],
+      types: {
+        ...defaultTypesUpTo116,
+        ...logionSession.types
+      }
+    },
+    {
       // Latest
-      minmax: [112, undefined],
+      minmax: [117, undefined],
       types: {
         ...logionDefault.types,
         ...logionSession.types

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -45013,6 +45013,11 @@ export const typesBundle = {
       ]
     },
     "logion": {
+      "alias": {
+        "loAuthorityList": {
+          "StorageVersion": "LoAuthorityListStorageVersion"
+        }
+      },
       "types": [
         {
           "minmax": [
@@ -45232,12 +45237,12 @@ export const typesBundle = {
         {
           "minmax": [
             112,
-            null
+            116
           ],
           "types": {
             "Address": "MultiAddress",
             "LookupSource": "MultiAddress",
-            "PeerId": "(Vec<u8>)",
+            "OpaquePeerId": "Vec<u8>",
             "AccountInfo": "AccountInfoWithDualRefCount",
             "TAssetBalance": "u128",
             "AssetId": "u64",
@@ -45306,7 +45311,8 @@ export const typesBundle = {
                 "V3RequesterEnum",
                 "V4ItemSubmitter",
                 "V5Collection",
-                "V6ItemUpload"
+                "V6ItemUpload",
+                "V7ItemToken"
               ]
             },
             "Requester": {
@@ -45333,6 +45339,137 @@ export const typesBundle = {
             "CollectionItemToken": {
               "token_type": "Vec<u8>",
               "token_id": "Vec<u8>"
+            },
+            "FullIdentification": "Exposure",
+            "IdentificationTuple": "(ValidatorId, FullIdentification)",
+            "MembershipProof": {
+              "session": "SessionIndex",
+              "trieNodes": "Vec<Vec<u8>>",
+              "validatorCount": "ValidatorCount"
+            },
+            "SessionIndex": "u32",
+            "ValidatorCount": "u32",
+            "SessionKeys2": "(AccountId, AccountId)",
+            "Keys": "SessionKeys2"
+          }
+        },
+        {
+          "minmax": [
+            117,
+            null
+          ],
+          "types": {
+            "Address": "MultiAddress",
+            "LookupSource": "MultiAddress",
+            "OpaquePeerId": "Vec<u8>",
+            "AccountInfo": "AccountInfoWithDualRefCount",
+            "TAssetBalance": "u128",
+            "AssetId": "u64",
+            "AssetDetails": {
+              "owner": "AccountId",
+              "issuer": "AccountId",
+              "admin": "AccountId",
+              "freezer": "AccountId",
+              "supply": "Balance",
+              "deposit": "DepositBalance",
+              "max_zombies": "u32",
+              "min_balance": "Balance",
+              "zombies": "u32",
+              "accounts": "u32",
+              "is_frozen": "bool"
+            },
+            "AssetMetadata": {
+              "deposit": "DepositBalance",
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8"
+            },
+            "LocId": "u128",
+            "LegalOfficerCaseOf": {
+              "owner": "AccountId",
+              "requester": "Requester",
+              "metadata": "Vec<MetadataItem>",
+              "files": "Vec<File>",
+              "closed": "bool",
+              "loc_type": "LocType",
+              "links": "Vec<LocLink>",
+              "void_info": "Option<LocVoidInfo<LocId>>",
+              "replacer_of": "Option<LocId>",
+              "collection_last_block_submission": "Option<BlockNumber>",
+              "collection_max_size": "Option<CollectionSize>",
+              "collection_can_upload": "bool",
+              "seal": "Option<Hash>"
+            },
+            "MetadataItem": {
+              "name": "Vec<u8>",
+              "value": "Vec<u8>",
+              "submitter": "AccountId"
+            },
+            "LocType": {
+              "_enum": [
+                "Transaction",
+                "Identity",
+                "Collection"
+              ]
+            },
+            "LocLink": {
+              "id": "LocId",
+              "nature": "Vec<u8>"
+            },
+            "File": {
+              "hash": "Hash",
+              "nature": "Vec<u8>",
+              "submitter": "AccountId"
+            },
+            "LocVoidInfo": {
+              "replacer": "Option<LocId>"
+            },
+            "StorageVersion": {
+              "_enum": [
+                "V1",
+                "V2MakeLocVoid",
+                "V3RequesterEnum",
+                "V4ItemSubmitter",
+                "V5Collection",
+                "V6ItemUpload",
+                "V7ItemToken",
+                "V8AddSeal"
+              ]
+            },
+            "Requester": {
+              "_enum": {
+                "None": null,
+                "Account": "AccountId",
+                "Loc": "LocId"
+              }
+            },
+            "CollectionSize": "u32",
+            "CollectionItemId": "Hash",
+            "CollectionItem": {
+              "description": "Vec<u8>",
+              "files": "Vec<CollectionItemFile<Hash>>",
+              "token": "Option<CollectionItemToken>",
+              "restricted_delivery": "bool"
+            },
+            "CollectionItemFile": {
+              "name": "Vec<u8>",
+              "content_type": "Vec<u8>",
+              "fileSize": "u32",
+              "hash": "Hash"
+            },
+            "CollectionItemToken": {
+              "token_type": "Vec<u8>",
+              "token_id": "Vec<u8>"
+            },
+            "LegalOfficerData": {
+              "node_id": "Option<OpaquePeerId>",
+              "base_url": "Option<Vec<u8>>"
+            },
+            "LoAuthorityListStorageVersion": {
+              "_enum": [
+                "V1",
+                "V2AddOnchainSettings"
+              ]
             },
             "FullIdentification": "Exposure",
             "IdentificationTuple": "(ValidatorId, FullIdentification)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,9 +2412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@logion/node-api@npm:0.4.1"
+"@logion/node-api@npm:^0.5.0-2":
+  version: 0.5.0-2
+  resolution: "@logion/node-api@npm:0.5.0-2"
   dependencies:
     "@polkadot/api": ^8.14.1
     "@polkadot/util": ^10.1.1
@@ -2422,7 +2422,7 @@ __metadata:
     "@types/uuid": ^8.3.4
     fast-sha256: ^1.3.0
     uuid: ^8.3.2
-  checksum: 0b1cb772561591de00a51702775c271b555e3e4534e015231d7bb44a008f568259870bbd24543007c3405fec6a7d5d4d55a74e567117b42c51a97ddfbea2bd72
+  checksum: cfc0b521b7357f9d1db2da32bc24ff240e4dc386e795ae508bd2af4ea908872626ce78fa5b496e483019be0315192182ce9f7572e36be7b18931fa6b07acd2c2
   languageName: node
   linkType: hard
 
@@ -3162,7 +3162,7 @@ __metadata:
     "@interlay/interbtc-types": 1.9.0
     "@kiltprotocol/type-definitions": ^0.2.0
     "@laminar/type-definitions": 0.3.1
-    "@logion/node-api": ^0.4.1
+    "@logion/node-api": ^0.5.0-2
     "@mangata-finance/types": ^0.8.0
     "@metaverse-network-sdk/type-definitions": ^0.0.1-13
     "@parallel-finance/type-definitions": 1.7.9


### PR DESCRIPTION
This PR defines new types for an upcoming logion runtime upgrade and fixes the encoding/decoding of `OpaquePeerId` with logion chains (see #8113).