### PR TITLE
Add endpoints for Polkadot and Kusama - IBP Network 

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -851,6 +851,7 @@ export const prodRelayKusama: EndpointOption = {
     'Dotters Net': 'wss://rpc.dotters.network/kusama',
     Dwellir: 'wss://kusama-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
+    'IBP Network': 'wss://rpc.ibp.network/kusama',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
     Parity: 'wss://kusama-rpc.polkadot.io',
     Pinknode: 'wss://public-rpc.pinknode.io/kusama',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -620,6 +620,7 @@ export const prodRelayPolkadot: EndpointOption = {
     'Dotters Net': 'wss://rpc.dotters.network/polkadot',
     Dwellir: 'wss://polkadot-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
+    'IBP Network': 'wss://rpc.ibp.network/polkadot',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
     Parity: 'wss://rpc.polkadot.io',
     Pinknode: 'wss://public-rpc.pinknode.io/polkadot',


### PR DESCRIPTION
Dear @jacogr, dear team,

For your consideration, this request aims to add the remaining endpoints from the Infrastructure Builders Programme for the Polkadot and Kusama networks, as agreed a the previous PR #8852.

The trial period for the Westend endpoint (#8872) has now reached  two weeks, and we trust the service has been provided to a high standard (please inform if otherwise).

Would you kindly consider adding these addftional endpoints?

Many thanks, best regards

**_Miloš_**