### PR TITLE
RadiumBlock Statemint endpoint via hybrid compute

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -430,7 +430,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Dwellir: 'wss://statemint-rpc.dwellir.com',
       Pinknode: 'wss://public-rpc.pinknode.io/statemint',
-      RadiumBlock: 'wss://statemint.public.curie.radiumblock.xyz/ws'
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws'
     }
   },
   {


### PR DESCRIPTION
Deploying statemint endpoint using our hybrid (cloud + on-prem) compute infrastructure for better decentralization, cost prediction and compute provider risk mitigation.