### PR TITLE
Change Provider for SubsocialX

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -508,8 +508,7 @@ export const prodParasKusama: EndpointOption[] = [
     paraId: 2100,
     text: 'SubsocialX',
     providers: {
-      'Dappforce 1': 'wss://para.f3joule.space'
-      // 'Dappforce 2': 'wss://para.subsocial.network' // https://github.com/polkadot-js/apps/issues/8781
+      'Dappforce 1': 'wss://para.subsocial.network'
     }
   },
   {


### PR DESCRIPTION
Subsocial team decided to leave `para.f3joule.space` as a private node for stability purpose