### PR TITLE
Update Frequency to 1.5.2 with esm support

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -26,7 +26,7 @@
     "@edgeware/node-types": "3.6.2-wako",
     "@equilab/definitions": "1.4.18",
     "@fragnova/api-augment": "0.1.0-spec-1.0.4-mainnet",
-    "@frequency-chain/api-augment": "1.3.0",
+    "@frequency-chain/api-augment": "1.5.2",
     "@interlay/interbtc-types": "1.12.0",
     "@kiltprotocol/type-definitions": "0.32.0",
     "@laminar/type-definitions": "0.3.1",

--- a/packages/apps-config/src/api/spec/frequency.ts
+++ b/packages/apps-config/src/api/spec/frequency.ts
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Not used/included in index.ts as of https://github.com/polkadot-js/apps/pull/9243
-
 import type { OverrideBundleDefinition } from '@polkadot/types/types';
 
 import { rpc, runtime, signedExtensions, types } from '@frequency-chain/api-augment';

--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -47,8 +47,7 @@ import equilibrium from './equilibrium.js';
 import fantour from './fantour.js';
 // See https://github.com/polkadot-js/apps/pull/9243
 // import fragnova from './fragnova.js';
-// See https://github.com/polkadot-js/apps/pull/9243
-// import frequency from './frequency.js';
+import frequency from './frequency.js';
 import galital from './galital.js';
 import galitalParachain from './galital-parachain.js';
 import galois from './galois.js';
@@ -196,9 +195,8 @@ const spec: Record<string, OverrideBundleDefinition> = {
   // See https://github.com/polkadot-js/apps/pull/9243
   // fragnova,
   // 'fragnova-testnet': fragnova,
-  // See https://github.com/polkadot-js/apps/pull/9243
-  // frequency,
-  // 'frequency-rococo': frequency,
+  frequency,
+  'frequency-rococo': frequency,
   galital,
   'galital-collator': galitalParachain,
   gamepower,

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,14 +685,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@frequency-chain/api-augment@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@frequency-chain/api-augment@npm:1.3.0"
+"@frequency-chain/api-augment@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@frequency-chain/api-augment@npm:1.5.2"
   dependencies:
-    "@polkadot/api": ^9.14.2
-    "@polkadot/rpc-provider": ^9.14.2
-    "@polkadot/types": ^9.14.2
-  checksum: 99d684fda3eedd034da8021f52996860cf71396dd80658568bbcb6730011940353f68dceacacf7cc57ff2e6063b44a37c502de1da294afd763ddc75b84a8db38
+    "@polkadot/api": ^10.3.2
+    "@polkadot/rpc-provider": ^10.3.2
+    "@polkadot/types": ^10.3.2
+  checksum: 5e5c103236d90f5525ee187597ff3d1ff9fdc34548efe41292f7868ea0c06664a0a43bfd03c2b3f945b447c05545f9eb47c9cc76ee8587ceade9451f1adf8c85
   languageName: node
   linkType: hard
 
@@ -1691,7 +1691,7 @@ __metadata:
     "@edgeware/node-types": 3.6.2-wako
     "@equilab/definitions": 1.4.18
     "@fragnova/api-augment": 0.1.0-spec-1.0.4-mainnet
-    "@frequency-chain/api-augment": 1.3.0
+    "@frequency-chain/api-augment": 1.5.2
     "@interlay/interbtc-types": 1.12.0
     "@kiltprotocol/type-definitions": 0.32.0
     "@laminar/type-definitions": 0.3.1


### PR DESCRIPTION
Just finished updating the `@frequency-chain/api-augment` JS package to support esm in v1.5.2.

The build now passes and pulls in the correct augmented information for Frequency. (See example ss below)

Question: @jacogr, I don't think I need to update `packages/apps-config/src/api/typesBundle.ts`, but let me know if I do.

References:
- #9243 
- https://github.com/LibertyDSNP/frequency/issues/1116

Screenshot (showing that it loads in the custom RPCs): 
<img width="308" alt="image" src="https://user-images.githubusercontent.com/1252199/231481733-edbb7260-3d8b-4c5e-bc92-88aa5b9dfd05.png">
