### PR TITLE
Add explicit ErrorBoundary to Modal displays

### DIFF
--- a/packages/react-components/src/Modal/index.tsx
+++ b/packages/react-components/src/Modal/index.tsx
@@ -7,6 +7,7 @@ import styled, { createGlobalStyle } from 'styled-components';
 
 import { useTheme } from '@polkadot/react-hooks';
 
+import ErrorBoundary from '../ErrorBoundary';
 import Actions from './Actions';
 import Columns from './Columns';
 import Content from './Content';
@@ -55,7 +56,9 @@ function ModalBase ({ children, className = '', header, onClose, size = 'medium'
           header={header}
           onClose={onClose}
         />
-        {children}
+        <ErrorBoundary>
+          {children}
+        </ErrorBoundary>
       </div>
     </StyledDiv>,
     document.body


### PR DESCRIPTION
As commented on in https://github.com/polkadot-js/apps/issues/8926#issuecomment-1415766986

This ensures that the signing modal doesn't bring down the whole app