### PR TITLE
Motion page to display motion with no preimage

### DIFF
--- a/packages/page-democracy/src/Overview/ProposalCell.tsx
+++ b/packages/page-democracy/src/Overview/ProposalCell.tsx
@@ -32,8 +32,8 @@ function ProposalCell ({ className = '', imageHash, proposal }: Props): React.Re
   // while we still have this endpoint, democracy will use it
   const democracy = api.query.democracy;
 
-  const displayProposal = democracy ? 
-    democracy.preimages
+  const displayProposal = democracy
+    ? democracy.preimages
       ? proposal
       : preimage?.proposal
     : proposal;

--- a/packages/page-democracy/src/Overview/ProposalCell.tsx
+++ b/packages/page-democracy/src/Overview/ProposalCell.tsx
@@ -30,9 +30,13 @@ function ProposalCell ({ className = '', imageHash, proposal }: Props): React.Re
   const preimage = usePreimage(imageHash);
 
   // while we still have this endpoint, democracy will use it
-  const displayProposal = api.query.democracy?.preimages
-    ? proposal
-    : preimage?.proposal;
+  const democracy = api.query.democracy;
+
+  const displayProposal = democracy ? 
+    democracy.preimages
+      ? proposal
+      : preimage?.proposal
+    : proposal;
 
   if (!displayProposal) {
     const textHash = imageHash.toString();


### PR DESCRIPTION
In the next week or two, we will be assisting in the upgrade of the [Watr devnet](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.dev.watr.org#/explorer) to include a simple governance. The Mainnet will be launched soon as well. 

This governance only uses a collective, does not have Democracy, and does not rely on preimages. 

As is, the Polkadot.js UI only displays the motion hash for this governance. This PR adds a small change that will display the motion in text if democracy and the preimage does not exist.

Thank you for your help! 