### PR TITLE
Fixes External URLs for Moonbase Alpha

### DIFF
--- a/packages/apps-config/src/links/polkassembly.ts
+++ b/packages/apps-config/src/links/polkassembly.ts
@@ -48,7 +48,7 @@ export const PolkassemblyNetwork: ExternalDef = {
     'KILT Spiritnet': 'kilt',
     Karura: 'karura',
     'Khala Network': 'khala',
-    Moonbase: 'moonbase',
+    'Moonbase Alpha': 'moonbase',
     Moonbeam: 'moonbeam',
     Moonriver: 'moonriver'
   },

--- a/packages/apps-config/src/links/subscan.ts
+++ b/packages/apps-config/src/links/subscan.ts
@@ -50,7 +50,7 @@ export const Subscan: ExternalDef = {
     Litmus: 'litmus',
     'Mangata Kusama Mainnet': 'mangatax',
     'Mangata Public Testnet': 'mangata-testnet',
-    Moonbase: 'moonbase',
+    'Moonbase Alpha': 'moonbase',
     Moonbeam: 'moonbeam',
     Moonriver: 'moonriver',
     'Nodle Parachain': 'nodle',


### PR DESCRIPTION
There were some naming issues with the External URLs for Subscan and Polkassembly that were not auto-populating the `external links` sections