### PR TITLE
Restore nodle testnet link

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -341,7 +341,7 @@ export const testParasRococo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'rococoNodle',
     paraId: 2026,
     providers: {
-      // OnFinality: 'wss://nodle-paradis.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/9415
+      OnFinality: 'wss://nodle-paradis.api.onfinality.io/public-ws'
     },
     text: 'Nodle',
     ui: {


### PR DESCRIPTION
A few weeks ago nodle testnet experienced an outage related to an expired parachain lease on Rococo. 

The lease has been restored and the endpoint is operational again now. 

Link was removed in PR #9416 and automatic ticket #9415 