### PR TITLE
Adding Westend RadiumBlock Endpoint Accelerator

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -197,6 +197,7 @@ export const testRelayWestend: EndpointOption = {
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/westend',
     LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
+    RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws',
     Parity: 'wss://westend-rpc.polkadot.io',
     Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'


### PR DESCRIPTION
Deploying Westend RadiumBlock Endpoint Accelerator using our hybrid compute infrastructure 