### PR TITLE
Update Zeitgeist entry for Rococo

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -355,10 +355,10 @@ export const testParasRococo: EndpointOption[] = [
   },
   {
     info: 'rococoZeitgeist',
-    paraId: 2050,
-    text: 'Zeitgeist PC',
+    paraId: 2101,
+    text: 'Battery Station (Rococo)',
     providers: {
-      // Zeitggeist: 'wss://roc.zeitgeist.pm' // See https://github.com/polkadot-js/apps/issues/5842
+      Zeitggeist: 'wss://roc.zeitgeist.pm'
     }
   }
 ];

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -56,14 +56,6 @@ export const testParasRococo: EndpointOption[] = [
     }
   },
   {
-    info: 'rococoZeitgeist',
-    paraId: 2101,
-    text: 'Battery Station',
-    providers: {
-      Zeitgeist: 'wss://roc.zeitgeist.pm'
-    }
-  },
-  {
     info: 'rococoBifrost',
     paraId: 2001,
     text: 'Bifrost',
@@ -361,6 +353,14 @@ export const testParasRococo: EndpointOption[] = [
       Watr: 'wss://rpc.dev.watr.org'
     }
   },
+  {
+    info: 'rococoZeitgeist',
+    paraId: 2101,
+    text: 'Zeitgeist Battery Station',
+    providers: {
+      Zeitgeist: 'wss://roc.zeitgeist.pm'
+    }
+  }
 ];
 
 export const testParasRococoCommon: EndpointOption[] = [

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -358,7 +358,7 @@ export const testParasRococo: EndpointOption[] = [
     paraId: 2101,
     text: 'Battery Station (Rococo)',
     providers: {
-      Zeitggeist: 'wss://roc.zeitgeist.pm'
+      Zeitgeist: 'wss://roc.zeitgeist.pm'
     }
   }
 ];

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -56,6 +56,14 @@ export const testParasRococo: EndpointOption[] = [
     }
   },
   {
+    info: 'rococoZeitgeist',
+    paraId: 2101,
+    text: 'Battery Station',
+    providers: {
+      Zeitgeist: 'wss://roc.zeitgeist.pm'
+    }
+  },
+  {
     info: 'rococoBifrost',
     paraId: 2001,
     text: 'Bifrost',
@@ -353,14 +361,6 @@ export const testParasRococo: EndpointOption[] = [
       Watr: 'wss://rpc.dev.watr.org'
     }
   },
-  {
-    info: 'rococoZeitgeist',
-    paraId: 2101,
-    text: 'Battery Station (Rococo)',
-    providers: {
-      Zeitgeist: 'wss://roc.zeitgeist.pm'
-    }
-  }
 ];
 
 export const testParasRococoCommon: EndpointOption[] = [


### PR DESCRIPTION
Changes the `paraId` to that used by Zeitgeist on Kusama and updates the testnet name.
Additionally, it enables the rpc endpoint for the Parachain: `wss://roc.zeitgeist.pm`. ~The endpoint is currently being set up, I'll ping once it's ready.~