### PR TITLE
Add BlockOps RPC node to Westend

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -191,6 +191,7 @@ export const testRelayWestend: EndpointOption = {
     ...testParasWestend
   ],
   providers: {
+    BlockOps: 'wss://westend-rpc.blockops.network/ws',
     Dwellir: 'wss://westend-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
     'IBP-GeoDNS1': 'wss://rpc.ibp.network/westend',


### PR DESCRIPTION
Hi Devs,

I would like to add our Westend rpc node to polkadot.js. This aligns with the earlier [guidance](https://github.com/polkadot-js/apps/pull/9239) that getting listed on a testnet is a necessary quality control measure prior to being listed on mainnets.

Regards,
Calvin | BlockOps
