### PR TITLE
Skip (& don't break) on previous-gen preimage pallet

### DIFF
--- a/packages/page-preimages/src/usePreimage.ts
+++ b/packages/page-preimages/src/usePreimage.ts
@@ -82,8 +82,11 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
   const { api } = useApi();
 
   const hash = useMemo(
-    () => hashOrBounded && getPreimageHash(hashOrBounded),
-    [hashOrBounded]
+    // we need a hash _and_ be on the newset supported version of the pallet
+    // (after the application of bounded calls)
+    () => api.query.preimage?.preimageFor?.creator.meta.type.isMap && api.registry.lookup.getTypeDef(api.query.preimage.preimageFor.creator.meta.type.asMap.key).type === '(H256,u32)' && hashOrBounded &&
+      getPreimageHash(hashOrBounded),
+    [api, hashOrBounded]
   );
 
   const optStatus = useCall<Option<PalletPreimageRequestStatus>>(hash && api.query.preimage?.statusFor, [hash]);

--- a/packages/page-preimages/src/usePreimage.ts
+++ b/packages/page-preimages/src/usePreimage.ts
@@ -82,7 +82,7 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
   const { api } = useApi();
 
   const hash = useMemo(
-    // we need a hash _and_ be on the newset supported version of the pallet
+    // we need a hash _and_ be on the newest supported version of the pallet
     // (after the application of bounded calls)
     () => api.query.preimage?.preimageFor?.creator.meta.type.isMap && api.registry.lookup.getTypeDef(api.query.preimage.preimageFor.creator.meta.type.asMap.key).type === '(H256,u32)' && hashOrBounded &&
       getPreimageHash(hashOrBounded),


### PR DESCRIPTION
The solution here is exceptionally messy to say the least.

Closes https://github.com/polkadot-js/apps/issues/8440