### PR TITLE
fix: bad logo after PR 8941

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -5,7 +5,7 @@ import type { EndpointOption } from './types';
 
 import { KUSAMA_GENESIS } from '../api/constants';
 import { chainsAbandPNG, chainsKusamaSVG, chainsTinkerPNG, chainsTuringPNG } from '../ui/logos/chains';
-import { nodesAjunaPNG, nodesBridgeHubBlackSVG, nodesStatemineSVG, nodesZeitgeistPNG } from '../ui/logos/nodes';
+import { nodesBajunPNG, nodesBridgeHubBlackSVG, nodesStatemineSVG, nodesZeitgeistPNG } from '../ui/logos/nodes';
 import { getTeleports } from './util';
 
 // The available endpoints that will show in the dropdown. For the most part (with the exception of
@@ -60,7 +60,7 @@ export const prodParasKusama: EndpointOption[] = [
     },
     text: 'Bajun Network',
     uiColor: '#161212',
-    uiLogo: nodesAjunaPNG
+    uiLogo: nodesBajunPNG
   },
   {
     homepage: 'https://app.basilisk.cloud',

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -5,7 +5,7 @@ import type { EndpointOption } from './types';
 
 import { ROCOCO_GENESIS } from '../api/constants';
 import { chainsT0rnPNG, chainsTinkerPNG, chainsTuringPNG, chainsVirtoPNG, chainsWatrPNG } from '../ui/logos/chains';
-import { nodesAjunaPNG, nodesBasiliskRococoBgPNG, nodesBridgeHubBlackSVG, nodesStatemineSVG, nodesZeitgeistPNG } from '../ui/logos/nodes';
+import { nodesBajunPNG, nodesBasiliskRococoBgPNG, nodesBridgeHubBlackSVG, nodesStatemineSVG, nodesZeitgeistPNG } from '../ui/logos/nodes';
 import { getTeleports } from './util';
 
 // The available endpoints that will show in the dropdown. For the most part (with the exception of
@@ -57,7 +57,7 @@ export const testParasRococo: EndpointOption[] = [
     },
     text: 'Bajun Network',
     uiColor: '#161212',
-    uiLogo: nodesAjunaPNG
+    uiLogo: nodesBajunPNG
   },
   {
     info: 'rococoBasilisk',


### PR DESCRIPTION
It seems like the Bajun Logo got wrongly changed to the Ajuna Logo. Hopefully, this will fix the change.

Kusama and Rococo are running under the Baju Network (nodesBajunPNG)