### PR TITLE
Updating one of the RPC endpoint for Edgeware

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -111,8 +111,8 @@ export const prodChains: EndpointOption[] = [
     info: 'edgeware',
     text: 'Edgeware',
     providers: {
-      'Commonwealth Labs': 'wss://mainnet.edgewa.re',
       JelliedOwl: 'wss://edgeware.jelliedowl.net',
+      'Commonwealth Labs': 'wss://mainnet2.edgewa.re',
       OnFinality: 'wss://edgeware.api.onfinality.io/public-ws',
       Dwellir: 'wss://edgeware-rpc.dwellir.com'
     }


### PR DESCRIPTION
Changing the CW Labs' endpoint temporarily to an upgraded solo node. Given that it's not a load-balanced RPC, changing the display priority for now.