### PR TITLE
Add dracones mainnet & test to ethereumChains.ts

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -22,5 +22,7 @@ export const ethereumChains = [
   'Pangoro2',
   'thebifrost-dev',
   'thebifrost-testnet',
-  'thebifrost-mainnet'
+  'thebifrost-mainnet',
+  'dracones',
+  'dracones-dwarf'
 ];


### PR DESCRIPTION
Added the dracones networks.

The source code for those is https://github.com/farcaller/dracones-blockchain, a H160-based substrate chain with EVM that's _not_ a moon* fork-off. It's primarily focused on the educational use, featuring a consensus alternative based on raft. It's known as chain 8387 on [the chainlist](https://chainlist.org/chain/8387).

No type changes for now, as the primary ones _are_ moon* compatible.