### PR TITLE
Make disabled input fields selectable

### DIFF
--- a/packages/react-components/src/Input.tsx
+++ b/packages/react-components/src/Input.tsx
@@ -208,6 +208,7 @@ function Input ({ autoFocus = false, children, className, defaultValue, icon, in
           data-testid={label}
           onPaste={_onPaste}
           spellCheck={false}
+          style={{ pointerEvents: 'auto' }}
         />
         {isEditable && (
           <i className='edit icon' />


### PR DESCRIPTION
Closes #8212

This is particularly useful for any fields containing output values, for example when decoding an extrinsic. Currently it is impossible to select and copy and values in Firefox because all pointer events are disabled.