### PR TITLE
Added LuckyFriday's Kusama and Statemine RPC nodes

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -782,7 +782,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
       'IBP-GeoDNS1': 'wss://sys.ibp.network/statemine',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemine',
-      LuckyFriday : 'wss://rpc-statemine.luckyfriday.io',
+      LuckyFriday: 'wss://rpc-statemine.luckyfriday.io',
       OnFinality: 'wss://statemine.api.onfinality.io/public-ws',
       Parity: 'wss://statemine-rpc.polkadot.io',
       RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws'
@@ -841,7 +841,7 @@ export const prodRelayKusama: EndpointOption = {
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
     'IBP-GeoDNS1': 'wss://rpc.ibp.network/kusama',
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/kusama',
-    LuckyFriday : 'wss://rpc-kusama.luckyfriday.io',
+    LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
     Parity: 'wss://kusama-rpc.polkadot.io',
     RadiumBlock: 'wss://kusama.public.curie.radiumblock.co/ws',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -782,6 +782,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
       'IBP-GeoDNS1': 'wss://sys.ibp.network/statemine',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemine',
+      'LuckyFriday': 'wss://rpc-statemine.luckyfriday.io',
       OnFinality: 'wss://statemine.api.onfinality.io/public-ws',
       Parity: 'wss://statemine-rpc.polkadot.io',
       RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws'
@@ -840,6 +841,7 @@ export const prodRelayKusama: EndpointOption = {
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
     'IBP-GeoDNS1': 'wss://rpc.ibp.network/kusama',
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/kusama',
+    'LuckyFriday': 'wss://rpc-kusama.luckyfriday.io',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
     Parity: 'wss://kusama-rpc.polkadot.io',
     RadiumBlock: 'wss://kusama.public.curie.radiumblock.co/ws',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -841,7 +841,7 @@ export const prodRelayKusama: EndpointOption = {
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
     'IBP-GeoDNS1': 'wss://rpc.ibp.network/kusama',
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/kusama',
-    'LuckyFriday': 'wss://rpc-kusama.luckyfriday.io',
+    LuckyFriday : 'wss://rpc-kusama.luckyfriday.io',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
     Parity: 'wss://kusama-rpc.polkadot.io',
     RadiumBlock: 'wss://kusama.public.curie.radiumblock.co/ws',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -782,7 +782,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
       'IBP-GeoDNS1': 'wss://sys.ibp.network/statemine',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemine',
-      'LuckyFriday': 'wss://rpc-statemine.luckyfriday.io',
+      LuckyFriday : 'wss://rpc-statemine.luckyfriday.io',
       OnFinality: 'wss://statemine.api.onfinality.io/public-ws',
       Parity: 'wss://statemine-rpc.polkadot.io',
       RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws'


### PR DESCRIPTION
Dear PJS team,

Subsequent to our [treasury application](https://kusama.subsquare.io/council/motion/572) and successful rounds of testing the LuckyFriday team is seeking approval to have their RPC nodes listed within the Polkadot.JS application.  The RPC nodes are hosted on self-owned, newly acquired bare-metal servers hosted at a private Datacenter with bandwidth rated at 20 GBit (in/out/redundant).  We believe that LuckyFriday would be a good addition to the listing providing service outside of mainstream cloud and infrastructure providers.

We have spent the past few weeks load testing the servers using various sized payloads from from the staking and conviction voting pallets.  Tests were done at multiple geographic locations all to our satisfaction.  We also invited members of ChaosDAO to load test the endpoints and neither have broken.

Our monitoring stack comprises of Prometheus, Grafana and Alert Manager.  Alerts are sent to a common slack channel and if not attended to escalates to Pager-Duty calls.  Alerts are generated based on node unavailability or when there are 20 blocks behind finalization.  

I look forward to your feedback,

Kind Regards,
Will | Paradox