### PR TITLE
Adjust TS compilation target

### DIFF
--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "importHelpers": true,
     "jsx": "react-jsx",
-    "module": "es2020",
-    "skipLibCheck": true
+    "module": "esnext",
+    "skipLibCheck": true,
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
Closes #9117 

Seems to be the actual tsc compiler using `__spreadArray` on iterators which in turn uses a non-existent length and thus never spreads the iterator. This seems to fix the tsc output by forcing it to latest (as a side-effect this also aligns with the settings used in the libs, so at worst is consistent).