### PR TITLE
Move Vara from Live networks to Test networks

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -310,13 +310,6 @@ export const prodChains: EndpointOption[] = [
     }
   },
   {
-    info: 'vara',
-    text: 'Vara',
-    providers: {
-      'Gear Tech': 'wss://rpc.vara-network.io'
-    }
-  },
-  {
     info: 'westlake',
     text: 'Westlake',
     providers: {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -590,6 +590,13 @@ export const testChains: EndpointOption[] = [
     }
   },
   {
+    info: 'vara',
+    text: 'Vara',
+    providers: {
+      'Gear Tech': 'wss://rpc.vara-network.io'
+    }
+  },
+  {
     info: 'vodka',
     text: 'Vodka',
     providers: {


### PR DESCRIPTION
The Vara network has been accidentally added to the production endpoint while being actually at the testing stage.

This PR puts everything in its place.