### PR TITLE
Add Pendulum chain (unreachable) & logo

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -357,6 +357,16 @@ export const prodParasPolkadot: EndpointOption[] = [
     }
   },
   {
+    info: 'pendulum',
+    homepage: 'https://pendulumchain.org/',
+    paraId: 2094,
+    text: 'Pendulum',
+    isUnreachable: true,
+    providers: {
+      PendulumChain: 'wss://rpc.pendulumchain.tech'
+    }
+  },
+  {
     info: 'phala',
     homepage: 'https://phala.network',
     paraId: 2035,

--- a/packages/apps-config/src/ui/colors.ts
+++ b/packages/apps-config/src/ui/colors.ts
@@ -114,6 +114,7 @@ const chainPangolin = '#4B30DD';
 const chainPangoro = '#4B30DD';
 const chainParallel = '#ef18ac';
 const chainParami = '#ee06e2';
+const chainPendulum = '#49E2FD';
 const chainPicasso = '#000000';
 const chainPichiu = '#ed007e';
 const chainPhala = '#c6fa4c';
@@ -432,6 +433,7 @@ export const chainColors: Record<string, string> = Object.entries({
   Parallel: chainParallel,
   'Parallel Heiko': chainHeiko,
   'Parami PC2': chainParami,
+  Pendulum: chainPendulum,
   Phala: chainPhala,
   PHOENIX: chainPhoenix,
   Picasso: chainPicasso,

--- a/packages/apps-config/src/ui/logos/chains/pendulum.svg
+++ b/packages/apps-config/src/ui/logos/chains/pendulum.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="158px" height="158px" viewBox="0 0 158 158" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Pendulum symbol</title>
+    <g id="Pendulum-symbol" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(10.000000, 10.000000)" fill="#000000" fill-rule="nonzero">
+            <path d="M69,0 C107.107648,0 138,30.8923523 138,69 C138,107.107648 107.107648,138 69,138 C30.8923523,138 0,107.107648 0,69 C0,30.8923523 30.8923523,0 69,0 Z M69,13.543457 C38.372197,13.543457 13.543457,38.372197 13.543457,69 C13.543457,99.627803 38.372197,124.456543 69,124.456543 C99.627803,124.456543 124.456543,99.627803 124.456543,69 C124.456543,38.372197 99.627803,13.543457 69,13.543457 Z" id="Combined-Shape"></path>
+            <rect id="Rectangle" transform="translate(69.000000, 69.000000) rotate(23.500000) translate(-69.000000, -69.000000) " x="62.2282715" y="26.5" width="13.543457" height="85"></rect>
+        </g>
+    </g>
+</svg>

--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -53,6 +53,7 @@ import chainOpal from './chains/opal-logo.png';
 import chainOriginTrail from './chains/origintrail.png';
 import chainOriginTrailTestnet from './chains/origintrail-testnet.png';
 import chainParallel from './chains/parallel.svg';
+import chainPendulum from './chains/pendulum.svg';
 import chainPicasso from './chains/picasso.svg';
 import chainQuartz from './chains/quartz.png';
 import chainRiodefi from './chains/riodefi.png';
@@ -394,6 +395,7 @@ export const chainLogos = Object.entries({
   'Parallel Heiko': chainParallel,
   'Parallel Heiko Dev': chainParallel,
   'Parami PC2': nodeParami,
+  Pendulum: chainPendulum,
   Phala: nodePhala,
   'PHOENIX PC1': nodePhoenix,
   Picasso: chainPicasso,
@@ -607,6 +609,7 @@ export const nodeLogos = Object.entries({
   Parami: nodeParami,
   'parity-polkadot': nodePolkadot,
   'Patract Node': nodeJupiter,
+  Pendulum: chainPendulum,
   Phala: nodePhala,
   phala: nodePhala,
   'Phala Collator': nodePhala,
@@ -831,6 +834,7 @@ export const namedLogos: Record<string, unknown> = {
   pangolin: nodePangolin,
   pangoro: nodePangoro,
   parallel: chainParallel,
+  pendulum: chainPendulum,
   phala: nodePhala,
   phoenix: nodePhoenix,
   picasso: chainPicasso,


### PR DESCRIPTION
The main purpose is to be able to see our chain's name and logo for the Polkadot crowdloan, parathread, and parachain pages.
Please that the endpoint is set to Unreachable until we launch.

As reference, similar PR for Kusama: https://github.com/polkadot-js/apps/pull/7807