### PR TITLE
refactor: apply relocation of KILT to Polkadot

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -211,17 +211,6 @@ export const prodParasKusama: EndpointOption[] = [
     }
   },
   {
-    info: 'kilt',
-    homepage: 'https://www.kilt.io/',
-    paraId: 2086,
-    text: 'KILT Spiritnet',
-    providers: {
-      'KILT Protocol': 'wss://spiritnet.kilt.io/',
-      OnFinality: 'wss://spiritnet.api.onfinality.io/public-ws',
-      Dwellir: 'wss://kilt-rpc.dwellir.com'
-    }
-  },
-  {
     info: 'kintsugi',
     homepage: 'https://kintsugi.interlay.io/',
     paraId: 2092,

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -228,6 +228,17 @@ export const prodParasPolkadot: EndpointOption[] = [
     }
   },
   {
+    info: 'kilt',
+    homepage: 'https://www.kilt.io/',
+    paraId: 2086,
+    text: 'KILT Spiritnet',
+    providers: {
+      'KILT Protocol': 'wss://spiritnet.kilt.io/',
+      OnFinality: 'wss://spiritnet.api.onfinality.io/public-ws',
+      Dwellir: 'wss://kilt-rpc.dwellir.com'
+    }
+  },
+  {
     info: 'kylin',
     homepage: 'https://kylin.network/',
     paraId: 2052,


### PR DESCRIPTION
The KILT Spiritnet is currently [relocating from Kusama relay chain to Polkadot](https://medium.com/kilt-protocol/kilt-moves-to-polkadot-b5d4b56f8040).

The parachain ID is the same, thus I just moved the code from Kusama to Polkadot. 

We will be live in 50 minutes and we would love if this PR could be merged ASAP 🥹. 

Much thanks in advance!