### PR TITLE
Addressing issue 9480

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -660,8 +660,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       'IBP-GeoDNS1': 'wss://sys.ibp.network/statemint',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/statemint',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
-      Parity: 'wss://statemint-rpc.polkadot.io'
-      // RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws' // https://github.com/polkadot-js/apps/issues/9480
+      Parity: 'wss://statemint-rpc.polkadot.io',
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws'
     },
     teleport: [-1],
     text: 'Statemint',


### PR DESCRIPTION
Addressing https://github.com/polkadot-js/apps/issues/9480

We had switched to using the relay chain as external RPC rather than running a relay chain RPC along with asset chains - to take advantage of a feature in cumulus binary. We are having mixed success with this. Its particularly worse since the relay chain block constantly lags beyond what is usually considered acceptable (>10 blocks) ever since v0.39. We struggle with > v0.39 for validators too. We are seriously considering downgrading back to v0.39 rather than following the convention of using the latest binary.  What makes this hard is that the timeouts due block delays are infrequent and only a service restart seems to fix it. We will revert the external RPC to make sure that choice is not amplifying the issue. We request our statemint RPC to be added back. 

Meanwhile any advice on the matter of binary version is much appreciated.