### PR TITLE
Adding LuckyFriday to Polkadot WSS endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -712,6 +712,7 @@ export const prodRelayPolkadot: EndpointOption = {
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
     'IBP-GeoDNS1': 'wss://rpc.ibp.network/polkadot',
     'IBP-GeoDNS2': 'wss://rpc.dotters.network/polkadot',
+    LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
     Parity: 'wss://rpc.polkadot.io',
     RadiumBlock: 'wss://polkadot.public.curie.radiumblock.co/ws',


### PR DESCRIPTION
Dear Devs,

Following our successful implementation of endpoints on Westend, Statemine and Kusama, we are following up with an endpoint for Polkadot.  This endpoint has been in operation for a little over a week and has passed our internal load and up-time checks.

We hope this is satisfactory.

Kind Regards,
Will | Paradox