### PR TITLE
Fix duration formatting to use proper SI symbols

### DIFF
--- a/packages/react-hooks/src/useBlockTime.ts
+++ b/packages/react-hooks/src/useBlockTime.ts
@@ -27,24 +27,16 @@ export function calcBlockTime (blockTime: BN, blocks: BN, t: TFunction): Result 
     blockTime.toNumber(),
     `${value < 0 ? '+' : ''}${[
       days
-        ? (days > 1)
-          ? t<string>('{{days}} days', { replace: { days } })
-          : t<string>('1 day')
+        ? t<string>('{{days}} d', { replace: { days } })
         : null,
       hours
-        ? (hours > 1)
-          ? t<string>('{{hours}} hrs', { replace: { hours } })
-          : t<string>('1 hr')
+        ? t<string>('{{hours}} h', { replace: { hours } })
         : null,
       minutes
-        ? (minutes > 1)
-          ? t<string>('{{minutes}} mins', { replace: { minutes } })
-          : t<string>('1 min')
+        ? t<string>('{{minutes}} min', { replace: { minutes } })
         : null,
       seconds
-        ? (seconds > 1)
-          ? t<string>('{{seconds}} s', { replace: { seconds } })
-          : t<string>('1 s')
+        ? t<string>('{{seconds}} s', { replace: { seconds } })
         : null
     ]
       .filter((s): s is string => !!s)

--- a/packages/react-query/src/Elapsed.tsx
+++ b/packages/react-query/src/Elapsed.tsx
@@ -57,7 +57,7 @@ function getDisplayValue (now = 0, value: BN | Date | number = 0): React.ReactNo
     ? formatValue(elapsed, 's', elapsed < 15)
     : (elapsed < 3600)
       ? formatValue(elapsed / 60, 'min')
-      : formatValue(elapsed / 3600, 'hr');
+      : formatValue(elapsed / 3600, 'h');
 }
 
 tick();


### PR DESCRIPTION
This commit fixes the formatting of durations in the app so that they use the proper SI symbols for the various time units to make it as standardized and international as possible.