### PR TITLE
Fix tooltips

### DIFF
--- a/packages/react-components/src/Badge.tsx
+++ b/packages/react-components/src/Badge.tsx
@@ -67,7 +67,7 @@ function Badge ({ className = '', color = 'normal', hover, hoverAction, icon, in
       {hover && (
         <Tooltip
           className='accounts-badge'
-          clickable={!!hoverAction}
+          isClickable={!!hoverAction}
           text={hoverContent}
           trigger={trigger}
         />

--- a/packages/react-components/src/Tooltip.tsx
+++ b/packages/react-components/src/Tooltip.tsx
@@ -15,13 +15,13 @@ function rootElement () {
 interface Props {
   children?: React.ReactNode;
   className?: string;
-  isCickable?: boolean;
+  isClickable?: boolean;
   place?: 'bottom' | 'top' | 'right' | 'left';
   text?: React.ReactNode;
   trigger: string;
 }
 
-function Tooltip ({ children, className = '', isCickable = false, place, text, trigger }: Props): React.ReactElement<Props> | null {
+function Tooltip ({ children, className = '', isClickable = false, place, text, trigger }: Props): React.ReactElement<Props> | null {
   const [tooltipContainer] = useState(
     typeof document === 'undefined'
       ? {} as HTMLElement // This hack is required for server side rendering
@@ -41,7 +41,7 @@ function Tooltip ({ children, className = '', isCickable = false, place, text, t
   return createPortal(
     <ReactTooltip
       className={`ui--Tooltip ${className}`}
-      clickable={isCickable}
+      clickable={isClickable}
       effect='solid'
       id={trigger}
       place={place}


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/8759

This fucking styled-components and Props - it gets completely lost and causes issues like this where the Props are not type-checked. This is 2023.