### PR TITLE
new (Manta Network) load balanced provider url

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -119,7 +119,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     info: 'calamari',
     paraId: 2084,
     providers: {
-      // 'Manta Network': 'wss://ws.calamari.systems/' // https://github.com/polkadot-js/apps/issues/9331
+      'Manta Network': 'wss://calamari.systems'
     },
     text: 'Calamari',
     ui: {


### PR DESCRIPTION
following issues with Manta's lb, a new lb url for the calamari network has been provisioned.