### PR TITLE
Add dotters network rpc endpoints for westend, kusama, polkadot

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -562,6 +562,7 @@ export const prodRelayKusama: EndpointOption = {
     Pinknode: 'wss://public-rpc.pinknode.io/kusama',
     // 'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/ksm',
+    'Dotters Net': 'wss://rpc.dotters.network/kusama',
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/kusama' // NOTE: Keep last
   },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -418,6 +418,7 @@ export const prodRelayPolkadot: EndpointOption = {
     RadiumBlock: 'wss://polkadot.public.curie.radiumblock.io/ws',
     // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/dot',
+    'Dotters Net': 'wss://rpc.dotters.network/polkadot',
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/polkadot' // NOTE: Keep last
   },

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -133,6 +133,7 @@ export const testRelayWestend: EndpointOption = {
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Pinknode: 'wss://rpc.pinknode.io/westend/explorer',
     Dwellir: 'wss://westend-rpc.dwellir.com',
+    'Dotters Net': 'wss://rpc.dotters.network/westend',
     // 'NodeFactory(Vedran)': 'wss://westend.vedran.nodefactory.io/ws', // https://github.com/polkadot-js/apps/issues/5580
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/westend' // NOTE: Keep last


### PR DESCRIPTION
In the commit I labeled it as stake.plus endpoints by accident when it's actually a geodns endpoint split between multiple sites as part of the proof of concept milestone for the infrastructure builders program. This program will be open for RFC/RFQ soon. You can view the future program proposal below. This endpoint is currently split between one site located in US-East serving North and South America and one site located in Istanbul serving EU, and MEA. The US-East site is hosted by https://stake.plus/ and the Istanbul location is being hosted by https://helikon.io/

https://docs.google.com/document/d/16USQYVhlyAlrU829EUB2TRoqUC0nnfoS_uCdZ84HT8k/edit?usp=sharing
