### PR TITLE
fix the cess testnet logo wrong bug

### DIFF
--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -752,6 +752,7 @@ export const namedLogos: Record<string, unknown> = {
   calamari: nodeCalamari,
   centrifuge: nodeCentrifuge,
   cess: nodeCESS,
+  'cess-testnet': nodeCESS,
   chainoli: nodeChainOLI,
   chainx: nodeChainx,
   charcoal: nodeCentrifuge,


### PR DESCRIPTION
The logo of our cess testnet chain is not displayed. We found the reason because the name is wrong, so we can modify it to display it.