### PR TITLE
Fix default threshold in motion

### DIFF
--- a/packages/page-council/src/Motions/ProposeMotion.tsx
+++ b/packages/page-council/src/Motions/ProposeMotion.tsx
@@ -39,7 +39,7 @@ function Propose ({ isMember, members }: Props): React.ReactElement<Props> | nul
   useEffect((): void => {
     members && setThreshold({
       isThresholdValid: members.length !== 0,
-      threshold: new BN(Math.min(members.length, Math.ceil(members.length * getProposalThreshold(api))))
+      threshold: new BN(Math.min(members.length, Math.floor(members.length * getProposalThreshold(api)) + 1))
     });
   }, [api, members]);
 


### PR DESCRIPTION
From the description, the default motion threshold should be "50%+1". However the old implementation was `ceil(50% council)`. When the council has an even member size, it produces 50% council, but not 50%+1. This commit fixes it.