### PR TITLE
[Spike] Update `PaymentInfo` to use `Assets` pallet for fee asset if applicable

### DIFF
--- a/packages/apps-config/src/settings/feeAssets.ts
+++ b/packages/apps-config/src/settings/feeAssets.ts
@@ -1,0 +1,13 @@
+// Copyright 2017-2022 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChainSpecName, FeeAsset } from './types';
+
+// A mapping of chains to their fee asset if different to the native token
+export const feeAssets: Record<ChainSpecName, FeeAsset> = {
+  root: {
+    assetId: 2,
+    decimals: 6,
+    symbol: 'XRP'
+  }
+};

--- a/packages/apps-config/src/settings/index.ts
+++ b/packages/apps-config/src/settings/index.ts
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './ethereumChains';
+export * from './feeAssets';
 export * from './languages';
 export * from './ss58';

--- a/packages/apps-config/src/settings/types.ts
+++ b/packages/apps-config/src/settings/types.ts
@@ -21,3 +21,10 @@ export interface LinkOption extends Option {
   paraId?: number;
   textBy: string;
 }
+
+export type ChainSpecName = string;
+export interface FeeAsset {
+  assetId: number;
+  symbol: string;
+  decimals: number;
+}

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -30,6 +30,7 @@ export { useEventChanges } from './useEventChanges';
 export { useEventTrigger } from './useEventTrigger';
 export { useExtrinsicTrigger } from './useExtrinsicTrigger';
 export { useFavorites } from './useFavorites';
+export { useFeeAssetBalance } from './useFeeAssetBalance';
 export { useFormField } from './useFormField';
 export { useIncrement } from './useIncrement';
 export { useInflation } from './useInflation';

--- a/packages/react-hooks/src/useFeeAssetBalance.ts
+++ b/packages/react-hooks/src/useFeeAssetBalance.ts
@@ -1,0 +1,40 @@
+// Copyright 2017-2022 @polkadot/react-signer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FeeAsset } from '@polkadot/apps-config/settings/types';
+import type { Option } from '@polkadot/types';
+import type { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
+import type { BN } from '@polkadot/util';
+
+import { useEffect, useState } from 'react';
+
+import { feeAssets } from '@polkadot/apps-config';
+import { useApi, useCall } from '@polkadot/react-hooks';
+
+export const useFeeAssetBalance = (accountId: string | null): [
+  FeeAsset,
+  BN | null
+] => {
+  const { api } = useApi();
+  const [feeBalance, setFeeBalance] = useState<BN | null>(null);
+  const feeAsset = feeAssets[api.runtimeVersion.specName.toString()];
+  const assetsAccount = useCall<Option<PalletAssetsAssetAccount>>(api.query.assets.account, [feeAsset?.assetId, accountId]);
+
+  useEffect(() => {
+    if (!assetsAccount) {
+      return;
+    }
+
+    if (assetsAccount.isSome) {
+      const { balance } = assetsAccount.unwrap();
+
+      setFeeBalance(balance);
+    }
+
+    if (assetsAccount.isNone) {
+      setFeeBalance(api.registry.createType('Balance', 0));
+    }
+  }, [api, assetsAccount]);
+
+  return [feeAsset, feeBalance];
+};

--- a/packages/react-hooks/src/useFeeAssetBalance.ts
+++ b/packages/react-hooks/src/useFeeAssetBalance.ts
@@ -18,7 +18,7 @@ export const useFeeAssetBalance = (accountId: string | null): [
   const { api } = useApi();
   const [feeBalance, setFeeBalance] = useState<BN | null>(null);
   const feeAsset = feeAssets[api.runtimeVersion.specName.toString()];
-  const assetsAccount = useCall<Option<PalletAssetsAssetAccount>>(api.query.assets.account, [feeAsset?.assetId, accountId]);
+  const assetsAccount = useCall<Option<PalletAssetsAssetAccount>>(api.query.assets?.account, [feeAsset?.assetId, accountId]);
 
   useEffect(() => {
     if (!assetsAccount) {

--- a/packages/react-signer/src/PaymentInfo.tsx
+++ b/packages/react-signer/src/PaymentInfo.tsx
@@ -27,11 +27,10 @@ interface Props {
 function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
+  const [feeAsset, feeAssetBalance] = useFeeAssetBalance(accountId);
   const [dispatchInfo, setDispatchInfo] = useState<RuntimeDispatchInfo | null>(null);
   const balances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [accountId]);
   const mountedRef = useIsMountedRef();
-
-  const [feeAsset, feeAssetBalance] = useFeeAssetBalance(accountId);
 
   useEffect((): void => {
     accountId && extrinsic && api.call.transactionPaymentApi &&
@@ -55,7 +54,7 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
     balances.freeBalance.sub(dispatchInfo.partialFee).lte(api.consts.balances.existentialDeposit)
   );
 
-  const isAssetFeeError = feeAsset && feeAssetBalance?.lte(dispatchInfo.partialFee);
+  const isFeeAssetError = feeAsset && feeAssetBalance?.lte(dispatchInfo.partialFee);
 
   return (
     <>
@@ -63,11 +62,11 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
         className={className}
         summary={
           <Trans i18nKey='feesForSubmission'>
-            Fees of <span className='highlight'>{formatBalance(dispatchInfo.partialFee, { withSiFull: true, withUnit: feeAsset?.symbol })}</span> will be applied to the submission
+            Fees of <span className='highlight'>{formatBalance(dispatchInfo.partialFee, { decimals: feeAsset?.decimals, withSiFull: true, withUnit: feeAsset?.symbol })}</span> will be applied to the submission
           </Trans>
         }
       />
-      {(isFeeError || isAssetFeeError) && (
+      {(isFeeError || isFeeAssetError) && (
         <MarkWarning content={t<string>('The account does not have enough free funds (excluding locked/bonded/reserved) available to cover the transaction fees without dropping the balance below the account existential amount.')} />
       )}
     </>

--- a/packages/react-signer/src/PaymentInfo.tsx
+++ b/packages/react-signer/src/PaymentInfo.tsx
@@ -35,15 +35,15 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
 
   useEffect((): void => {
     accountId && extrinsic && api.call.transactionPaymentApi &&
-          nextTick(async (): Promise<void> => {
-            try {
-              const info = await extrinsic.paymentInfo(accountId);
+      nextTick(async (): Promise<void> => {
+        try {
+          const info = await extrinsic.paymentInfo(accountId);
 
-              mountedRef.current && setDispatchInfo(info);
-            } catch (error) {
-              console.error(error);
-            }
-          });
+          mountedRef.current && setDispatchInfo(info);
+        } catch (error) {
+          console.error(error);
+        }
+      });
   }, [api, accountId, extrinsic, mountedRef]);
 
   if (!dispatchInfo || !extrinsic) {
@@ -55,7 +55,7 @@ function PaymentInfo ({ accountId, className = '', extrinsic }: Props): React.Re
     balances.freeBalance.sub(dispatchInfo.partialFee).lte(api.consts.balances.existentialDeposit)
   );
 
-  const isAssetFeeError = api.query.assets && feeAssetBalance?.lte(dispatchInfo.partialFee);
+  const isAssetFeeError = feeAsset && feeAssetBalance?.lte(dispatchInfo.partialFee);
 
   return (
     <>


### PR DESCRIPTION
## The problem
 - At `futureverse` we use an asset from our Assets pallet to handle all fees for the network. The number displayed in `PaymentInfo` is correct, but the symbol is not, and the fee error can trigger when it shouldn't

## The solution
 - Add a `feeAssets` map in `@polkadot/apps-config` where any chain can add their fee asset's details
 - Add a hook that attempts to fetch the fee asset balance based on that map
 - If that hook finds anything, use that data for the fee error and `feesForSubmission` section of `PaymentInfo`