### PR TITLE
Fix statemint endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -619,7 +619,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://statemint-rpc.polkadot.io',
-      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws'
     },
     teleport: [-1],
     text: 'Statemint',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -618,7 +618,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://statemint-rpc.dwellir.com',
       'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
-      Parity: 'wss://statemint-rpc.polkadot.io'
+      Parity: 'wss://statemint-rpc.polkadot.io',
       RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
     },
     teleport: [-1],

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -619,7 +619,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://statemint-rpc.polkadot.io'
-      // RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' // https://github.com/polkadot-js/apps/issues/9089
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
     },
     teleport: [-1],
     text: 'Statemint',


### PR DESCRIPTION
We faced a DNS issue with one of our onprem servers that confused the front end load balancer causing a failure with the statemint endpoint. We have been working to fix it. The fix is in place and endpoint has been operating stable and would like to re-enable it. 

We take this disruption very seriously and would like to apologize and assure that we will continue to monitor the endpoint with high priority.