### PR TITLE
display discord identity in profile sidebar

### DIFF
--- a/packages/page-accounts/src/Sidebar/Identity.tsx
+++ b/packages/page-accounts/src/Sidebar/Identity.tsx
@@ -7,6 +7,7 @@ import React, { useMemo } from 'react';
 
 import { AddressMini, AvatarItem, Expander, IconLink } from '@polkadot/react-components';
 import { useApi, useRegistrars, useSubidentities, useToggle } from '@polkadot/react-hooks';
+import { AddressIdentityOtherDiscordKey } from '@polkadot/react-hooks/types';
 import { isHex } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
@@ -138,11 +139,11 @@ function Identity ({ address, identity }: Props): React.ReactElement<Props> | nu
                 </div>
               </div>
             )}
-            {identity.other && "Discord" in identity.other && (
+            {identity.other && AddressIdentityOtherDiscordKey in identity.other && (
               <div className='tr'>
                 <div className='th'>{t<string>('discord')}</div>
                 <div className='td'>
-                  {identity.other["Discord"]}
+                  {identity.other[AddressIdentityOtherDiscordKey]}
                 </div>
               </div>
             )}

--- a/packages/page-accounts/src/Sidebar/Identity.tsx
+++ b/packages/page-accounts/src/Sidebar/Identity.tsx
@@ -138,6 +138,14 @@ function Identity ({ address, identity }: Props): React.ReactElement<Props> | nu
                 </div>
               </div>
             )}
+            {identity.other && "Discord" in identity.other && (
+              <div className='tr'>
+                <div className='th'>{t<string>('discord')}</div>
+                <div className='td'>
+                  {identity.other["Discord"]}
+                </div>
+              </div>
+            )}
             {identity.riot && (
               <div className='tr'>
                 <div className='th'>{t<string>('riot')}</div>

--- a/packages/page-accounts/src/modals/IdentityMain.tsx
+++ b/packages/page-accounts/src/modals/IdentityMain.tsx
@@ -10,6 +10,7 @@ import { ApiPromise } from '@polkadot/api';
 import { Input, InputBalance, Modal, Toggle, TxButton } from '@polkadot/react-components';
 import { getAddressMeta } from '@polkadot/react-components/util';
 import { useApi, useCall } from '@polkadot/react-hooks';
+import { AddressIdentityOtherDiscordKey } from '@polkadot/react-hooks/types';
 import { u8aToString } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
@@ -33,7 +34,6 @@ interface ValueState {
 }
 
 const WHITESPACE = [' ', '\t'];
-const ADDITIONAL_FIELD_DISCORD = 'Discord';
 
 function setData (data: Data, setActive: null | ((isActive: boolean) => void), setVal: (val: string) => void): void {
   if (data.isRaw) {
@@ -96,7 +96,7 @@ function IdentityMain ({ address, className = '', onClose }: Props): React.React
       setData(info.legal, setHasLegal, setValLegal);
       setData(info.riot, setHasRiot, setValRiot);
       setData(info.twitter, setHasTwitter, setValTwitter);
-      const infoDiscord = setAdditionalFieldData(api, info, ADDITIONAL_FIELD_DISCORD, setHasDiscord, setValDiscord);
+      const infoDiscord = setAdditionalFieldData(api, info, AddressIdentityOtherDiscordKey, setHasDiscord, setValDiscord);
 
       setData(info.web, setHasWeb, setValWeb);
 
@@ -124,7 +124,7 @@ function IdentityMain ({ address, className = '', onClose }: Props): React.React
     setInfo({
       info: {
         additional: [
-          (okDiscord && hasDiscord ? [{ raw: ADDITIONAL_FIELD_DISCORD }, { raw: valDiscord }] : null)
+          (okDiscord && hasDiscord ? [{ raw: AddressIdentityOtherDiscordKey }, { raw: valDiscord }] : null)
         ].filter((item) => !!item),
         display: { [okDisplay ? 'raw' : 'none']: valDisplay || null },
         email: { [okEmail && hasEmail ? 'raw' : 'none']: okEmail && hasEmail ? valEmail : null },

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -104,6 +104,8 @@ export interface AddressFlags extends DeriveAccountFlags {
   isNominator: boolean;
 }
 
+export const AddressIdentityOtherDiscordKey = 'Discord';
+
 export interface AddressIdentity extends DeriveAccountRegistration {
   isExistent: boolean;
   isKnownGood: boolean;


### PR DESCRIPTION
Enables discord identity in the sidebar. Follow up to #8381 