### PR TITLE
Update t0rn websocket endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -334,7 +334,7 @@ export const testParasRococo: EndpointOption[] = [
     paraId: 3333,
     text: 't0rn',
     providers: {
-      t3rn: 'wss://dev.net.t3rn.io'
+      t3rn: 'wss://ws.t0rn.io'
     }
   },
   {


### PR DESCRIPTION
Hey

We have completed migration of our websocket and rpc to new infrastructure and new domain. We would love to replace our old address with new one, as the old one is deprecated at this point.

Thanks!