### PR TITLE
Adjust governance proxy list (w/ gov2 support)

### DIFF
--- a/packages/react-signer/src/Address.tsx
+++ b/packages/react-signer/src/Address.tsx
@@ -94,7 +94,7 @@ function filterProxies (allAccounts: string[], tx: Call | SubmittableExtrinsic<'
 
         case 'Governance':
           return checkNested(address) || (
-            ['council', 'democracy', 'elections', 'electionsPhragmen', 'phragmenElection', 'poll', 'society', 'technicalCommittee', 'tips', 'treasury'].includes(section)
+            ['convictionVoting', 'council', 'councilCollective', 'democracy', 'elections', 'electionsPhragmen', 'fellowshipCollective', 'fellowshipReferenda', 'phragmenElection', 'poll', 'referenda', 'society', 'technicalCommittee', 'tips', 'treasury', 'whitelist'].includes(section)
           );
 
         case 'IdentityJudgement':
@@ -118,7 +118,7 @@ function filterProxies (allAccounts: string[], tx: Call | SubmittableExtrinsic<'
 
         case 'Staking':
           return checkNested(address) || (
-            section === 'staking'
+            ['fastUnstake', 'staking'].includes(section)
           );
 
         case 'SudoBalances':


### PR DESCRIPTION
Governance 2 support (available now in Kusama runtime proxy filtering)

(Additionally also closes https://github.com/polkadot-js/apps/issues/8463 with renamed palette included, since we did touch this list)