### PR TITLE
change aleph testnet name to make it unique

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -40,7 +40,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
-    info: 'aleph',
+    info: 'aleph-testnet',
     providers: {
       'Aleph Zero Foundation': 'wss://ws.test.azero.dev',
       Dwellir: 'wss://aleph-zero-testnet-rpc.dwellir.com'


### PR DESCRIPTION
Change the aleph zero testnet name, to make it distinguishable from aleph zero mainnet. Needed for Sirato smart contract verifier.