### PR TITLE
Allow to run with isDevelopment on ethereum-like chains

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -187,7 +187,7 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
     chainSS58,
     hasInjectedAccounts: injectedAccounts.length !== 0,
     isApiReady: true,
-    isDevelopment: isEthereum ? false : isDevelopment,
+    isDevelopment,
     isEthereum,
     specName: api.runtimeVersion.specName.toString(),
     specVersion: api.runtimeVersion.specVersion.toString(),


### PR DESCRIPTION
Currently any `isEthereum==true` chain will force the development mode off, making it impossible to add any extra types as needed.