### PR TITLE
Astar first wss bootnode

### DIFF
--- a/packages/react-api/src/light/polkadot/astar.json
+++ b/packages/react-api/src/light/polkadot/astar.json
@@ -3,12 +3,7 @@
   "id": "astar",
   "chainType": "Live",
   "bootNodes": [
-    "/dnsaddr/bootnode.astar.network/p2p/12D3KooWMaG4prEjqt1C6Mfas8LCFs31f5k11jw4nRuV52KR3yaB",
-    "/ip4/51.91.105.142/tcp/30333/ws/p2p/12D3KooWMfHf9G1Mtawz4qySe1EqaBmrieidqn2xnEYckUYkpe52",
-    "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
-    "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",
-    "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
+    "/dns/wss-bootnode-astar.bldnodes.org/tcp/443/wss/p2p/12D3KooWA5CX8s2Y68Q197wng5LfWFki4bk8sk4guDEZ6YoyPaG8"
   ],
   "protocolId": "astar",
   "properties": {


### PR DESCRIPTION
Result of a proof of concept that wss do work with light clients as bootnodes.