### PR TITLE
Small fixes to provide council page compatibility

### DIFF
--- a/packages/page-council/src/Overview/Voters.tsx
+++ b/packages/page-council/src/Overview/Voters.tsx
@@ -28,30 +28,26 @@ function Voters ({ balance, voters }: Props): React.ReactElement<Props> {
 
   return (
     <>
-      {voters ? (
-        <>
-          <td className='expand'>
-            <ExpanderScroll
-              className={balance ? '' : '--tmp'}
-              renderChildren={renderVoters}
-              summary={<FormatBalance value={balance} />}
-            />
-          </td>
-          <td className='number'>
-            {voters
-              ? formatNumber(voters.length)
-              : <span className='--tmp'>123</span>
-            }
-          </td>
-        </>
-      ) : (
-        <>
-          {/* empty <td>'s necessary to maintain row sizes */}
-          <td></td>
-          <td></td>
-        </>
-      )}
-
+      {voters
+        ? (
+          <>
+            <td className='expand'>
+              <ExpanderScroll
+                className={balance ? '' : '--tmp'}
+                renderChildren={renderVoters}
+                summary={<FormatBalance value={balance} />}
+              />
+            </td>
+            <td className='number'>
+              {voters
+                ? formatNumber(voters.length)
+                : <span className='--tmp'>123</span>
+              }
+            </td>
+          </>
+        )
+        : <td colSpan={2} />
+      }
     </>
   );
 }

--- a/packages/page-council/src/Overview/Voters.tsx
+++ b/packages/page-council/src/Overview/Voters.tsx
@@ -28,19 +28,30 @@ function Voters ({ balance, voters }: Props): React.ReactElement<Props> {
 
   return (
     <>
-      <td className='expand'>
-        <ExpanderScroll
-          className={balance ? '' : '--tmp'}
-          renderChildren={renderVoters}
-          summary={<FormatBalance value={balance} />}
-        />
-      </td>
-      <td className='number'>
-        {voters
-          ? formatNumber(voters.length)
-          : <span className='--tmp'>123</span>
-        }
-      </td>
+      {voters ? (
+        <>
+          <td className='expand'>
+            <ExpanderScroll
+              className={balance ? '' : '--tmp'}
+              renderChildren={renderVoters}
+              summary={<FormatBalance value={balance} />}
+            />
+          </td>
+          <td className='number'>
+            {voters
+              ? formatNumber(voters.length)
+              : <span className='--tmp'>123</span>
+            }
+          </td>
+        </>
+      ) : (
+        <>
+          {/* empty <td>'s necessary to maintain row sizes */}
+          <td></td>
+          <td></td>
+        </>
+      )}
+
     </>
   );
 }

--- a/packages/page-democracy/src/Overview/ProposalCell.tsx
+++ b/packages/page-democracy/src/Overview/ProposalCell.tsx
@@ -31,7 +31,7 @@ function ProposalCell ({ className = '', imageHash, proposal }: Props): React.Re
   const preimage = usePreimage(imageHash);
 
   // while we still have this endpoint, democracy will use it
-  const displayProposal = api.query.democracy?.preimages 
+  const displayProposal = api.query.democracy?.preimages
     ? proposal
     : preimage?.proposal;
 

--- a/packages/page-democracy/src/Overview/ProposalCell.tsx
+++ b/packages/page-democracy/src/Overview/ProposalCell.tsx
@@ -31,9 +31,13 @@ function ProposalCell ({ className = '', imageHash, proposal }: Props): React.Re
   const preimage = usePreimage(imageHash);
 
   // while we still have this endpoint, democracy will use it
-  const displayProposal = api.query.democracy.preimages
-    ? proposal
-    : preimage?.proposal;
+  const democracy = api.query.democracy;
+
+  const displayProposal = democracy ? 
+    democracy.preimages
+      ? proposal
+      : preimage?.proposal
+    : proposal;
 
   if (!displayProposal) {
     const textHash = imageHash.toString();

--- a/packages/page-democracy/src/Overview/ProposalCell.tsx
+++ b/packages/page-democracy/src/Overview/ProposalCell.tsx
@@ -31,13 +31,9 @@ function ProposalCell ({ className = '', imageHash, proposal }: Props): React.Re
   const preimage = usePreimage(imageHash);
 
   // while we still have this endpoint, democracy will use it
-  const democracy = api.query.democracy;
-
-  const displayProposal = democracy ? 
-    democracy.preimages
-      ? proposal
-      : preimage?.proposal
-    : proposal;
+  const displayProposal = api.query.democracy?.preimages 
+    ? proposal
+    : preimage?.proposal;
 
   if (!displayProposal) {
     const textHash = imageHash.toString();


### PR DESCRIPTION
Currently, the Governance -> Council page relies on Democracy. Using Council without Democracy causes the Council page to not render properly. 

See [Issue 8788](https://github.com/polkadot-js/apps/issues/8788) for more details. 

This PR provides two small changes to provide compatibility for a chain with Council, but without Democracy.

The following screenshots show the Overview and Motion page with the new changes. 

**Polkadot**
![Screen Shot 2023-01-13 at 4 10 36 PM](https://user-images.githubusercontent.com/23270067/212435466-a820b394-f391-4064-bf24-33a6bf499d3c.png)
![Screen Shot 2023-01-13 at 4 10 45 PM](https://user-images.githubusercontent.com/23270067/212435471-98f4cefb-9cd8-4d35-92f0-cb9ea7d03997.png)
**Without Democracy**
![Screen Shot 2023-01-13 at 4 10 03 PM](https://user-images.githubusercontent.com/23270067/212435491-d75d0d9a-1dc0-4c0e-ac18-2202ee384569.png)
![Screen Shot 2023-01-13 at 4 10 15 PM](https://user-images.githubusercontent.com/23270067/212435502-81cf82c6-423a-4ace-8425-d78f5882733a.png)
