### PR TITLE
Add ErrorBoundary to charts

### DIFF
--- a/packages/page-staking/src/Query/Chart.tsx
+++ b/packages/page-staking/src/Query/Chart.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ChartInfo } from './types';
+import type { LineData } from './types';
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
@@ -9,16 +9,17 @@ import styled from 'styled-components';
 import { Chart, Spinner } from '@polkadot/react-components';
 
 interface Props {
-  chart: ChartInfo;
   className?: string;
   colors: (string | undefined)[];
   header: string;
+  labels: string[];
   legends: string[];
+  values: LineData;
 }
 
-function ChartDisplay ({ chart: { labels, values }, className = '', colors, header, legends }: Props): React.ReactElement<Props> {
+function ChartDisplay ({ className = '', colors, header, labels, legends, values }: Props): React.ReactElement<Props> {
   const isLoading = useMemo(
-    () => labels.length === 0 || values.length === 0 || !values[0] || values[0].length !== labels.length,
+    () => !labels || labels.length === 0 || !values || values.length === 0 || !values[0] || !values[0].length,
     [labels, values]
   );
 
@@ -31,17 +32,19 @@ function ChartDisplay ({ chart: { labels, values }, className = '', colors, head
         legends={legends}
         values={values}
       />
-      {isLoading && <Spinner />}
+      {isLoading && (
+        <Spinner />
+      )}
     </div>
   );
 }
 
 export default React.memo(styled(ChartDisplay)`
-  position: relative;
-
   &.isLoading {
+    position: relative;
+
     canvas, h1 {
-      opacity: 0.5;
+      opacity: 0.25;
     }
 
     .ui--Spinner {

--- a/packages/page-staking/src/Query/ChartPrefs.tsx
+++ b/packages/page-staking/src/Query/ChartPrefs.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { DeriveStakerPrefs } from '@polkadot/api-derive/types';
-import type { ChartInfo, LineDataEntry, Props } from './types';
+import type { LineData, Props } from './types';
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -15,10 +15,9 @@ import Chart from './Chart';
 const MULT = new BN(100 * 100);
 const COLORS_POINTS = [undefined, '#acacac'];
 
-function extractPrefs (prefs: DeriveStakerPrefs[] = []): ChartInfo {
-  const labels: string[] = [];
-  const avgSet: LineDataEntry = [];
-  const idxSet: LineDataEntry = [];
+function extractPrefs (labels: string[], prefs: DeriveStakerPrefs[]): LineData {
+  const avgSet = new Array<number>(labels.length);
+  const idxSet = new Array<number>(labels.length);
   const [total, avgCount] = prefs.reduce(([total, avgCount], { validatorPrefs }) => {
     const comm = validatorPrefs.commission.unwrap().mul(MULT).div(BN_BILLION).toNumber() / 100;
 
@@ -35,33 +34,32 @@ function extractPrefs (prefs: DeriveStakerPrefs[] = []): ChartInfo {
     const avg = avgCount > 0
       ? Math.ceil(total * 100 / avgCount) / 100
       : 0;
+    const index = labels.indexOf(era.toHuman());
 
-    labels.push(era.toHuman());
-    avgSet.push(avg);
-    idxSet.push(comm);
+    if (index !== -1) {
+      avgSet[index] = avg;
+      idxSet[index] = comm;
+    }
   });
 
-  return {
-    labels,
-    values: [idxSet, avgSet]
-  };
+  return [idxSet, avgSet];
 }
 
-function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
+function ChartPrefs ({ labels, validatorId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const params = useMemo(() => [validatorId, false], [validatorId]);
   const stakerPrefs = useCall<DeriveStakerPrefs[]>(api.derive.staking.stakerPrefs, params);
-  const [chart, setChart] = useState<ChartInfo>({ labels: [], values: [] });
+  const [values, setValues] = useState<LineData>([]);
 
   useEffect(
-    () => setChart({ labels: [], values: [] }),
+    () => setValues([]),
     [validatorId]
   );
 
   useEffect(
-    () => setChart(extractPrefs(stakerPrefs)),
-    [stakerPrefs]
+    () => stakerPrefs && setValues(extractPrefs(labels, stakerPrefs)),
+    [labels, stakerPrefs]
   );
 
   const legendsRef = useRef([
@@ -71,10 +69,11 @@ function ChartPrefs ({ validatorId }: Props): React.ReactElement<Props> {
 
   return (
     <Chart
-      chart={chart}
       colors={COLORS_POINTS}
       header={t<string>('commission')}
+      labels={labels}
       legends={legendsRef.current}
+      values={values}
     />
   );
 }

--- a/packages/page-staking/src/Query/Validator.tsx
+++ b/packages/page-staking/src/Query/Validator.tsx
@@ -13,16 +13,28 @@ import ChartPrefs from './ChartPrefs';
 import ChartRewards from './ChartRewards';
 import ChartStake from './ChartStake';
 
-function Validator ({ className = '', validatorId }: Props): React.ReactElement<Props> {
+function Validator ({ className = '', labels, validatorId }: Props): React.ReactElement<Props> | null {
   return (
     <Columar className={className}>
       <Columar.Column>
-        <ChartPoints validatorId={validatorId} />
-        <ChartRewards validatorId={validatorId} />
+        <ChartPoints
+          labels={labels}
+          validatorId={validatorId}
+        />
+        <ChartRewards
+          labels={labels}
+          validatorId={validatorId}
+        />
       </Columar.Column>
       <Columar.Column>
-        <ChartStake validatorId={validatorId} />
-        <ChartPrefs validatorId={validatorId} />
+        <ChartStake
+          labels={labels}
+          validatorId={validatorId}
+        />
+        <ChartPrefs
+          labels={labels}
+          validatorId={validatorId}
+        />
       </Columar.Column>
     </Columar>
   );

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -1,10 +1,13 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useState } from 'react';
+import type { INumber } from '@polkadot/types/types';
+
+import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { Button, InputAddressSimple } from '@polkadot/react-components';
+import { Button, InputAddressSimple, Spinner } from '@polkadot/react-components';
+import { useApi, useCall } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate';
 import Validator from './Validator';
@@ -13,19 +16,32 @@ interface Props {
   className?: string;
 }
 
+function doQuery (validatorId?: string | null): void {
+  if (validatorId) {
+    window.location.hash = `/staking/query/${validatorId}`;
+  }
+}
+
 function Query ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const { api } = useApi();
   const { value } = useParams<{ value: string }>();
   const [validatorId, setValidatorId] = useState<string | null>(value || null);
+  const eras = useCall<INumber[]>(api.derive.staking.erasHistoric);
+
+  const labels = useMemo(
+    () => eras && eras.map((e) => e.toHuman() as string),
+    [eras]
+  );
 
   const _onQuery = useCallback(
-    (): void => {
-      if (validatorId) {
-        window.location.hash = `/staking/query/${validatorId}`;
-      }
-    },
+    () => doQuery(validatorId),
     [validatorId]
   );
+
+  if (!labels) {
+    return <Spinner />;
+  }
 
   return (
     <div className={className}>
@@ -44,7 +60,10 @@ function Query ({ className }: Props): React.ReactElement<Props> {
         />
       </InputAddressSimple>
       {value && (
-        <Validator validatorId={value} />
+        <Validator
+          labels={labels}
+          validatorId={value}
+        />
       )}
     </div>
   );

--- a/packages/page-staking/src/Query/types.ts
+++ b/packages/page-staking/src/Query/types.ts
@@ -5,6 +5,7 @@ import type { BN } from '@polkadot/util';
 
 export interface Props {
   className?: string;
+  labels: string[];
   validatorId: string;
 }
 

--- a/packages/react-components/src/Chart/Line.tsx
+++ b/packages/react-components/src/Chart/Line.tsx
@@ -10,6 +10,7 @@ import * as Chart from 'react-chartjs-2';
 
 import { isBn, objectSpread } from '@polkadot/util';
 
+import ErrorBoundary from '../ErrorBoundary';
 import { alphaColor } from './utils';
 
 interface State {
@@ -126,12 +127,14 @@ function LineChart ({ className, colors, labels, legends, options, values }: Lin
 
   return (
     <div className={className}>
-      <Chart.Line
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        data={chartData as any}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        options={chartOptions as any}
-      />
+      <ErrorBoundary>
+        <Chart.Line
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          data={chartData as any}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          options={chartOptions as any}
+        />
+      </ErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
Inspired by https://github.com/polkadot-js/apps/issues/8588

It also tweaks the staking charts to pass in a known set of labels (which may or may not have some impact on resolving the above)