### PR TITLE
Re-enable Neatcoin endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -193,7 +193,7 @@ export const prodChains: EndpointOption[] = [
     info: 'neatcoin',
     text: 'Neatcoin',
     providers: {
-      // Neatcoin: 'wss://rpc.neatcoin.org/ws' // https://github.com/polkadot-js/apps/issues/8266
+      Neatcoin: 'wss://rpc.neatcoin.org/ws'
     }
   },
   {


### PR DESCRIPTION
Messed up DNS settings during a change. Oops!

It should be back up now.