### PR TITLE
Update ChainEndpoints Check task

### DIFF
--- a/.github/workflows/chain-endpoints.yml
+++ b/.github/workflows/chain-endpoints.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   types:
-    if: (github.event_name == 'schedule' && github.repository == 'polkadot-js/apps') || (github.event_name != 'schedule')
+    if: github.repository == 'polkadot-js/apps'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/chain-endpoints.yml
+++ b/.github/workflows/chain-endpoints.yml
@@ -1,10 +1,11 @@
 name: Chain endpoints
 on:
   schedule:
-    - cron:  '45 0/12 * * *'
+    - cron:  '50 0/12 * * *'
 
 jobs:
   types:
+    if: (github.event_name == 'schedule' && github.repository == 'polkadot-js/apps') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c


### PR DESCRIPTION
Hi @jacogr,

We're not finding an easy way to whitelist just your automated CI for our rate limited endpoints.
We suspect that one of the big issues is that every fork (heres mine doing it https://github.com/jamesbayly/apps/actions/runs/4159421728) will run this automated check task at the same time, so we might have tens if not hundreds of calls from GItHub at the same time (that get rate limited) as each fork executes the check.

I've added a line that only runs the endpoints check in your repo (not on forks) and changes the time it does this to slight later in the 12 hour window since i can't change code in already forked codebases

Let me know if you have any other ideas that we should pursue

James