### PR TITLE
Fix ChainImg logo to match chain

### DIFF
--- a/packages/react-components/src/ChainImg.tsx
+++ b/packages/react-components/src/ChainImg.tsx
@@ -22,7 +22,7 @@ function sanitize (value?: string): string {
 function ChainImg ({ className = '', isInline, logo, onClick, withoutHl }: Props): React.ReactElement<Props> {
   const { specName, systemChain, systemName } = useApi();
   const [isEmpty, img] = useMemo((): [boolean, string] => {
-    const found = logo !== 'empty'
+    const found = logo && logo !== 'empty'
       ? namedLogos[logo]
       : chainLogos[sanitize(systemChain)] || nodeLogos[sanitize(systemName)] || specLogos[sanitize(specName)];
 

--- a/packages/react-components/src/ChainImg.tsx
+++ b/packages/react-components/src/ChainImg.tsx
@@ -22,7 +22,7 @@ function sanitize (value?: string): string {
 function ChainImg ({ className = '', isInline, logo, onClick, withoutHl }: Props): React.ReactElement<Props> {
   const { specName, systemChain, systemName } = useApi();
   const [isEmpty, img] = useMemo((): [boolean, string] => {
-    const found = logo
+    const found = logo !== 'empty'
       ? namedLogos[logo]
       : chainLogos[sanitize(systemChain)] || nodeLogos[sanitize(systemName)] || specLogos[sanitize(specName)];
 


### PR DESCRIPTION
This PR fixes the ChainImg component when the `logo` prop is not specified. Previously this would always be an empty logo, using the chain color only, but this change uses the defined chain logo, if it matches, as intended.