### PR TITLE
fix: democracy page for chains without launchPeriod

### DIFF
--- a/packages/page-democracy/src/Overview/Summary.tsx
+++ b/packages/page-democracy/src/Overview/Summary.tsx
@@ -55,19 +55,21 @@ function Summary ({ referendumCount }: Props): React.ReactElement<Props> {
             : <span className='--tmp'>99</span>}
         </CardSummary>
       </section>
-      <section className='media--1100'>
-        <CardSummary
-          label={t<string>('launch period')}
-          progress={{
-            isBlurred: !bestNumber,
-            total: api.consts.democracy.launchPeriod,
-            value: bestNumber
-              ? bestNumber.mod(api.consts.democracy.launchPeriod).iadd(BN_ONE)
-              : api.consts.democracy.launchPeriod.mul(BN_TWO).div(BN_THREE),
-            withTime: true
-          }}
-        />
-      </section>
+      {api.consts.democracy.launchPeriod && (
+        <section className='media--1100'>
+          <CardSummary
+            label={t<string>('launch period')}
+            progress={{
+              isBlurred: !bestNumber,
+              total: api.consts.democracy.launchPeriod,
+              value: bestNumber
+                ? bestNumber.mod(api.consts.democracy.launchPeriod).iadd(BN_ONE)
+                : api.consts.democracy.launchPeriod.mul(BN_TWO).div(BN_THREE),
+              withTime: true
+            }}
+          />
+        </section>
+      )}
     </SummaryBox>
   );
 }


### PR DESCRIPTION
Our chain no longer has `api.consts.democracy.launchPeriod`, causing the democracy page to generate an error when loading. This PR just hides the launch period card summary if this constant is undefined. This is a quick fix to get the page to load again.

The reason why we no longer have the `launchPeriod` is because we made some changes to the referendum scheduling, s.t. they are always created on mondays. Longer term I'd love to be able to get the launch period card summary to work for our chain as well, but I'm not sure how to approach that. Right now we use a timestamp-based approach, but we could refactor this back to be block-based. Then the only change required for us would be that the value would be calculated as `(bestNumber + api.consts.democracy.ourNonStandardOffset) mod(api.consts.democracy.launchPeriod).iadd(BN_ONE)`. Is this something we can achieve by adding an item to `api.derive`? Some pointer would be much appreciated!