### PR TITLE
Add stakeworld westend rpc node

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -197,6 +197,7 @@ export const testRelayWestend: EndpointOption = {
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/westend',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
+    Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'
   },
   teleport: getTeleports(testParasWestendCommon),


### PR DESCRIPTION
Hi Jaco,

I would like to add our westend rpc node to polkadot.js. I have an [earlier PR](https://github.com/polkadot-js/apps/pull/8227) for a kusama rpc node but I understand you prefer to start with a test net first so i'll close that for now and resubmit later if this one goes well.

Regards
Max | Stakeworld





 