### PR TITLE
Add identicon override for litentry-node

### DIFF
--- a/packages/apps-config/src/ui/identityIcons/index.ts
+++ b/packages/apps-config/src/ui/identityIcons/index.ts
@@ -7,6 +7,7 @@
 export const identityNodes: Record<string, string> = [
   ['centrifuge chain', 'polkadot'],
   ['joystream-node', 'beachball'],
+  ['litentry-node', 'polkadot'],
   ['parity-polkadot', 'polkadot']
 ].reduce((icons, [node, icon]): Record<string, string> => ({
   ...icons,


### PR DESCRIPTION
Hi, we'd like to add an identicon override for `litentry-node` as we prefer `polkadot` style.