### PR TITLE
Removed PinkNode endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -341,9 +341,7 @@ export const prodParasKusama: EndpointOption[] = [
       'Moonbeam Foundation': 'wss://wss.api.moonriver.moonbeam.network',
       Blast: 'wss://moonriver.public.blastapi.io',
       OnFinality: 'wss://moonriver.api.onfinality.io/public-ws',
-      Pinknode: 'wss://public-rpc.pinknode.io/moonriver',
       UnitedBloc: 'wss://moonriver.unitedbloc.com:2001'
-      // Pinknode: 'wss://rpc.pinknode.io/moonriver/explorer' // https://github.com/polkadot-js/apps/issues/7058
     }
   },
   {

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -302,9 +302,7 @@ export const prodParasPolkadot: EndpointOption[] = [
       'Automata 1RPC': 'wss://1rpc.io/glmr',
       Blast: 'wss://moonbeam.public.blastapi.io',
       OnFinality: 'wss://moonbeam.api.onfinality.io/public-ws',
-      Pinknode: 'wss://public-rpc.pinknode.io/moonbeam',
       UnitedBloc: 'wss://moonbeam.unitedbloc.com:3001'
-
     }
   },
   {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -365,7 +365,6 @@ export const testChains: EndpointOption[] = [
       'Moonbeam Foundation': 'wss://wss.api.moonbase.moonbeam.network',
       Blast: 'wss://moonbase-alpha.public.blastapi.io',
       OnFinality: 'wss://moonbeam-alpha.api.onfinality.io/public-ws',
-      Pinknode: 'wss://public-rpc.pinknode.io/alphanet',
       UnitedBloc: 'wss://moonbase.unitedbloc.com:1001'
     }
   },


### PR DESCRIPTION
We've been notified that PinkNode will not serve Moonbeam-based networks anymore.

This PR is to remove them from all Moonbeam-based networks.