### PR TITLE
Debug and fix cron issue of RadiumBlock statemint endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -657,7 +657,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemint',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://statemint-rpc.polkadot.io'
-      // RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' // https://github.com/polkadot-js/apps/issues/9240
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
     },
     teleport: [-1],
     text: 'Statemint',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -656,7 +656,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'IBP-GeoDNS1': 'wss://sys.ibp.network/statemint',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemint',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
-      Parity: 'wss://statemint-rpc.polkadot.io'
+      Parity: 'wss://statemint-rpc.polkadot.io',
       RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
     },
     teleport: [-1],

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -657,7 +657,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemint',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://statemint-rpc.polkadot.io',
-      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' 
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws'
     },
     teleport: [-1],
     text: 'Statemint',


### PR DESCRIPTION
We have spent a significant amount of time trying to reproduce the issue in https://github.com/polkadot-js/apps/issues/9240
However we are not able to reproduce this issue. The endpoint loads on our end.
https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstatemint.public.curie.radiumblock.co%2Fws#/explorer
We have not detected any failures in our monitoring systems.
We run monitoring from various locations around the world and have not seen any failures.
Our monitoring includes standalone wss requests as well as automated polkadot-js page loads. 
We are attaching the monitoring report from we have for the endpoint.
![Screen Shot 2023-03-28 at 2 18 03 PM](https://user-images.githubusercontent.com/95440512/228344532-beeb49f5-bc29-4c60-9b47-88a7b0a98385.png)
![Screen Shot 2023-03-28 at 2 16 30 PM](https://user-images.githubusercontent.com/95440512/228344535-4c7e7244-4465-4d40-8425-25214e592c38.png)

We don't believe it's an issue with the setup or load given that statemint has a fraction of the load seen on kusama and polkadot and those endpoints of ours have been working without any downtime for the last year or so. 

We believe the large data packet nature of the test request being run(state_getMetadata is close to 1M as a single request) is triggering some DDOS filters for your test. 
Obviously we do take this issue seriously and in an abundance of caution we have doubled the resource allocation for statemint. 
We have also added your test to our monitoring system so we can tune and desensitize the DDOS filters. 

So please re-enable our endpoint.