### PR TITLE
Updated Robonomics RPCs

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -395,7 +395,6 @@ export const prodParasKusama: EndpointOption[] = [
     providers: {
       Airalab: 'wss://kusama.rpc.robonomics.network/',
       OnFinality: 'wss://robonomics.api.onfinality.io/public-ws',
-      Dwellir: 'wss://robonomics-rpc.dwellir.com',
       Samsara: 'wss://robonomics.0xsamsara.com',
       Leemo: 'wss://robonomics.leemo.me'
     }


### PR DESCRIPTION
Removed Dwellir RPC endpoint from Robonomics parachain due to it being shut down soon.