### PR TITLE
Update testingRelayWestend.ts

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -186,7 +186,7 @@ export const testRelayWestend: EndpointOption = {
     LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
-    // RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', #Disabling until we can fully rebuild the deployment to address stability issues. 
+    // RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', #Disabling until we can fully rebuild the deployment to address stability issues.
     Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'
   },


### PR DESCRIPTION
#Disabling our westend endpoint until we can fully rebuild the deployment to deep dive and root cause stability issues.