### PR TITLE
Add Polkadot trackinfo

### DIFF
--- a/packages/apps-config/src/api/params/tracks/index.ts
+++ b/packages/apps-config/src/api/params/tracks/index.ts
@@ -4,11 +4,13 @@
 import type { ApiPromise } from '@polkadot/api';
 import type { TrackInfo } from './types';
 
-import { KUSAMA_GENESIS } from '../../constants';
+import { KUSAMA_GENESIS, POLKADOT_GENESIS } from '../../constants';
 import { kusama } from './kusama';
+import { polkadot } from './polkadot';
 
 const KNOWN_GENE_TRACKS: Record<string, Record<string, TrackInfo[]>> = {
-  [KUSAMA_GENESIS]: kusama
+  [KUSAMA_GENESIS]: kusama,
+  [POLKADOT_GENESIS]: polkadot
 };
 
 const KNOWN_SPEC_TRACKS: Record<string, Record<string, TrackInfo[]>> = {
@@ -22,7 +24,8 @@ const KNOWN_SPEC_TRACKS: Record<string, Record<string, TrackInfo[]>> = {
         origin: { system: 'Root' }
       }
     ]
-  }
+  },
+  polkadot
 };
 
 export function getGovernanceTracks (api: ApiPromise, specName: string, palletReferenda: string): TrackInfo[] | undefined {

--- a/packages/apps-config/src/api/params/tracks/polkadot.ts
+++ b/packages/apps-config/src/api/params/tracks/polkadot.ts
@@ -9,16 +9,16 @@ import { compareFellowshipRank, formatSpendFactory } from './util';
 
 // hardcoded here since this is static (hopefully no re-denomination anytime...)
 const formatSpend = formatSpendFactory({
-  decimals: 12,
+  decimals: 10,
   forceUnit: '-',
   withSi: true,
-  withUnit: 'KSM'
+  withUnit: 'DOT'
 });
 
 // https://github.com/paritytech/polkadot/blob/6e3f2c5b4b6e6927915de2f784e1d831717760fa/runtime/kusama/constants/src/lib.rs#L28-L32
-const UNITS = new BN(1_000_000_000_000);
-const QUID = UNITS.divn(30);
-const GRAND = QUID.muln(1_000);
+const UNITS = new BN(10_000_000_000);
+const DOLLARS = UNITS;
+const GRAND = DOLLARS.muln(1_000);
 
 // https://github.com/paritytech/polkadot/blob/6e3f2c5b4b6e6927915de2f784e1d831717760fa/runtime/kusama/src/governance/origins.rs#L170-L179
 const SPEND_LIMITS = {
@@ -26,11 +26,11 @@ const SPEND_LIMITS = {
   BigTipper: formatSpend(1, GRAND),
   MediumSpender: formatSpend(100, GRAND),
   SmallSpender: formatSpend(10, GRAND),
-  SmallTipper: formatSpend(250, QUID),
+  SmallTipper: formatSpend(250, DOLLARS),
   Treasurer: formatSpend(10_000, GRAND)
 };
 
-export const kusama: Record<string, TrackInfo[]> = {
+export const polkadot: Record<string, TrackInfo[]> = {
   fellowshipReferenda: [
     {
       compare: compareFellowshipRank(0),

--- a/packages/apps-config/src/api/params/tracks/util.ts
+++ b/packages/apps-config/src/api/params/tracks/util.ts
@@ -1,0 +1,24 @@
+// Copyright 2017-2023 @polkadot/app-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { BN, formatBalance } from '@polkadot/util';
+
+interface FormatOptions {
+  decimals: number;
+  forceUnit: '-',
+  withSi: true,
+  withUnit: string;
+}
+
+export function formatSpendFactory (options: FormatOptions): (mul: number, value: BN) => string {
+  return (mul: number, value: BN): string => {
+    // We lose the decimals here... depending on chain config, this could be non-optimal
+    // (A simple formatBalance(value.muln(mul), FMT_OPTS) formats to 4 decimals)
+    return `${formatBalance(value.muln(mul), options).split('.')[0]} ${options.withUnit}`;
+  };
+}
+
+export function compareFellowshipRank (trackId: number): (rank: BN) => boolean {
+  return (rank: BN): boolean =>
+    rank.gten(trackId);
+}


### PR DESCRIPTION
Just pulls in the human summaries like we have on Kusama.

Values as per https://github.com/paritytech/polkadot/pull/6701