### PR TITLE
Adjust all chart options

### DIFF
--- a/packages/page-explorer/src/Latency/Chart.tsx
+++ b/packages/page-explorer/src/Latency/Chart.tsx
@@ -17,35 +17,8 @@ interface Props {
 }
 
 const OPTIONS = {
-  animation: {
-    duration: 0
-  },
   aspectRatio: 6,
-  maintainAspectRatio: true,
-  plugins: {
-    crosshair: {
-      line: {
-        color: '#ff8c00',
-        dashPattern: [5, 5],
-        width: 2
-      },
-      snapping: {
-        enabled: true
-      },
-      sync: {
-        enabled: true,
-        group: Date.now()
-      },
-      // this would be nice, but atm just doesn't quite
-      // seem or feel intuitive...
-      zoom: {
-        enabled: false
-      }
-    },
-    tooltip: {
-      intersect: false
-    }
-  }
+  maintainAspectRatio: true
 };
 
 function ChartDisplay ({ className, colors, legends, title, value: { labels, values } }: Props): React.ReactElement<Props> {

--- a/packages/page-referenda/src/Referenda/Referendum.tsx
+++ b/packages/page-referenda/src/Referenda/Referendum.tsx
@@ -285,28 +285,14 @@ function getChartProps (bestNumber: BN, blockInterval: BN, chartProps: ChartResu
             )
           },
           crosshair: {
-            line: {
-              color: '#ff8c00',
-              dashPattern: [5, 5],
-              width: 2
-            },
-            snapping: {
-              enabled: true
-            },
             sync: {
               group: refId.toNumber()
-            },
-            // this would be nice, but atm just doesn't quite
-            // seem or feel intuitive...
-            zoom: {
-              enabled: false
             }
           },
           tooltip: {
             callbacks: {
               title
-            },
-            intersect: false
+            }
           }
         }
       }, OPTIONS),

--- a/packages/page-staking/src/Query/Chart.tsx
+++ b/packages/page-staking/src/Query/Chart.tsx
@@ -19,8 +19,8 @@ interface Props {
 
 function ChartDisplay ({ className = '', colors, header, labels, legends, values }: Props): React.ReactElement<Props> {
   const isLoading = useMemo(
-    () => labels.length === 0,
-    [labels]
+    () => labels.length === 0 || values.length === 0 || !values[0] || values[0].length !== labels.length,
+    [labels, values]
   );
 
   return (

--- a/packages/page-staking/src/Query/Chart.tsx
+++ b/packages/page-staking/src/Query/Chart.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { LineData } from './types';
+import type { ChartInfo } from './types';
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
@@ -9,15 +9,14 @@ import styled from 'styled-components';
 import { Chart, Spinner } from '@polkadot/react-components';
 
 interface Props {
+  chart: ChartInfo;
   className?: string;
   colors: (string | undefined)[];
   header: string;
-  labels: string[];
   legends: string[];
-  values: LineData;
 }
 
-function ChartDisplay ({ className = '', colors, header, labels, legends, values }: Props): React.ReactElement<Props> {
+function ChartDisplay ({ chart: { labels, values }, className = '', colors, header, legends }: Props): React.ReactElement<Props> {
   const isLoading = useMemo(
     () => labels.length === 0 || values.length === 0 || !values[0] || values[0].length !== labels.length,
     [labels, values]

--- a/packages/page-staking/src/Query/Chart.tsx
+++ b/packages/page-staking/src/Query/Chart.tsx
@@ -1,0 +1,55 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LineData } from './types';
+
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+
+import { Chart, Spinner } from '@polkadot/react-components';
+
+interface Props {
+  className?: string;
+  colors: (string | undefined)[];
+  header: string;
+  labels: string[];
+  legends: string[];
+  values: LineData;
+}
+
+function ChartDisplay ({ className = '', colors, header, labels, legends, values }: Props): React.ReactElement<Props> {
+  const isLoading = useMemo(
+    () => labels.length === 0,
+    [labels]
+  );
+
+  return (
+    <div className={`staking--Chart ${className}${isLoading ? ' isLoading' : ''}`}>
+      <h1>{header}</h1>
+      <Chart.Line
+        colors={colors}
+        labels={labels}
+        legends={legends}
+        values={values}
+      />
+      {isLoading && <Spinner />}
+    </div>
+  );
+}
+
+export default React.memo(styled(ChartDisplay)`
+  position: relative;
+
+  &.isLoading {
+    canvas, h1 {
+      opacity: 0.5;
+    }
+
+    .ui--Spinner {
+      position: absolute;
+      top: 34%;
+      left: 0;
+      right: 0;
+    }
+  }
+`);

--- a/packages/page-staking/src/Query/ChartPoints.tsx
+++ b/packages/page-staking/src/Query/ChartPoints.tsx
@@ -4,7 +4,7 @@
 import type { DeriveStakerPoints } from '@polkadot/api-derive/types';
 import type { ChartInfo, LineDataEntry, Props } from './types';
 
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
 
@@ -37,8 +37,8 @@ function extractPoints (points: DeriveStakerPoints[] = []): ChartInfo {
   });
 
   return {
-    chart: [idxSet, avgSet],
-    labels
+    labels,
+    values: [idxSet, avgSet]
   };
 }
 
@@ -47,11 +47,15 @@ function ChartPoints ({ validatorId }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const params = useMemo(() => [validatorId, false], [validatorId]);
   const stakerPoints = useCall<DeriveStakerPoints[]>(api.derive.staking.stakerPoints, params);
+  const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  const { chart, labels } = useMemo(
-    () => extractPoints(stakerPoints),
-    [stakerPoints]
-  );
+  useEffect((): void => {
+    setChart({ labels: [], values: [] });
+  }, [validatorId]);
+
+  useEffect((): void => {
+    setChart(extractPoints(stakerPoints));
+  }, [stakerPoints]);
 
   const legendsRef = useRef([
     t<string>('points'),
@@ -60,9 +64,9 @@ function ChartPoints ({ validatorId }: Props): React.ReactElement<Props> {
 
   return (
     <Chart
+      chart={chart}
       colors={COLORS_POINTS}
       header={t<string>('era points')}
-      labels={labels}
       legends={legendsRef.current}
       values={chart}
     />

--- a/packages/page-staking/src/Query/ChartPoints.tsx
+++ b/packages/page-staking/src/Query/ChartPoints.tsx
@@ -6,11 +6,10 @@ import type { ChartInfo, LineDataEntry, Props } from './types';
 
 import React, { useMemo, useRef } from 'react';
 
-import { Chart, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate';
-import { chartOptions } from './util';
+import Chart from './Chart';
 
 const COLORS_POINTS = [undefined, '#acacac'];
 
@@ -60,21 +59,13 @@ function ChartPoints ({ validatorId }: Props): React.ReactElement<Props> {
   ]);
 
   return (
-    <div className='staking--Chart'>
-      <h1>{t<string>('era points')}</h1>
-      {labels.length
-        ? (
-          <Chart.Line
-            colors={COLORS_POINTS}
-            labels={labels}
-            legends={legendsRef.current}
-            options={chartOptions}
-            values={chart}
-          />
-        )
-        : <Spinner />
-      }
-    </div>
+    <Chart
+      colors={COLORS_POINTS}
+      header={t<string>('era points')}
+      labels={labels}
+      legends={legendsRef.current}
+      values={chart}
+    />
   );
 }
 

--- a/packages/page-staking/src/Query/ChartPoints.tsx
+++ b/packages/page-staking/src/Query/ChartPoints.tsx
@@ -49,13 +49,15 @@ function ChartPoints ({ validatorId }: Props): React.ReactElement<Props> {
   const stakerPoints = useCall<DeriveStakerPoints[]>(api.derive.staking.stakerPoints, params);
   const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  useEffect((): void => {
-    setChart({ labels: [], values: [] });
-  }, [validatorId]);
+  useEffect(
+    () => setChart({ labels: [], values: [] }),
+    [validatorId]
+  );
 
-  useEffect((): void => {
-    setChart(extractPoints(stakerPoints));
-  }, [stakerPoints]);
+  useEffect(
+    () => setChart(extractPoints(stakerPoints)),
+    [stakerPoints]
+  );
 
   const legendsRef = useRef([
     t<string>('points'),

--- a/packages/page-staking/src/Query/ChartPrefs.tsx
+++ b/packages/page-staking/src/Query/ChartPrefs.tsx
@@ -4,7 +4,7 @@
 import type { DeriveStakerPrefs } from '@polkadot/api-derive/types';
 import type { ChartInfo, LineDataEntry, Props } from './types';
 
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { BN, BN_BILLION } from '@polkadot/util';
@@ -42,8 +42,8 @@ function extractPrefs (prefs: DeriveStakerPrefs[] = []): ChartInfo {
   });
 
   return {
-    chart: [idxSet, avgSet],
-    labels
+    labels,
+    values: [idxSet, avgSet]
   };
 }
 
@@ -52,11 +52,15 @@ function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const params = useMemo(() => [validatorId, false], [validatorId]);
   const stakerPrefs = useCall<DeriveStakerPrefs[]>(api.derive.staking.stakerPrefs, params);
+  const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  const { chart, labels } = useMemo(
-    () => extractPrefs(stakerPrefs),
-    [stakerPrefs]
-  );
+  useEffect((): void => {
+    setChart({ labels: [], values: [] });
+  }, [validatorId]);
+
+  useEffect((): void => {
+    setChart(extractPrefs(stakerPrefs));
+  }, [stakerPrefs]);
 
   const legendsRef = useRef([
     t<string>('commission'),
@@ -65,11 +69,10 @@ function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
 
   return (
     <Chart
+      chart={chart}
       colors={COLORS_POINTS}
       header={t<string>('commission')}
-      labels={labels}
       legends={legendsRef.current}
-      values={chart}
     />
   );
 }

--- a/packages/page-staking/src/Query/ChartPrefs.tsx
+++ b/packages/page-staking/src/Query/ChartPrefs.tsx
@@ -6,12 +6,11 @@ import type { ChartInfo, LineDataEntry, Props } from './types';
 
 import React, { useMemo, useRef } from 'react';
 
-import { Chart, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { BN, BN_BILLION } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import { chartOptions } from './util';
+import Chart from './Chart';
 
 const MULT = new BN(100 * 100);
 const COLORS_POINTS = [undefined, '#acacac'];
@@ -65,21 +64,13 @@ function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
   ]);
 
   return (
-    <div className='staking--Chart'>
-      <h1>{t<string>('commission')}</h1>
-      {labels.length
-        ? (
-          <Chart.Line
-            colors={COLORS_POINTS}
-            labels={labels}
-            legends={legendsRef.current}
-            options={chartOptions}
-            values={chart}
-          />
-        )
-        : <Spinner />
-      }
-    </div>
+    <Chart
+      colors={COLORS_POINTS}
+      header={t<string>('commission')}
+      labels={labels}
+      legends={legendsRef.current}
+      values={chart}
+    />
   );
 }
 

--- a/packages/page-staking/src/Query/ChartPrefs.tsx
+++ b/packages/page-staking/src/Query/ChartPrefs.tsx
@@ -54,13 +54,15 @@ function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
   const stakerPrefs = useCall<DeriveStakerPrefs[]>(api.derive.staking.stakerPrefs, params);
   const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  useEffect((): void => {
-    setChart({ labels: [], values: [] });
-  }, [validatorId]);
+  useEffect(
+    () => setChart({ labels: [], values: [] }),
+    [validatorId]
+  );
 
-  useEffect((): void => {
-    setChart(extractPrefs(stakerPrefs));
-  }, [stakerPrefs]);
+  useEffect(
+    () => setChart(extractPrefs(stakerPrefs)),
+    [stakerPrefs]
+  );
 
   const legendsRef = useRef([
     t<string>('commission'),

--- a/packages/page-staking/src/Query/ChartRewards.tsx
+++ b/packages/page-staking/src/Query/ChartRewards.tsx
@@ -68,18 +68,23 @@ function ChartRewards ({ validatorId }: Props): React.ReactElement<Props> {
   const stakerPoints = useCall<DeriveStakerPoints[]>(api.derive.staking.stakerPoints, params);
   const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  const { currency, divisor } = useMemo(() => ({
-    currency: formatBalance.getDefaults().unit,
-    divisor: new BN('1'.padEnd(formatBalance.getDefaults().decimals + 1, '0'))
-  }), []);
+  const { currency, divisor } = useMemo(
+    () => ({
+      currency: formatBalance.getDefaults().unit,
+      divisor: new BN('1'.padEnd(formatBalance.getDefaults().decimals + 1, '0'))
+    }),
+    []
+  );
 
-  useEffect((): void => {
-    setChart({ labels: [], values: [] });
-  }, [validatorId]);
+  useEffect(
+    () => setChart({ labels: [], values: [] }),
+    [validatorId]
+  );
 
-  useEffect((): void => {
-    setChart(extractRewards(erasRewards, ownSlashes, stakerPoints, divisor));
-  }, [divisor, erasRewards, ownSlashes, stakerPoints]);
+  useEffect(
+    () => setChart(extractRewards(erasRewards, ownSlashes, stakerPoints, divisor)),
+    [divisor, erasRewards, ownSlashes, stakerPoints]
+  );
 
   const legends = useMemo(() => [
     t<string>('{{currency}} slashed', { replace: { currency } }),

--- a/packages/page-staking/src/Query/ChartRewards.tsx
+++ b/packages/page-staking/src/Query/ChartRewards.tsx
@@ -6,12 +6,12 @@ import type { ChartInfo, LineDataEntry, Props } from './types';
 
 import React, { useMemo } from 'react';
 
-import { Chart, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { BN, formatBalance } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import { balanceToNumber, chartOptions } from './util';
+import Chart from './Chart';
+import { balanceToNumber } from './util';
 
 const COLORS_REWARD = ['#8c2200', '#008c22', '#acacac'];
 
@@ -84,21 +84,13 @@ function ChartRewards ({ validatorId }: Props): React.ReactElement<Props> {
   ], [currency, t]);
 
   return (
-    <div className='staking--Chart'>
-      <h1>{t<string>('rewards & slashes')}</h1>
-      {labels.length
-        ? (
-          <Chart.Line
-            colors={COLORS_REWARD}
-            labels={labels}
-            legends={legends}
-            options={chartOptions}
-            values={chart}
-          />
-        )
-        : <Spinner />
-      }
-    </div>
+    <Chart
+      colors={COLORS_REWARD}
+      header={t<string>('rewards & slashes')}
+      labels={labels}
+      legends={legends}
+      values={chart}
+    />
   );
 }
 

--- a/packages/page-staking/src/Query/ChartStake.tsx
+++ b/packages/page-staking/src/Query/ChartStake.tsx
@@ -58,18 +58,23 @@ function ChartStake ({ validatorId }: Props): React.ReactElement<Props> {
   const ownExposures = useCall<DeriveOwnExposure[]>(api.derive.staking.ownExposures, params);
   const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
 
-  const { currency, divisor } = useMemo((): { currency: string; divisor: BN } => ({
-    currency: formatBalance.getDefaults().unit,
-    divisor: new BN('1'.padEnd(formatBalance.getDefaults().decimals + 1, '0'))
-  }), []);
+  const { currency, divisor } = useMemo(
+    () => ({
+      currency: formatBalance.getDefaults().unit,
+      divisor: new BN('1'.padEnd(formatBalance.getDefaults().decimals + 1, '0'))
+    }),
+    []
+  );
 
-  useEffect((): void => {
-    setChart({ labels: [], values: [] });
-  }, [validatorId]);
+  useEffect(
+    () => setChart({ labels: [], values: [] }),
+    [validatorId]
+  );
 
-  useEffect((): void => {
-    setChart(extractStake(ownExposures, divisor));
-  }, [divisor, ownExposures]);
+  useEffect(
+    () => setChart(extractStake(ownExposures, divisor)),
+    [divisor, ownExposures]
+  );
 
   const legends = useMemo(() => [
     t<string>('{{currency}} clipped', { replace: { currency } }),

--- a/packages/page-staking/src/Query/ChartStake.tsx
+++ b/packages/page-staking/src/Query/ChartStake.tsx
@@ -6,12 +6,12 @@ import type { ChartInfo, LineDataEntry, Props } from './types';
 
 import React, { useMemo } from 'react';
 
-import { Chart, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { BN, formatBalance } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import { balanceToNumber, chartOptions } from './util';
+import Chart from './Chart';
+import { balanceToNumber } from './util';
 
 const COLORS_STAKE = [undefined, '#8c2200', '#acacac'];
 
@@ -74,21 +74,13 @@ function ChartStake ({ validatorId }: Props): React.ReactElement<Props> {
   ], [currency, t]);
 
   return (
-    <div className='staking--Chart'>
-      <h1>{t<string>('elected stake')}</h1>
-      {labels.length
-        ? (
-          <Chart.Line
-            colors={COLORS_STAKE}
-            labels={labels}
-            legends={legends}
-            options={chartOptions}
-            values={chart}
-          />
-        )
-        : <Spinner />
-      }
-    </div>
+    <Chart
+      colors={COLORS_STAKE}
+      header={t<string>('elected stake')}
+      labels={labels}
+      legends={legends}
+      values={chart}
+    />
   );
 }
 

--- a/packages/page-staking/src/Query/types.ts
+++ b/packages/page-staking/src/Query/types.ts
@@ -13,6 +13,6 @@ export type LineDataEntry = (BN | number)[];
 export type LineData = LineDataEntry[];
 
 export interface ChartInfo {
-  chart: LineData;
   labels: string[];
+  values: LineData;
 }

--- a/packages/page-staking/src/Query/util.ts
+++ b/packages/page-staking/src/Query/util.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ChartOptions } from 'chart.js';
 import type { BN } from '@polkadot/util';
 
 import { BN_THOUSAND, BN_ZERO, isBn, isFunction } from '@polkadot/util';
@@ -9,33 +8,6 @@ import { BN_THOUSAND, BN_ZERO, isBn, isFunction } from '@polkadot/util';
 interface ToBN {
   toBn: () => BN;
 }
-
-export const chartOptions = {
-  plugins: {
-    crosshair: {
-      line: {
-        color: '#ff8c00',
-        dashPattern: [5, 5],
-        width: 2
-      },
-      snapping: {
-        enabled: true
-      },
-      sync: {
-        enabled: true,
-        group: Date.now()
-      },
-      // this would be nice, but atm just doesn't quite
-      // seem or feel intuitive...
-      zoom: {
-        enabled: false
-      }
-    },
-    tooltip: {
-      intersect: false
-    }
-  }
-} as unknown as ChartOptions;
 
 export function balanceToNumber (amount: BN | ToBN = BN_ZERO, divisor: BN): number {
   const value = isBn(amount)

--- a/packages/react-components/src/Chart/Line.tsx
+++ b/packages/react-components/src/Chart/Line.tsx
@@ -53,8 +53,29 @@ const BASE_OPTS: ChartOptions = {
     mode: 'index'
   },
   plugins: {
+    crosshair: {
+      line: {
+        color: '#ff8c00',
+        dashPattern: [5, 5],
+        width: 2
+      },
+      snap: {
+        enabled: true
+      },
+      sync: {
+        enabled: true
+      },
+      // this would be nice, but atm just doesn't quite
+      // seem or feel intuitive...
+      zoom: {
+        enabled: false
+      }
+    },
     legend: {
       display: false
+    },
+    tooltip: {
+      intersect: false
     }
   },
   scales: {
@@ -87,7 +108,12 @@ function calculateOptions (colors: (string | undefined)[] = [], legends: string[
     chartData,
     chartOptions: objectSpread({}, BASE_OPTS, options, {
       // Re-spread plugins for deep(er) copy
-      plugins: objectSpread({}, BASE_OPTS.plugins, options.plugins)
+      plugins: objectSpread({}, BASE_OPTS.plugins, options.plugins, {
+        // Same applied to plugins, we may want specific values
+        annotation: objectSpread({}, BASE_OPTS.plugins?.annotation, options.plugins?.annotation),
+        crosshair: objectSpread({}, BASE_OPTS.plugins?.crosshair, options.plugins?.crosshair),
+        tooltip: objectSpread({}, BASE_OPTS.plugins?.tooltip, options.plugins?.tooltip)
+      })
     })
   };
 }

--- a/packages/react-components/src/Chart/chart-js-crosshair.d.ts
+++ b/packages/react-components/src/Chart/chart-js-crosshair.d.ts
@@ -1,0 +1,12 @@
+// Copyright 2017-2022 @polkadot/react-components authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChartType } from 'chart.js';
+import type { CrosshairOptions } from 'chartjs-plugin-crosshair';
+
+declare module 'chart.js' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface PluginOptionsByType<TType extends ChartType> {
+    crosshair: CrosshairOptions;
+  }
+}


### PR DESCRIPTION
This _may_ help with https://github.com/polkadot-js/apps/issues/8588

- ensure all charts have the same options (enable per-plugin overrides on options)
- display all staking charts at once (with loader overlay - this is driven by the comments above that there could be a timing issue - staking is different since not all charts are available at the same time)

Some small option fixes for crosshair as well, correctly enabling snapping