### PR TITLE
Bittensor - switch node to finney public node

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -65,7 +65,7 @@ export const prodChains: EndpointOption[] = [
   {
     info: 'bittensor',
     providers: {
-      'Opentensor Fdn (Archive)': 'wss://archivelb.nakamoto.opentensor.ai:9943'
+      'Opentensor Fdn (Archive)': 'wss://entrypoint-finney.opentensor.ai:443'
     },
     text: 'Bittensor',
     ui: {


### PR DESCRIPTION
Bittensor recently hard-forked to a new network, so I'm updating the Opentensor Foundation's node url.