### PR TITLE
Add endpoints for Polkadot, Kusama and Westend - IBP Network

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -621,6 +621,7 @@ export const prodRelayKusama: EndpointOption = {
     // 'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/ksm',
     'Dotters Net': 'wss://rpc.dotters.network/kusama',
+    'IBP Network': 'wss://rpc.ibp.network/kusama',
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/kusama' // NOTE: Keep last
   },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -73,7 +73,7 @@ export const prodParasPolkadot: EndpointOption[] = [
     homepage: 'https://www.aventus.io/',
     paraId: 2056,
     text: 'Aventus',
-    providers: { }
+    providers: {}
   },
   {
     info: 'bifrost',
@@ -461,6 +461,7 @@ export const prodRelayPolkadot: EndpointOption = {
     // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/dot',
     'Dotters Net': 'wss://rpc.dotters.network/polkadot',
+    'IBP Network': 'wss://rpc.ibp.network/polkadot',
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/polkadot' // NOTE: Keep last
   },

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -144,6 +144,7 @@ export const testRelayWestend: EndpointOption = {
     Dwellir: 'wss://westend-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
     'Dotters Net': 'wss://rpc.dotters.network/westend',
+    'IBP Network': 'wss://rpc.ibp.network/westend',
     // 'NodeFactory(Vedran)': 'wss://westend.vedran.nodefactory.io/ws', // https://github.com/polkadot-js/apps/issues/5580
     // NOTE: Keep this as the last entry, nothing after it
     'light client': 'light://substrate-connect/westend' // NOTE: Keep last


### PR DESCRIPTION
Dear team:

Please consider the following request to add endpoints serving the networks: Polkadot, Kusama and Westend.

These endpoints are provided by a network of geographically distributed and decentralised operators under the Infrastructure Builders Program, which is detailed [here](https://docs.google.com/document/d/16USQYVhlyAlrU829EUB2TRoqUC0nnfoS_uCdZ84HT8k/edit?usp=sharing).

The current GeoDNS design can be found [here](https://docs.google.com/spreadsheets/d/1563-TMFBi39Ye8uMXUDCimOLeAFlbLKIQtn4mBktIp4/edit?usp=sharing), and the geolocation of the independent nodes is:

1. [Gatotech](https://gatotech.uk/) -> Costa Rica
2. [Stake.plus](https://stake.plus/) -> United States
3. [Helikon](https://helikon.io/) -> Turkey
4. [Amforc](https://amforc.com/) -> Switzerland
5. [Metaspan](https://metaspan.io/) -> United Kingdom

For resiliency, all worldwide territories are covered with at minimum of 2 different operators, each one serving their RPC endpoints from at least 2 High Availability backend nodes in each relevant network. Their availability is monitored via ICMP pings every 1 minute for automated DNS replacement and their quality of service is measured every 5 minutes from this custom [application](https://ibp-monitor.metaspan.io/) by Mestaspan.

The quality of service is supported by fully owned hardware colocated in high specification datacentres in the above locations, with excellent reliability, connectivity and sustainability ratings each.

Many thanks!! We remain attentive in case of any questions...

Best regards

**_Miloš_** 
