### PR TITLE
Add IBP system chain support, update naming convention

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -799,7 +799,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
       OnFinality: 'wss://statemine.api.onfinality.io/public-ws',
       Parity: 'wss://statemine-rpc.polkadot.io',
-      RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws'
+      RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/statemine'
     },
     teleport: [-1],
     text: 'Statemine',
@@ -814,7 +815,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     paraId: 1001,
     providers: {
       'Encointer Association': 'wss://kusama.api.encointer.org',
-      OnFinality: 'wss://encointer.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/8553, reenabled for Polkadot JS
+      OnFinality: 'wss://encointer.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/8553, reenabled for Polkadot JS
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/encointer-kusama'
     },
     teleport: [-1],
     text: 'Encointer Network',
@@ -827,7 +829,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     info: 'kusamaBridgeHub',
     paraId: 1002,
     providers: {
-      Parity: 'wss://kusama-bridge-hub-rpc.polkadot.io'
+      Parity: 'wss://kusama-bridge-hub-rpc.polkadot.io',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-kusama'
     },
     text: 'BridgeHub',
     ui: {
@@ -847,10 +850,10 @@ export const prodRelayKusama: EndpointOption = {
   providers: {
     // 'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/ksm',
-    'Dotters Net': 'wss://rpc.dotters.network/kusama',
+    'IBP-GeoDNS2': 'wss://rpc.dotters.network/kusama',
     Dwellir: 'wss://kusama-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
-    'IBP Network': 'wss://rpc.ibp.network/kusama',
+    'IBP-GeoDNS1': 'wss://rpc.ibp.network/kusama',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
     Parity: 'wss://kusama-rpc.polkadot.io',
     RadiumBlock: 'wss://kusama.public.curie.radiumblock.co/ws',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -623,7 +623,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://statemint-rpc.polkadot.io',
-      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws'
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/statemint'
     },
     teleport: [-1],
     text: 'Statemint',
@@ -637,7 +638,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1001,
     providers: {
       OnFinality: 'wss://collectives.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-collectives-rpc.polkadot.io'
+      Parity: 'wss://polkadot-collectives-rpc.polkadot.io',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/collectives-polkadot'
     },
     teleport: [-1],
     text: 'Collectives',
@@ -670,10 +672,10 @@ export const prodRelayPolkadot: EndpointOption = {
   providers: {
     // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     'Automata 1RPC': 'wss://1rpc.io/dot',
-    'Dotters Net': 'wss://rpc.dotters.network/polkadot',
+    'IBP-GeoDNS2': 'wss://rpc.dotters.network/polkadot',
     Dwellir: 'wss://polkadot-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
-    'IBP Network': 'wss://rpc.ibp.network/polkadot',
+    'IBP-GeoDNS1': 'wss://rpc.ibp.network/polkadot',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
     Parity: 'wss://rpc.polkadot.io',
     RadiumBlock: 'wss://polkadot.public.curie.radiumblock.co/ws',

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -143,7 +143,8 @@ export const testParasWestendCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://westmint-rpc.dwellir.com',
       'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
-      Parity: 'wss://westmint-rpc.polkadot.io'
+      Parity: 'wss://westmint-rpc.polkadot.io',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/westmint'
     },
     teleport: [-1],
     text: 'Westmint',
@@ -156,7 +157,8 @@ export const testParasWestendCommon: EndpointOption[] = [
     info: 'westendCollectives',
     paraId: 1001,
     providers: {
-      Parity: 'wss://westend-collectives-rpc.polkadot.io'
+      Parity: 'wss://westend-collectives-rpc.polkadot.io',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/collectives-westend'
     },
     teleport: [-1],
     text: 'Collectives',
@@ -187,10 +189,10 @@ export const testRelayWestend: EndpointOption = {
     ...testParasWestend
   ],
   providers: {
-    'Dotters Net': 'wss://rpc.dotters.network/westend',
+    'IBP-GeoDNS2': 'wss://rpc.dotters.network/westend',
     Dwellir: 'wss://westend-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
-    'IBP Network': 'wss://rpc.ibp.network/westend',
+    'IBP-GeoDNS1': 'wss://rpc.ibp.network/westend',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
     'light client': 'light://substrate-connect/westend'


### PR DESCRIPTION
Hello,

This request alters the names of both "Dotters Net" and "IBP Network" to bring them into a naming convention alignment for the IBP program. "IBP Network" will be renamed to "IBP-GeoDNS1" and "Dotters Net" will be renamed to "IBP-GeoDNS2".

Additionally, we are requesting to add our RPC endpoints on IBP-GeoDNS2 for the following system chains: Westmint, Collectives-Westend, Statemine, BridgeHub-Kusama, Encointer-Kusama, Collectives-Polkadot, and Statemint.

Thanks!