### PR TITLE
add altlayer's ethereum chain to `ethereumChains`

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -9,6 +9,7 @@ export const ethereumChains = [
   'moonbeam',
   'moonriver',
   'moonshadow',
+  'altbeacon',
   'alt-producer',
   'flash-layer',
   'armonia-eva',


### PR DESCRIPTION
we (altlayer) support one runtime spec-name for ethereum chain:
1. altbeacon