### PR TITLE
Replace (some-browser-broken) visibility: collapsed

### DIFF
--- a/packages/react-components/src/Table/index.tsx
+++ b/packages/react-components/src/Table/index.tsx
@@ -434,11 +434,7 @@ export default React.memo(styled(Table)`
       }
 
       &.isCollapsed {
-        visibility: collapse;
-      }
-
-      &.isExpanded {
-        visibility: visible;
+        display: none;
       }
 
       .ui--Button-Group {


### PR DESCRIPTION
On Safari `visibility: collapsed` has a bug, i.e. it is treated as `visibility: hidden` by the browser.

Since we don't have alternating rows (anymore), using `display: none` does exactly the same job. As a bonus, we are removing some lines of css.
