### PR TITLE
Add disputes overview

### DIFF
--- a/packages/page-parachains/src/Disputes/index.tsx
+++ b/packages/page-parachains/src/Disputes/index.tsx
@@ -1,0 +1,49 @@
+// Copyright 2017-2023 @polkadot/app-parachains authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useRef } from 'react';
+
+import { AddressMini, Table } from '@polkadot/react-components';
+
+import { useTranslation } from '../translate.js';
+import useSessionDisputes from './useSessionDisputes.js';
+
+interface Props {
+  className?: string;
+}
+
+function Disputes ({ className }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const disputeInfo = useSessionDisputes();
+
+  const headerRef = useRef<[React.ReactNode?, string?, number?][]>([
+    [t<string>('disputes'), 'start', 2]
+  ]);
+
+  return (
+    <Table
+      className={className}
+      empty={disputeInfo?.disputes && t<string>('No ongoing disputes found')}
+      header={headerRef.current}
+    >
+      {disputeInfo?.disputes && Object
+        .entries(disputeInfo?.disputes)
+        .map(([d, v]) => (
+          <tr key={d}>
+            <td>{d}</td>
+            <td className='all'>
+              {v.map((v) => (
+                <AddressMini
+                  key={v}
+                  value={v}
+                />
+              ))}
+            </td>
+          </tr>
+        ))
+      }
+    </Table>
+  );
+}
+
+export default React.memo(Disputes);

--- a/packages/page-parachains/src/Disputes/types.ts
+++ b/packages/page-parachains/src/Disputes/types.ts
@@ -1,0 +1,15 @@
+// Copyright 2017-2023 @polkadot/app-parachains authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { u32 } from '@polkadot/types';
+
+export interface SessionInfo {
+  paraValidators: string[];
+  sessionIndex: u32;
+  sessionValidators: string[];
+}
+
+export interface DisputeInfo {
+  disputes?: Record<string, string[]>;
+  sessionInfo: SessionInfo;
+}

--- a/packages/page-parachains/src/Disputes/useSessionDisputes.ts
+++ b/packages/page-parachains/src/Disputes/useSessionDisputes.ts
@@ -1,0 +1,60 @@
+// Copyright 2017-2023 @polkadot/app-parachains authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Option, StorageKey } from '@polkadot/types';
+import type { PolkadotPrimitivesV4DisputeState } from '@polkadot/types/lookup';
+import type { Codec } from '@polkadot/types/types';
+import type { HexString } from '@polkadot/util/types';
+import type { DisputeInfo, SessionInfo } from './types.js';
+
+import { useMemo } from 'react';
+
+import { createNamedHook, useApi, useMapEntries } from '@polkadot/react-hooks';
+
+import useSessionInfo from './useSessionInfo.js';
+
+const OPT_ENTRIES = {
+  transform: (entries: [StorageKey<[Codec, Codec]>, Option<PolkadotPrimitivesV4DisputeState>][]): [HexString, boolean[]][] =>
+    entries
+      .map(([{ args: [, id] }, optInfo]): [HexString, PolkadotPrimitivesV4DisputeState | null] => [id.toHex(), optInfo.unwrapOr(null)])
+      .filter((d): d is [HexString, PolkadotPrimitivesV4DisputeState] => !!d[1])
+      .map(([k, d]) => [k, d.validatorsAgainst.toBoolArray()])
+};
+
+function extractDisputes (sessionInfo?: SessionInfo, disputes?: [HexString, boolean[]][]): DisputeInfo | undefined {
+  if (!sessionInfo) {
+    return undefined;
+  } else if (!disputes) {
+    return { sessionInfo };
+  }
+
+  console.log(disputes);
+
+  return {
+    disputes: disputes.reduce<Record<HexString, string[]>>((all, [k, v]) => {
+      all[k] = v
+        .map((f, index) =>
+          f
+            ? sessionInfo.paraValidators[index]
+            : null
+        )
+        .filter((v): v is string => !!v);
+
+      return all;
+    }, {}),
+    sessionInfo
+  };
+}
+
+function useSessionDisputesImpl (): DisputeInfo | undefined {
+  const { api } = useApi();
+  const session = useSessionInfo();
+  const disputedBv = useMapEntries(session && api.query.parasDisputes?.disputes, [session?.sessionIndex], OPT_ENTRIES);
+
+  return useMemo(
+    () => extractDisputes(session, disputedBv),
+    [disputedBv, session]
+  );
+}
+
+export default createNamedHook('useSessionDisputes', useSessionDisputesImpl);

--- a/packages/page-parachains/src/Disputes/useSessionInfo.ts
+++ b/packages/page-parachains/src/Disputes/useSessionInfo.ts
@@ -1,0 +1,32 @@
+// Copyright 2017-2023 @polkadot/app-parachains authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { u32 } from '@polkadot/types';
+import type { AccountId } from '@polkadot/types/interfaces';
+import type { SessionInfo } from './types.js';
+
+import { createNamedHook, useApi, useCallMulti } from '@polkadot/react-hooks';
+
+const OPT_MULTI = {
+  transform: ([sessionIndex, validators, activeValidatorIndices]: [u32, AccountId[], u32[]]): SessionInfo => {
+    const sessionValidators = validators.map((v) => v.toString());
+
+    return {
+      paraValidators: activeValidatorIndices.map((i) => sessionValidators[i.toNumber()]),
+      sessionIndex,
+      sessionValidators
+    };
+  }
+};
+
+function useSessionInfoImpl (): SessionInfo | undefined {
+  const { api } = useApi();
+
+  return useCallMulti<SessionInfo>([
+    api.query.session?.currentIndex,
+    api.query.session?.validators,
+    api.query.parasShared?.activeValidatorIndices
+  ], OPT_MULTI);
+}
+
+export default createNamedHook('useSessionInfo', useSessionInfoImpl);

--- a/packages/page-parachains/src/index.tsx
+++ b/packages/page-parachains/src/index.tsx
@@ -14,6 +14,7 @@ import { useApi, useCall } from '@polkadot/react-hooks';
 
 import Auctions from './Auctions/index.js';
 import Crowdloan from './Crowdloan/index.js';
+import Disputes from './Disputes/index.js';
 import Overview from './Overview/index.js';
 import Parathreads from './Parathreads/index.js';
 import Proposals from './Proposals/index.js';
@@ -99,6 +100,12 @@ function ParachainsApp ({ basePath, className }: Props): React.ReactElement<Prop
               />
             }
             path='crowdloan'
+          />
+          <Route
+            element={
+              <Disputes />
+            }
+            path='disputes'
           />
           <Route
             element={


### PR DESCRIPTION
Not linked by default (yet), accessible via `#/parachains/disputes`