### PR TITLE
refactor: better `useCall` hook type inference

### DIFF
--- a/packages/apps/src/Content/Status.tsx
+++ b/packages/apps/src/Content/Status.tsx
@@ -66,7 +66,7 @@ function Status ({ optionsAll }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
   const { allAccounts } = useAccounts();
   const { t } = useTranslation();
-  const events = useCall<EventRecord[]>(isApiReady && api.query.system?.events);
+  const events = useCall(isApiReady && api.query.system?.events);
 
   useEffect((): void => {
     const filtered = filterEvents(allAccounts, t, optionsAll, events);

--- a/packages/apps/src/Menu/ChainInfo.tsx
+++ b/packages/apps/src/Menu/ChainInfo.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/apps authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { RuntimeVersion } from '@polkadot/types/interfaces';
-
 import React from 'react';
 
 import { ChainImg, Icon, styled } from '@polkadot/react-components';
@@ -17,7 +15,7 @@ interface Props {
 
 function ChainInfo ({ className }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
-  const runtimeVersion = useCall<RuntimeVersion>(isApiReady && api.rpc.state.subscribeRuntimeVersion);
+  const runtimeVersion = useCall(isApiReady && api.rpc.state.subscribeRuntimeVersion);
   const { ipnsChain } = useIpfs();
   const [isEndpointsVisible, toggleEndpoints] = useToggle();
   const canToggle = !ipnsChain;

--- a/packages/apps/src/Menu/index.tsx
+++ b/packages/apps/src/Menu/index.tsx
@@ -4,7 +4,6 @@
 import type { TFunction } from 'i18next';
 import type { Route, Routes } from '@polkadot/apps-routing/types';
 import type { ApiProps } from '@polkadot/react-api/types';
-import type { AccountId } from '@polkadot/types/interfaces';
 import type { Group, Groups, ItemRoute } from './types.js';
 
 import React, { useMemo, useRef } from 'react';
@@ -92,7 +91,7 @@ function Menu ({ className = '' }: Props): React.ReactElement<Props> {
   const { allAccounts, hasAccounts } = useAccounts();
   const apiProps = useApi();
   const { allowTeleport } = useTeleport();
-  const sudoKey = useCall<AccountId>(apiProps.isApiReady && apiProps.api.query.sudo?.key);
+  const sudoKey = useCall(apiProps.isApiReady && apiProps.api.query.sudo?.key);
   const location = useLocation();
 
   const externalRef = useRef(createExternals(t));

--- a/packages/apps/src/WarmUp.tsx
+++ b/packages/apps/src/WarmUp.tsx
@@ -7,9 +7,9 @@ import { useApi, useCall } from '@polkadot/react-hooks';
 
 function WarmUp (): React.ReactElement {
   const { api, isApiReady } = useApi();
-  const indexes = useCall<unknown>(isApiReady && api.derive.accounts?.indexes);
-  const registrars = useCall<unknown>(isApiReady && api.query.identity?.registrars);
-  const issuance = useCall<unknown>(isApiReady && api.query.balances?.totalIssuance);
+  const indexes = useCall(isApiReady && api.derive.accounts?.indexes);
+  const registrars = useCall(isApiReady && api.query.identity?.registrars);
+  const issuance = useCall(isApiReady && api.query.balances?.totalIssuance);
   const [hasValues, setHasValues] = useState(false);
 
   useEffect((): void => {

--- a/packages/page-accounts/src/Accounts/Account.tsx
+++ b/packages/page-accounts/src/Accounts/Account.tsx
@@ -3,7 +3,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
-import type { DeriveDemocracyLock, DeriveStakingAccount } from '@polkadot/api-derive/types';
+import type { DeriveStakingAccount } from '@polkadot/api-derive/types';
 import type { Ledger } from '@polkadot/hw-ledger';
 import type { ActionStatus } from '@polkadot/react-components/Status/types';
 import type { Option } from '@polkadot/types';
@@ -155,8 +155,8 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
   const bestNumber = useBestNumber();
   const balancesAll = useBalancesAll(address);
   const stakingInfo = useStakingInfo(address);
-  const democracyLocks = useCall<DeriveDemocracyLock[]>(api.api.derive.democracy?.locks, [address]);
-  const recoveryInfo = useCall<RecoveryConfig | null>(api.api.query.recovery?.recoverable, [address], transformRecovery);
+  const democracyLocks = useCall(api.api.derive.democracy?.locks, [address]);
+  const recoveryInfo = useCall(api.api.query.recovery?.recoverable, [address], transformRecovery);
   const multiInfos = useMultisigApprovals(address);
   const proxyInfo = useProxies(address);
   const { flags: { isDevelopment, isEditable, isEthereum, isExternal, isHardware, isInjected, isMultisig, isProxied }, genesisHash, identity, name: accName, onSetGenesisHash, tags } = useAccountInfo(address);

--- a/packages/page-accounts/src/modals/IdentityMain.tsx
+++ b/packages/page-accounts/src/modals/IdentityMain.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ApiPromise } from '@polkadot/api';
-import type { Data, Option } from '@polkadot/types';
-import type { IdentityInfo, Registration } from '@polkadot/types/interfaces';
+import type { Data } from '@polkadot/types';
+import type { IdentityInfo } from '@polkadot/types/interfaces';
 
 import React, { useEffect, useState } from 'react';
 
@@ -70,7 +70,7 @@ function checkValue (hasValue: boolean, value: string | null | undefined, minLen
 function IdentityMain ({ address, className = '', onClose }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const identityOpt = useCall<Option<Registration>>(api.query.identity.identityOf, [address]);
+  const identityOpt = useCall(api.query.identity.identityOf, [address]);
   const [{ info, okAll, okDiscord, okDisplay, okEmail, okLegal, okRiot, okTwitter, okWeb }, setInfo] = useState<ValueState>({ info: {}, okAll: false });
   const [hasEmail, setHasEmail] = useState(false);
   const [hasLegal, setHasLegal] = useState(false);

--- a/packages/page-accounts/src/modals/IdentitySub.tsx
+++ b/packages/page-accounts/src/modals/IdentitySub.tsx
@@ -87,7 +87,7 @@ function IdentitySubModal ({ address, className, onClose }: Props): React.ReactE
   const { api } = useApi();
   const { allAccounts } = useAccounts();
   const queryIds = useSubidentities(address);
-  const queryInfos = useCall<[[string[]], Option<ITuple<[AccountId, Data]>>[]]>(queryIds && queryIds.length !== 0 && api.query.identity.superOf.multi, [queryIds], transformInfo);
+  const queryInfos: [[string[]], Option<ITuple<[AccountId, Data]>>[]] = useCall(queryIds && queryIds.length !== 0 && api.query.identity.superOf.multi, [queryIds], transformInfo);
   const [infos, setInfos] = useState<[string, string][] | undefined>();
 
   useEffect((): void => {

--- a/packages/page-accounts/src/modals/InputValidateAmount.tsx
+++ b/packages/page-accounts/src/modals/InputValidateAmount.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 import type { AmountValidateState } from '../Accounts/types.js';
 
@@ -22,7 +21,7 @@ interface Props {
 function ValidateAmount ({ amount, delegatingAccount, onError }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const delegatingAccountBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [delegatingAccount]);
+  const delegatingAccountBalance = useCall(api.derive.balances?.all, [delegatingAccount]);
   const [{ error, warning }, setResult] = useState<AmountValidateState>({ error: null, warning: null });
 
   useEffect((): void => {

--- a/packages/page-addresses/src/modals/Create.tsx
+++ b/packages/page-addresses/src/modals/Create.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-addresses authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveAccountInfo } from '@polkadot/api-derive/types';
 import type { ActionStatus } from '@polkadot/react-components/Status/types';
 import type { ModalProps as Props } from '../types.js';
 
@@ -33,7 +32,7 @@ function Create ({ onClose, onStatusChange }: Props): React.ReactElement<Props> 
   const { api, isEthereum } = useApi();
   const [{ isNameValid, name }, setName] = useState<NameState>({ isNameValid: false, name: '' });
   const [{ address, addressInput, isAddressExisting, isAddressValid }, setAddress] = useState<AddrState>({ address: '', addressInput: '', isAddressExisting: false, isAddressValid: false, isPublicKey: false });
-  const info = useCall<DeriveAccountInfo>(!!address && isAddressValid && api.derive.accounts.info, [address]);
+  const info = useCall(!!address && isAddressValid && api.derive.accounts.info, [address]);
   const isValid = (isAddressValid && isNameValid) && !!info?.accountId;
 
   const _onChangeAddress = useCallback(

--- a/packages/page-alliance/src/index.tsx
+++ b/packages/page-alliance/src/index.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-alliance authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Hash } from '@polkadot/types/interfaces';
-
 import React, { useCallback, useMemo } from 'react';
 import { Route, Routes } from 'react-router';
 
@@ -32,7 +30,7 @@ const DEFAULT_THRESHOLD = 2 / 3;
 function AllianceApp ({ basePath, className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const proposalHashes = useCall<Hash[]>(api.derive.alliance.proposalHashes);
+  const proposalHashes = useCall(api.derive.alliance.proposalHashes);
   const { isMember: isVoter, members: voters, prime } = useCollectiveMembers('alliance');
   const accouncements = useAnnoucements();
   const members = useMembers();

--- a/packages/page-alliance/src/useAnnoucements.ts
+++ b/packages/page-alliance/src/useAnnoucements.ts
@@ -16,7 +16,7 @@ const OPT_ANN = {
 function useAnnouncementsImpl (): Cid[] | undefined {
   const { api } = useApi();
 
-  return useCall<Cid[]>(api.query.alliance.announcements, [], OPT_ANN);
+  return useCall(api.query.alliance.announcements, [], OPT_ANN);
 }
 
 export default createNamedHook('useAnnouncements', useAnnouncementsImpl);

--- a/packages/page-alliance/src/useCounter.ts
+++ b/packages/page-alliance/src/useCounter.ts
@@ -7,7 +7,7 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useCounterImpl (): number {
   const { api, isApiReady } = useApi();
-  const proposalHashes = useCall<unknown[]>(isApiReady && api.derive.alliance.proposalHashes);
+  const proposalHashes = useCall(isApiReady && api.derive.alliance.proposalHashes);
 
   return useMemo(
     () => (proposalHashes && proposalHashes.length) || 0,

--- a/packages/page-alliance/src/useMemberInfo.ts
+++ b/packages/page-alliance/src/useMemberInfo.ts
@@ -10,9 +10,9 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useMemberInfoImpl (accountId: string): MemberInfo | undefined {
   const { api } = useApi();
-  const upForKicking = useCall<bool>(api.query.alliance.upForKicking, [accountId]);
-  const retiringAt = useCall<Option<UInt>>(api.query.alliance.retiringMembers, [accountId]);
-  const depositOf = useCall<Option<UInt>>(api.query.alliance.depositOf, [accountId]);
+  const upForKicking: bool = useCall(api.query.alliance.upForKicking, [accountId]);
+  const retiringAt: Option<UInt> = useCall(api.query.alliance.retiringMembers, [accountId]);
+  const depositOf: Option<UInt> = useCall(api.query.alliance.depositOf, [accountId]);
 
   return useMemo(
     () => depositOf && {

--- a/packages/page-alliance/src/useMembers.ts
+++ b/packages/page-alliance/src/useMembers.ts
@@ -37,9 +37,9 @@ function addMembers (prev: Member[], ...query: AccountId32[][]): Member[] {
 function useMembersImpl (): Member[] | undefined {
   const { api } = useApi();
   const [state, setState] = useState<Member[] | undefined>();
-  const role0 = useCall<AccountId32[]>(api.query.alliance.members, [ROLES[0]]);
-  const role1 = useCall<AccountId32[]>(api.query.alliance.members, [ROLES[1]]);
-  const role2 = useCall<AccountId32[]>(api.query.alliance.members, [ROLES[2]]);
+  const role0 = useCall(api.query.alliance.members, [ROLES[0]]);
+  const role1 = useCall(api.query.alliance.members, [ROLES[1]]);
+  const role2 = useCall(api.query.alliance.members, [ROLES[2]]);
 
   useEffect((): void => {
     role0 && role1 && role2 &&

--- a/packages/page-alliance/src/useRule.ts
+++ b/packages/page-alliance/src/useRule.ts
@@ -19,7 +19,7 @@ const OPT_RULE = {
 function useRuleImpl (): Rule | undefined {
   const { api } = useApi();
 
-  return useCall<Rule>(api.query.alliance.rule, [], OPT_RULE);
+  return useCall(api.query.alliance.rule, [], OPT_RULE);
 }
 
 export default createNamedHook('useRule', useRuleImpl);

--- a/packages/page-alliance/src/useUnscrupulous.ts
+++ b/packages/page-alliance/src/useUnscrupulous.ts
@@ -25,8 +25,8 @@ const OPT_WEB = {
 
 function useUnscrupulousImpl (): Unscrupulous | undefined {
   const { api } = useApi();
-  const accounts = useCall<string[]>(api.query.alliance.unscrupulousAccounts, [], OPT_ACC);
-  const websites = useCall<string[]>(api.query.alliance.unscrupulousWebsites, [], OPT_WEB);
+  const accounts = useCall(api.query.alliance.unscrupulousAccounts, [], OPT_ACC);
+  const websites = useCall(api.query.alliance.unscrupulousWebsites, [], OPT_WEB);
 
   return useMemo(
     () => accounts && websites && { accounts, websites },

--- a/packages/page-assets/src/useAssetInfos.ts
+++ b/packages/page-assets/src/useAssetInfos.ts
@@ -51,8 +51,8 @@ function extractInfo (allAccounts: string[], id: BN, optDetails: Option<PalletAs
 function useAssetInfosImpl (ids?: BN[]): AssetInfo[] | undefined {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
-  const metadata = useCall<[[BN[]], PalletAssetsAssetMetadata[]]>(api.query.assets.metadata.multi, [ids], QUERY_OPTS);
-  const details = useCall<[[BN[]], Option<PalletAssetsAssetDetails>[]]>(api.query.assets.asset.multi, [ids], QUERY_OPTS);
+  const metadata: [[BN[]], PalletAssetsAssetMetadata[]] = useCall(api.query.assets.metadata.multi, [ids], QUERY_OPTS);
+  const details: [[BN[]], Option<PalletAssetsAssetDetails>[]] = useCall(api.query.assets.asset.multi, [ids], QUERY_OPTS);
   const [state, setState] = useState<AssetInfo[] | undefined>();
 
   useEffect((): void => {

--- a/packages/page-bounties/src/hooks/useBalance.ts
+++ b/packages/page-bounties/src/hooks/useBalance.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-bounties authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
@@ -9,7 +8,7 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 function useBalanceImpl (accountId: string | null): Balance | undefined {
   const { api } = useApi();
 
-  return useCall<DeriveBalancesAll>(api.derive.balances?.all, [accountId])?.availableBalance;
+  return useCall(api.derive.balances?.all, [accountId])?.availableBalance;
 }
 
 export const useBalance = createNamedHook('useBalance', useBalanceImpl);

--- a/packages/page-bounties/src/hooks/useBounties.tsx
+++ b/packages/page-bounties/src/hooks/useBounties.tsx
@@ -73,9 +73,9 @@ function getStatics (api: ApiPromise): BountyApiStatics {
 
 function useBountiesImpl (): BountyApi {
   const { api } = useApi();
-  const bounties = useCall<DeriveBounties>(api.derive.bounties.bounties);
-  const bountyCount = useCall<BN>((api.query.bounties || api.query.treasury).bountyCount);
-  const childCount = useCall<BN>(api.query.childBounties?.childBountyCount);
+  const bounties = useCall(api.derive.bounties.bounties);
+  const bountyCount = useCall((api.query.bounties || api.query.treasury).bountyCount);
+  const childCount = useCall(api.query.childBounties?.childBountyCount);
   const bestNumber = useBestNumber();
 
   const statics = useMemo(

--- a/packages/page-bounties/src/useCounter.ts
+++ b/packages/page-bounties/src/useCounter.ts
@@ -1,15 +1,13 @@
 // Copyright 2017-2023 @polkadot/app-bounties authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBounties } from '@polkadot/api-derive/types';
-
 import { useMemo } from 'react';
 
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useCounterImpl (): number {
   const { api, isApiReady } = useApi();
-  const bounties = useCall<DeriveBounties>(isApiReady && api.derive.bounties?.bounties);
+  const bounties = useCall(isApiReady && api.derive.bounties?.bounties);
 
   return useMemo(
     () => bounties?.length || 0,

--- a/packages/page-calendar/src/useScheduled.ts
+++ b/packages/page-calendar/src/useScheduled.ts
@@ -202,13 +202,13 @@ function useScheduledImpl (): EntryInfoTyped[] {
   const blockTime = useBlockInterval();
   const bestNumber = useBestNumber();
   const leaseRangeMax = useLeaseRangeMax();
-  const auctionInfo = useCall<Option<ITuple<[LeasePeriodOf, BlockNumber]>>>(api.query.auctions?.auctionInfo);
-  const councilMotions = useCall<DeriveCollectiveProposal[]>(api.derive.council?.proposals);
-  const dispatches = useCall<DeriveDispatch[]>(api.derive.democracy?.dispatchQueue);
-  const referendums = useCall<DeriveReferendumExt[]>(api.derive.democracy?.referendums);
-  const scheduled = useCall<ScheduleEntry[]>(api.query.scheduler?.agenda?.entries);
-  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session?.progress);
-  const slashes = useCall<SlashEntry[]>(api.query.staking?.unappliedSlashes.entries);
+  const auctionInfo: Option<ITuple<[LeasePeriodOf, BlockNumber]>> = useCall(api.query.auctions?.auctionInfo);
+  const councilMotions: DeriveCollectiveProposal[] = useCall(api.derive.council?.proposals);
+  const dispatches: DeriveDispatch[] = useCall(api.derive.democracy?.dispatchQueue);
+  const referendums: DeriveReferendumExt[] = useCall(api.derive.democracy?.referendums);
+  const scheduled: ScheduleEntry[] = useCall(api.query.scheduler?.agenda?.entries);
+  const sessionInfo: DeriveSessionProgress = useCall(api.derive.session?.progress);
+  const slashes: SlashEntry[] = useCall(api.query.staking?.unappliedSlashes.entries);
   const [state, setState] = useState<EntryInfoTyped[]>([]);
 
   useEffect((): void => {

--- a/packages/page-claims/src/index.tsx
+++ b/packages/page-claims/src/index.tsx
@@ -178,7 +178,7 @@ function ClaimsApp ({ basePath }: Props): React.ReactElement<Props> {
 
   // If it's 1/ not preclaimed and 2/ not the old claiming process, fetch the
   // statement kind to sign.
-  const statementKind = useCall<StatementKind | null>(!isPreclaimed && !isOldClaimProcess && !!ethereumAddress && api.query.claims.signing, [ethereumAddress], transformStatement);
+  const statementKind: StatementKind | null = useCall(!isPreclaimed && !isOldClaimProcess && !!ethereumAddress && api.query.claims.signing, [ethereumAddress], transformStatement);
 
   const statementSentence = getStatement(systemChain, statementKind)?.sentence || '';
   const prefix = u8aToString(api.consts.claims.prefix.toU8a(true));

--- a/packages/page-claims/src/usePolkadotPreclaims.ts
+++ b/packages/page-claims/src/usePolkadotPreclaims.ts
@@ -17,7 +17,7 @@ function usePolkadotPreclaimsImpl (): string[] {
   const [needsAttest, setNeedsAttest] = useState<string[]>([]);
 
   // find all own preclaims
-  const preclaims = useCall<[string, EthereumAddress][]>(api.query.claims?.preclaims?.multi, [allAccounts], {
+  const preclaims: [string, EthereumAddress][] = useCall(api.query.claims?.preclaims?.multi, [allAccounts], {
     transform: (preclaims: Option<EthereumAddress>[]) =>
       preclaims
         .map((opt, index): [string, Option<EthereumAddress>] => [allAccounts[index], opt])

--- a/packages/page-collator/src/Summary.tsx
+++ b/packages/page-collator/src/Summary.tsx
@@ -18,7 +18,7 @@ interface Props {
 function Summary ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const desiredCandidates = useCall<BN>(api.query.collatorSelection.desiredCandidates);
+  const desiredCandidates: BN = useCall(api.query.collatorSelection.desiredCandidates);
 
   return (
     <SummaryBox className={className}>

--- a/packages/page-collator/src/useCollators.ts
+++ b/packages/page-collator/src/useCollators.ts
@@ -74,9 +74,9 @@ function useCollatorImpl (): Collator[] | undefined {
     [state]
   );
 
-  const invulnerables = useCall<Collator[]>(api.query.collatorSelection.invulnerables, [], OPT_INV);
-  const candidates = useCall<Collator[]>(api.query.collatorSelection.candidates, [], OPT_CAN);
-  const lastBlocks = useCall<Authored>(accountIds && api.query.collatorSelection.lastAuthoredBlock?.multi, [accountIds], OPT_AUT);
+  const invulnerables = useCall(api.query.collatorSelection.invulnerables, [], OPT_INV);
+  const candidates = useCall(api.query.collatorSelection.candidates, [], OPT_CAN);
+  const lastBlocks = useCall(accountIds && api.query.collatorSelection.lastAuthoredBlock?.multi, [accountIds], OPT_AUT);
 
   useEffect(
     () => invulnerables && candidates && setState(() =>

--- a/packages/page-contracts/src/Codes/Code.tsx
+++ b/packages/page-contracts/src/Codes/Code.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
-import type { Codec } from '@polkadot/types/types';
 import type { CodeStored } from '../types.js';
 
 import React, { useCallback } from 'react';
@@ -24,7 +22,7 @@ interface Props {
 function Code ({ className, code, onShowDeploy }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const optCode = useCall<Option<Codec>>(api.query.contracts.codeStorage, [code.json.codeHash]);
+  const optCode = useCall(api.query.contracts.codeStorage, [code.json.codeHash]);
   const [isForgetOpen, toggleIsForgetOpen] = useToggle();
   const { contractAbi } = useAbi([code.json.abi, code.contractAbi], code.json.codeHash, true);
 

--- a/packages/page-contracts/src/Codes/ValidateCode.tsx
+++ b/packages/page-contracts/src/Codes/ValidateCode.tsx
@@ -3,9 +3,6 @@
 
 /* eslint-disable camelcase */
 
-import type { Option } from '@polkadot/types';
-import type { PrefabWasmModule } from '@polkadot/types/interfaces';
-
 import React, { useMemo } from 'react';
 
 import { InfoForInput } from '@polkadot/react-components';
@@ -22,7 +19,7 @@ interface Props {
 function ValidateCode ({ codeHash, onChange }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { t } = useTranslation();
-  const codeStorage = useCall<Option<PrefabWasmModule>>((api.query.contracts || api.query.contract).codeStorage, [codeHash]);
+  const codeStorage = useCall((api.query.contracts || api.query.contract).codeStorage, [codeHash]);
   const [isValidHex, isValid] = useMemo(
     (): [boolean, boolean] => {
       const isValidHex = !!codeHash && isHex(codeHash) && codeHash.length === 66;

--- a/packages/page-contracts/src/Contracts/Contract.tsx
+++ b/packages/page-contracts/src/Contracts/Contract.tsx
@@ -33,7 +33,7 @@ function transformInfo (optInfo: Option<ContractInfo>): ContractInfo | null {
 function Contract ({ className, contract, index, links, onCall }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const info = useCall<ContractInfo | null>(api.query.contracts.contractInfoOf, [contract.address], { transform: transformInfo });
+  const info = useCall(api.query.contracts.contractInfoOf, [contract.address], { transform: transformInfo });
   const [isForgetOpen, toggleIsForgetOpen] = useToggle();
 
   const _onCall = useCallback(

--- a/packages/page-contracts/src/Contracts/ContractsTable.tsx
+++ b/packages/page-contracts/src/Contracts/ContractsTable.tsx
@@ -4,7 +4,6 @@
 import type { ApiPromise } from '@polkadot/api';
 import type { ContractPromise } from '@polkadot/api-contract';
 import type { ContractCallOutcome } from '@polkadot/api-contract/types';
-import type { SignedBlockExtended } from '@polkadot/api-derive/types';
 import type { ContractLink } from './types.js';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -38,7 +37,7 @@ function filterContracts (api: ApiPromise, keyringContracts: string[] = []): Con
 function ContractsTable ({ contracts: keyringContracts }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const newBlock = useCall<SignedBlockExtended>(api.derive.chain.subscribeNewBlocks);
+  const newBlock = useCall(api.derive.chain.subscribeNewBlocks);
   const [{ contractIndex, messageIndex, onCallResult }, setIndexes] = useState<Indexes>({ contractIndex: 0, messageIndex: 0 });
   const [isCallOpen, setIsCallOpen] = useState(false);
   const [contractLinks, setContractLinks] = useState<Record<string, ContractLink[]>>({});

--- a/packages/page-contracts/src/Contracts/Summary.tsx
+++ b/packages/page-contracts/src/Contracts/Summary.tsx
@@ -18,7 +18,7 @@ interface Props {
 function Summary ({ trigger }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const accountCounter = useCall<BN>(api.query.contracts.accountCounter);
+  const accountCounter: BN = useCall(api.query.contracts.accountCounter);
   const [numContracts, setNumContracts] = useState(0);
   const [numHashes, setNumHashes] = useState(0);
 

--- a/packages/page-contracts/src/Contracts/ValidateAddr.tsx
+++ b/packages/page-contracts/src/Contracts/ValidateAddr.tsx
@@ -1,9 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-contracts authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
-import type { ContractInfo } from '@polkadot/types/interfaces';
-
 import React, { useEffect, useState } from 'react';
 
 import { InfoForInput } from '@polkadot/react-components';
@@ -20,7 +17,7 @@ interface Props {
 function ValidateAddr ({ address, onChange }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const contractInfo = useCall<Option<ContractInfo>>(api.query.contracts.contractInfoOf, [address]);
+  const contractInfo = useCall(api.query.contracts.contractInfoOf, [address]);
   const [isAddress, setIsAddress] = useState(false);
   const [isStored, setIsStored] = useState(false);
 

--- a/packages/page-contracts/src/shared/Messages.tsx
+++ b/packages/page-contracts/src/shared/Messages.tsx
@@ -3,8 +3,6 @@
 
 import type { Abi, ContractPromise } from '@polkadot/api-contract';
 import type { AbiMessage, ContractCallOutcome } from '@polkadot/api-contract/types';
-import type { Option } from '@polkadot/types';
-import type { ContractInfo } from '@polkadot/types/interfaces';
 
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -46,7 +44,7 @@ function sortMessages (messages: AbiMessage[]): [AbiMessage, number][] {
 function Messages ({ className = '', contract, contractAbi: { constructors, info: { source }, messages }, isLabelled, isWatching, onSelect, onSelectConstructor, trigger, withConstructors, withMessages, withWasm }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const optInfo = useCall<Option<ContractInfo>>(contract && api.query.contracts.contractInfoOf, [contract?.address]);
+  const optInfo = useCall(contract && api.query.contracts.contractInfoOf, [contract?.address]);
   const [isUpdating, setIsUpdating] = useState(false);
   const [lastResults, setLastResults] = useState<(ContractCallOutcome | undefined)[]>([]);
 

--- a/packages/page-council/src/Overview/index.tsx
+++ b/packages/page-council/src/Overview/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-council authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveCouncilVotes, DeriveElectionsInfo } from '@polkadot/api-derive/types';
+import type { DeriveCouncilVotes } from '@polkadot/api-derive/types';
 import type { AccountId } from '@polkadot/types/interfaces';
 
 import React from 'react';
@@ -41,8 +41,8 @@ const transformVotes = {
 function Overview ({ className = '', prime }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const bestNumber = useBestNumber();
-  const electionsInfo = useCall<DeriveElectionsInfo>(api.derive.elections.info);
-  const allVotes = useCall<Record<string, AccountId[]>>(api.derive.council.votes, undefined, transformVotes);
+  const electionsInfo = useCall(api.derive.elections.info);
+  const allVotes = useCall(api.derive.council.votes, undefined, transformVotes);
   const modElections = useModuleElections();
   const hasElections = !!modElections;
 

--- a/packages/page-council/src/index.tsx
+++ b/packages/page-council/src/index.tsx
@@ -1,9 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-council authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveCollectiveProposal } from '@polkadot/api-derive/types';
-import type { AccountId } from '@polkadot/types/interfaces';
-
 import React, { useMemo } from 'react';
 import { Route, Routes } from 'react-router';
 import { useLocation } from 'react-router-dom';
@@ -28,8 +25,8 @@ function CouncilApp ({ basePath, className }: Props): React.ReactElement<Props> 
   const { api } = useApi();
   const { pathname } = useLocation();
   const numMotions = useCounter();
-  const prime = useCall<AccountId | null>(api.derive.council.prime);
-  const motions = useCall<DeriveCollectiveProposal[]>(api.derive.council.proposals);
+  const prime = useCall(api.derive.council.prime);
+  const motions = useCall(api.derive.council.proposals);
 
   const items = useMemo(() => [
     {

--- a/packages/page-council/src/useCounter.ts
+++ b/packages/page-council/src/useCounter.ts
@@ -12,7 +12,7 @@ const transformCounter = {
 function useCounterImpl (): number {
   const { hasAccounts } = useAccounts();
   const { api, isApiReady } = useApi();
-  const counter = useCall<number>(isApiReady && hasAccounts && api.derive.council?.proposals, undefined, transformCounter) || 0;
+  const counter = useCall(isApiReady && hasAccounts && api.derive.council?.proposals, undefined, transformCounter) || 0;
 
   return counter;
 }

--- a/packages/page-democracy/src/Overview/ExternalCell.tsx
+++ b/packages/page-democracy/src/Overview/ExternalCell.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-democracy authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveProposalImage } from '@polkadot/api-derive/types';
 import type { Hash } from '@polkadot/types/interfaces';
 
 import React from 'react';
@@ -19,7 +18,7 @@ interface Props {
 function ExternalCell ({ className = '', value }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const preimage = useCall<DeriveProposalImage>(api.derive.democracy.preimage, [value]);
+  const preimage = useCall(api.derive.democracy.preimage, [value]);
 
   if (!preimage?.proposal) {
     return null;

--- a/packages/page-democracy/src/Overview/Externals.tsx
+++ b/packages/page-democracy/src/Overview/Externals.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-democracy authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveProposalExternal } from '@polkadot/api-derive/types';
-
 import React, { useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
@@ -18,7 +16,7 @@ interface Props {
 function Externals ({ className }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const external = useCall<DeriveProposalExternal | null>(api.derive.democracy.nextExternal);
+  const external = useCall(api.derive.democracy.nextExternal);
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t<string>('external'), 'start'],

--- a/packages/page-democracy/src/Overview/Fasttrack.tsx
+++ b/packages/page-democracy/src/Overview/Fasttrack.tsx
@@ -40,7 +40,7 @@ function Fasttrack ({ imageHash, members, threshold }: Props): React.ReactElemen
   const [{ proposal, proposalLength }, setProposal] = useState<ProposalState>(() => ({ proposalLength: 0 }));
   const [withVote, toggleVote] = useToggle(true);
   const modLocation = useCollectiveInstance('technicalCommittee');
-  const proposalCount = useCall<BN>(modLocation && api.query[modLocation].proposalCount);
+  const proposalCount: BN = useCall(modLocation && api.query[modLocation].proposalCount);
 
   const memberThreshold = useMemo(
     () => new BN(

--- a/packages/page-democracy/src/Overview/Proposals.tsx
+++ b/packages/page-democracy/src/Overview/Proposals.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-democracy authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveProposal } from '@polkadot/api-derive/types';
-
 import React, { useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
@@ -18,7 +16,7 @@ interface Props {
 function Proposals ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const proposals = useCall<DeriveProposal[]>(api.derive.democracy.proposals);
+  const proposals = useCall(api.derive.democracy.proposals);
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t<string>('proposals'), 'start', 2],

--- a/packages/page-democracy/src/Overview/Propose.tsx
+++ b/packages/page-democracy/src/Overview/Propose.tsx
@@ -29,7 +29,7 @@ function Propose ({ className = '', onClose }: Props): React.ReactElement<Props>
   const [accountId, setAccountId] = useState<string | null>(null);
   const [balance, setBalance] = useState<BN | undefined>();
   const [{ hash, isHashValid }, setHash] = useState<HashState>({ isHashValid: false });
-  const publicProps = useCall<unknown[]>(api.query.democracy.publicProps);
+  const publicProps = useCall(api.query.democracy.publicProps);
   const preimage = usePreimage(hash);
 
   const _onChangeHash = useCallback(

--- a/packages/page-democracy/src/Overview/Referendum.tsx
+++ b/packages/page-democracy/src/Overview/Referendum.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { DeriveReferendumExt } from '@polkadot/api-derive/types';
-import type { Balance } from '@polkadot/types/interfaces';
 
 import React, { useMemo } from 'react';
 
@@ -44,7 +43,7 @@ function Referendum ({ className = '', value: { allAye, allNay, image, imageHash
   const { allAccounts } = useAccounts();
   const bestNumber = useBestNumber();
   const [isExpanded, toggleIsExpanded] = useToggle(false);
-  const totalIssuance = useCall<Balance>(api.query.balances?.totalIssuance);
+  const totalIssuance = useCall(api.query.balances?.totalIssuance);
   const { changeAye, changeNay } = useChangeCalc(status.threshold, votedAye, votedNay, votedTotal);
   const threshold = useMemo(
     () => status.threshold.type.toString().replace('majority', ' majority '),

--- a/packages/page-democracy/src/Overview/Summary.tsx
+++ b/packages/page-democracy/src/Overview/Summary.tsx
@@ -22,7 +22,7 @@ const optMulti = {
 function Summary ({ referendumCount }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const activeProposals = useCall<unknown[]>(api.derive.democracy.proposals);
+  const activeProposals = useCall(api.derive.democracy.proposals);
   const bestNumber = useBestNumber();
   const [publicPropCount, referendumTotal] = useCallMulti<[BN | undefined, BN | undefined]>([
     api.query.democracy.publicPropCount,

--- a/packages/page-democracy/src/Overview/TreasuryCell.tsx
+++ b/packages/page-democracy/src/Overview/TreasuryCell.tsx
@@ -44,7 +44,7 @@ function TreasuryCell ({ className = '', value }: Props): React.ReactElement<Pro
   const { t } = useTranslation();
   const { api } = useApi();
   const [proposalId] = useState(() => value.unwrap());
-  const proposal = useCall<TreasuryProposal | null>(api.query.treasury.proposals, [proposalId], OPT_PROP);
+  const proposal = useCall(api.query.treasury.proposals, [proposalId], OPT_PROP);
   const [{ params, values }, setExtracted] = useState<ParamState>(DEFAULT_PARAMS);
 
   useEffect((): void => {

--- a/packages/page-democracy/src/Overview/index.tsx
+++ b/packages/page-democracy/src/Overview/index.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-democracy authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveReferendumExt } from '@polkadot/api-derive/types';
-
 import React from 'react';
 
 import { Button } from '@polkadot/react-components';
@@ -25,7 +23,7 @@ function Overview ({ className }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const [isPreimageOpen, togglePreimage] = useToggle();
   const [isProposeOpen, togglePropose] = useToggle();
-  const referendums = useCall<DeriveReferendumExt[]>(api.derive.democracy.referendums);
+  const referendums = useCall(api.derive.democracy.referendums);
 
   return (
     <div className={className}>

--- a/packages/page-democracy/src/useChangeCalc.ts
+++ b/packages/page-democracy/src/useChangeCalc.ts
@@ -18,7 +18,7 @@ interface Result {
 
 function useChangeCalcImpl (threshold: VoteThreshold, votedAye: BN, votedNay: BN, votedTotal: BN): Result {
   const { api } = useApi();
-  const sqrtElectorate = useCall<BN>(api.derive.democracy.sqrtElectorate);
+  const sqrtElectorate = useCall(api.derive.democracy.sqrtElectorate);
   const [result, setResult] = useState<Result>({ changeAye: BN_ZERO, changeNay: BN_ZERO });
 
   useEffect((): void => {

--- a/packages/page-democracy/src/useCounter.ts
+++ b/packages/page-democracy/src/useCounter.ts
@@ -9,8 +9,8 @@ function useCounterImpl (): number {
   const { hasAccounts } = useAccounts();
   const { api, isApiReady } = useApi();
   const mountedRef = useIsMountedRef();
-  const proposals = useCall<unknown[]>(isApiReady && hasAccounts && api.derive.democracy?.proposals);
-  const referenda = useCall<unknown[]>(isApiReady && hasAccounts && api.derive.democracy?.referendumsActive);
+  const proposals = useCall(isApiReady && hasAccounts && api.derive.democracy?.proposals);
+  const referenda = useCall(isApiReady && hasAccounts && api.derive.democracy?.referendumsActive);
   const [counter, setCounter] = useState(0);
 
   useEffect((): void => {

--- a/packages/page-explorer/src/BestHash.tsx
+++ b/packages/page-explorer/src/BestHash.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Header } from '@polkadot/types/interfaces';
-
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -14,7 +12,7 @@ interface Props {
 
 function BestHash ({ className = '', label }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const newHead = useCall<Header>(api.rpc.chain.subscribeNewHeads);
+  const newHead = useCall(api.rpc.chain.subscribeNewHeads);
 
   return (
     <div className={className}>

--- a/packages/page-explorer/src/Latency/useLatency.ts
+++ b/packages/page-explorer/src/Latency/useLatency.ts
@@ -119,7 +119,7 @@ async function getNext (api: ApiPromise, { block: { number: start } }: Detail, {
 function useLatencyImpl (): Result {
   const { api } = useApi();
   const [details, setDetails] = useState<Detail[]>([]);
-  const signedBlock = useCall<SignedBlockExtended>(api.derive.chain.subscribeNewBlocks);
+  const signedBlock = useCall(api.derive.chain.subscribeNewBlocks);
   const hasHistoric = useRef(false);
 
   useEffect((): void => {

--- a/packages/page-explorer/src/SummarySession.tsx
+++ b/packages/page-explorer/src/SummarySession.tsx
@@ -1,9 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionProgress } from '@polkadot/api-derive/types';
-import type { Forcing } from '@polkadot/types/interfaces';
-
 import React from 'react';
 
 import { CardSummary } from '@polkadot/react-components';
@@ -22,8 +19,8 @@ interface Props {
 function SummarySession ({ className, withEra = true, withSession = true }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session?.progress);
-  const forcing = useCall<Forcing>(api.query.staking?.forceEra);
+  const sessionInfo = useCall(api.derive.session?.progress);
+  const forcing = useCall(api.query.staking?.forceEra);
 
   const eraLabel = t<string>('era');
   const sessionLabel = api.query.babe

--- a/packages/page-membership/src/useCounter.ts
+++ b/packages/page-membership/src/useCounter.ts
@@ -11,7 +11,7 @@ const OPT = {
 
 function useCounterImpl (): number {
   const { api, isApiReady } = useApi();
-  const counter = useCall<number>(isApiReady && api.query.membership?.proposals, undefined, OPT) || 0;
+  const counter = useCall(isApiReady && api.query.membership?.proposals, undefined, OPT) || 0;
 
   return counter;
 }

--- a/packages/page-nfts/src/AccountItems/useItemsInfos.ts
+++ b/packages/page-nfts/src/AccountItems/useItemsInfos.ts
@@ -66,7 +66,7 @@ function useItemsInfosImpl (accountItems: AccountItem[]): ItemInfo[] | undefined
     [accountItems]
   );
 
-  const metadata = useCall<[[[BN, BN][]], Option<PalletUniquesItemMetadata>[]]>(api.query.uniques.instanceMetadataOf.multi, [ids], QUERY_OPTS);
+  const metadata: [[[BN, BN][]], Option<PalletUniquesItemMetadata>[]] = useCall(api.query.uniques.instanceMetadataOf.multi, [ids], QUERY_OPTS);
 
   const ipfsHashes = useMemo((): string[] | undefined => {
     if (metadata && metadata[1].length) {

--- a/packages/page-nfts/src/useCollectionInfos.ts
+++ b/packages/page-nfts/src/useCollectionInfos.ts
@@ -82,8 +82,8 @@ const addIpfsData = (ipfsData: IpfsData) => (collectionInfo: CollectionInfo): Co
 function useCollectionInfosImpl (ids?: BN[]): CollectionInfo[] | undefined {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
-  const metadata = useCall<[[BN[]], Option<PalletUniquesCollectionMetadata>[]]>(api.query.uniques.classMetadataOf.multi, [ids], QUERY_OPTS);
-  const details = useCall<[[BN[]], Option<PalletUniquesCollectionDetails>[]]>(api.query.uniques.class.multi, [ids], QUERY_OPTS);
+  const metadata: [[BN[]], Option<PalletUniquesCollectionMetadata>[]] = useCall(api.query.uniques.classMetadataOf.multi, [ids], QUERY_OPTS);
+  const details: [[BN[]], Option<PalletUniquesCollectionDetails>[]] = useCall(api.query.uniques.class.multi, [ids], QUERY_OPTS);
   const [state, setState] = useState<CollectionInfo[] | undefined>();
 
   const ipfsHashes = useMemo(

--- a/packages/page-parachains/src/Auctions/Auction.tsx
+++ b/packages/page-parachains/src/Auctions/Auction.tsx
@@ -24,7 +24,7 @@ function Auction ({ auctionInfo, campaigns, className, winningData }: Props): Re
   const { t } = useTranslation();
   const { api } = useApi();
   const rangeMax = useLeaseRangeMax();
-  const newRaise = useCall<ParaId[]>(api.query.crowdloan.newRaise);
+  const newRaise: ParaId[] = useCall(api.query.crowdloan.newRaise);
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t<string>('bids'), 'start', 3],

--- a/packages/page-parachains/src/Auctions/Summary.tsx
+++ b/packages/page-parachains/src/Auctions/Summary.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { u32 } from '@polkadot/types';
-import type { Balance, BlockNumber } from '@polkadot/types/interfaces';
+import type { BlockNumber } from '@polkadot/types/interfaces';
 import type { AuctionInfo, Winning } from '../types.js';
 
 import React from 'react';
@@ -24,7 +24,7 @@ function Summary ({ auctionInfo, className, lastWinners }: Props): React.ReactEl
   const { t } = useTranslation();
   const { api } = useApi();
   const bestNumber = useBestNumber();
-  const totalIssuance = useCall<Balance>(api.query.balances?.totalIssuance);
+  const totalIssuance = useCall(api.query.balances?.totalIssuance);
 
   return (
     <SummaryBox className={className}>

--- a/packages/page-parachains/src/Crowdloan/useContributions.ts
+++ b/packages/page-parachains/src/Crowdloan/useContributions.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-parachains authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveContributions, DeriveOwnContributions } from '@polkadot/api-derive/types';
+import type { DeriveContributions } from '@polkadot/api-derive/types';
 import type { Balance, ParaId } from '@polkadot/types/interfaces';
 
 import { useEffect, useState } from 'react';
@@ -29,8 +29,8 @@ function useContributionsImpl (paraId: ParaId): Result {
   const { api } = useApi();
   const { allAccountsHex } = useAccounts();
   const [state, setState] = useState<Result>(() => NO_CONTRIB);
-  const derive = useCall<DeriveContributions>(api.derive.crowdloan.contributions, [paraId]);
-  const myContributions = useCall<DeriveOwnContributions>(api.derive.crowdloan.ownContributions, [paraId, state.myAccountsHex]);
+  const derive = useCall(api.derive.crowdloan.contributions, [paraId]);
+  const myContributions = useCall(api.derive.crowdloan.ownContributions, [paraId, state.myAccountsHex]);
 
   useEffect((): void => {
     derive && setState((prev): Result => {

--- a/packages/page-parachains/src/Overview/useChainDetails.ts
+++ b/packages/page-parachains/src/Overview/useChainDetails.ts
@@ -19,8 +19,8 @@ function useChainDetailsImpl (id: ParaId): Result {
 
   // We are not using the derive here, we keep this queries to the point to not overload
   return {
-    bestNumber: useCall<BlockNumber>(api?.rpc.chain.subscribeNewHeads, undefined, HDR_OPTS),
-    runtimeVersion: useCall<RuntimeVersion>(api?.rpc.state.subscribeRuntimeVersion)
+    bestNumber: useCall(api?.rpc.chain.subscribeNewHeads, undefined, HDR_OPTS),
+    runtimeVersion: useCall(api?.rpc.state.subscribeRuntimeVersion)
   };
 }
 

--- a/packages/page-parachains/src/Overview/useEvents.ts
+++ b/packages/page-parachains/src/Overview/useEvents.ts
@@ -83,7 +83,7 @@ function extractEvents (api: ApiPromise, lastBlock: SignedBlockExtended, prev: R
 
 function useEventsImpl (): Result {
   const { api } = useApi();
-  const lastBlock = useCall<SignedBlockExtended>(api.derive.chain.subscribeNewBlocks);
+  const lastBlock = useCall(api.derive.chain.subscribeNewBlocks);
   const [state, setState] = useState<Result>(EMPTY_EVENTS);
 
   useEffect((): void => {

--- a/packages/page-parachains/src/Parathreads/Actions.tsx
+++ b/packages/page-parachains/src/Parathreads/Actions.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ParaId } from '@polkadot/types/interfaces';
-import type { BN } from '@polkadot/util';
 import type { OwnedId } from '../types.js';
 
 import React from 'react';
@@ -32,7 +31,7 @@ function Actions ({ className, ownedIds }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const [isRegisterOpen, toggleRegisterOpen] = useToggle();
   const [isReserveOpen, toggleReserveOpen] = useToggle();
-  const nextParaId = useCall<ParaId | BN>(api.query.registrar.nextFreeParaId, [], OPT_NEXT);
+  const nextParaId = useCall(api.query.registrar.nextFreeParaId, [], OPT_NEXT);
 
   return (
     <Button.Group className={className}>

--- a/packages/page-parachains/src/Parathreads/useParaMap.ts
+++ b/packages/page-parachains/src/Parathreads/useParaMap.ts
@@ -63,7 +63,7 @@ function useParaMapImpl (ids?: ParaId[]): Result | undefined {
     [hasLinksMap]
   );
 
-  return useCall<Result>(ids && api.query.slots.leases.multi, [ids], {
+  return useCall(ids && api.query.slots.leases.multi, [ids], {
     transform,
     withParamsTransform: true
   });

--- a/packages/page-parachains/src/Proposals/useProposal.ts
+++ b/packages/page-parachains/src/Proposals/useProposal.ts
@@ -11,7 +11,7 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useProposalImpl (id: ParaId, approvedIds: ParaId[], scheduled: ScheduledProposals[]): ProposalExt {
   const { api } = useApi();
-  const opt = useCall<Option<ParachainProposal>>(api.query.proposeParachain.proposals, [id]);
+  const opt: Option<ParachainProposal> = useCall(api.query.proposeParachain.proposals, [id]);
 
   return useMemo(
     (): ProposalExt => ({

--- a/packages/page-parachains/src/index.tsx
+++ b/packages/page-parachains/src/index.tsx
@@ -44,7 +44,7 @@ function ParachainsApp ({ basePath, className }: Props): React.ReactElement<Prop
   const proposals = useProposals();
   const actionsQueue = useActionsQueue();
   const upcomingIds = useUpcomingIds();
-  const paraIds = useCall<ParaId[]>(api.query.paras.parachains);
+  const paraIds: ParaId[] = useCall(api.query.paras.parachains);
 
   const items = useRef([
     {

--- a/packages/page-parachains/src/useActionsQueue.ts
+++ b/packages/page-parachains/src/useActionsQueue.ts
@@ -18,9 +18,9 @@ const OPT_NEXT = {
 
 function useActionsQueueImpl (): QueuedAction[] {
   const { api } = useApi();
-  const currentIndex = useCall<SessionIndex>(api.query.session.currentIndex);
+  const currentIndex: SessionIndex = useCall(api.query.session.currentIndex);
   const queryIndexes = useMemo(() => currentIndex && INC.map((i) => currentIndex.add(i)), [currentIndex]);
-  const nextActions = useCall<[[BN[]], ParaId[][]]>(queryIndexes && api.query.paras.actionsQueue.multi, [queryIndexes], OPT_NEXT);
+  const nextActions: [[BN[]], ParaId[][]] = useCall(queryIndexes && api.query.paras.actionsQueue.multi, [queryIndexes], OPT_NEXT);
 
   return useMemo(
     (): QueuedAction[] =>

--- a/packages/page-parachains/src/useFunds.ts
+++ b/packages/page-parachains/src/useFunds.ts
@@ -159,8 +159,8 @@ function useFundsImpl (): Campaigns {
   const mountedRef = useIsMountedRef();
   const trigger = useEventTrigger([api.events.crowdloan?.Created]);
   const paraIds = useMapKeys(api.query.crowdloan?.funds, [], OPT_FUNDS, trigger.blockHash);
-  const campaigns = useCall<Campaign[]>(api.query.crowdloan?.funds.multi, [paraIds], OPT_FUNDS_MULTI);
-  const leases = useCall<ParaId[]>(api.query.slots.leases.multi, [paraIds], OPT_LEASE);
+  const campaigns = useCall(api.query.crowdloan?.funds.multi, [paraIds], OPT_FUNDS_MULTI);
+  const leases = useCall(api.query.slots.leases.multi, [paraIds], OPT_LEASE);
   const [result, setResult] = useState<Campaigns>(EMPTY);
 
   // here we manually add the actual ending status and calculate the totals

--- a/packages/page-parachains/src/useWinningData.ts
+++ b/packages/page-parachains/src/useWinningData.ts
@@ -128,8 +128,8 @@ function useWinningDataImpl (auctionInfo?: AuctionInfo): Winning[] | undefined {
   const bestNumber = useBestNumber();
   const trigger = useEventTrigger([api.events.auctions?.BidAccepted]);
   const triggerRef = useRef(trigger);
-  const initialEntries = useCall<[StorageKey<[BlockNumber]>, Option<WinningData>][]>(api.query.auctions?.winning.entries);
-  const optFirstData = useCall<Option<WinningData>>(api.query.auctions?.winning, FIRST_PARAM);
+  const initialEntries: [StorageKey<[BlockNumber]>, Option<WinningData>][] = useCall(api.query.auctions?.winning.entries);
+  const optFirstData: Option<WinningData> = useCall(api.query.auctions?.winning, FIRST_PARAM);
 
   // should be fired once, all entries as an initial round
   useEffect((): void => {

--- a/packages/page-referenda/src/Referenda/index.tsx
+++ b/packages/page-referenda/src/Referenda/index.tsx
@@ -33,8 +33,8 @@ interface Props {
 function Referenda ({ className, isConvictionVote, members, palletReferenda, palletVote, ranks }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const totalIssuance = useCall<BN | undefined>(api.query.balances.totalIssuance);
-  const inactiveIssuance = useCall<BN | undefined>(api.query.balances.inactiveIssuance);
+  const totalIssuance = useCall(api.query.balances.totalIssuance);
+  const inactiveIssuance = useCall(api.query.balances.inactiveIssuance);
   const { allAccounts } = useAccounts();
   const [grouped, tracks] = useReferenda(palletReferenda);
   const summary = useSummary(palletReferenda, grouped);

--- a/packages/page-referenda/src/useAccountLocks.ts
+++ b/packages/page-referenda/src/useAccountLocks.ts
@@ -147,7 +147,7 @@ function useAccountLocksImpl (palletReferenda: PalletReferenda, palletVote: Pall
     [accountId]
   );
 
-  const lockClasses = useCall<BN[] | undefined>(lockParams && api.query[palletVote]?.classLocksFor, lockParams, OPT_CLASS);
+  const lockClasses = useCall(lockParams && api.query[palletVote]?.classLocksFor, lockParams, OPT_CLASS);
 
   // retrieve the specific votes casted over the classes & accountId
   const voteParams = useMemo(
@@ -155,7 +155,7 @@ function useAccountLocksImpl (palletReferenda: PalletReferenda, palletVote: Pall
     [accountId, lockClasses]
   );
 
-  const votes = useCall<[BN, BN[], PalletConvictionVotingVoteCasting][] | undefined>(voteParams && api.query[palletVote]?.votingFor.multi, voteParams, OPT_VOTES);
+  const votes = useCall(voteParams && api.query[palletVote]?.votingFor.multi, voteParams, OPT_VOTES);
 
   // retrieve the referendums that were voted on
   const refParams = useMemo(

--- a/packages/page-referenda/src/useReferenda.ts
+++ b/packages/page-referenda/src/useReferenda.ts
@@ -142,7 +142,7 @@ function group (tracks: TrackDescription[], totalIssuance?: BN, referenda?: Refe
 
 function useReferendaImpl (palletReferenda: PalletReferenda): [ReferendaGroup[], TrackDescription[]] {
   const { api, isApiReady } = useApi();
-  const totalIssuance = useCall<BN>(isApiReady && api.query.balances.totalIssuance);
+  const totalIssuance = useCall(isApiReady && api.query.balances.totalIssuance);
   const ids = useReferendaIds(palletReferenda);
   const tracks = useTracks(palletReferenda);
   const referenda = useCall(isApiReady && ids && ids.length !== 0 && api.query[palletReferenda as 'referenda'].referendumInfoFor.multi, [ids], OPT_MULTI);

--- a/packages/page-referenda/src/useSummary.ts
+++ b/packages/page-referenda/src/useSummary.ts
@@ -18,7 +18,7 @@ function calcActive (grouped: ReferendaGroup[] = []): number {
 
 function useSummaryImpl (palletReferenda: PalletReferenda, grouped?: ReferendaGroup[] | undefined): Summary {
   const { api } = useApi();
-  const refCount = useCall<u32>(api.query[palletReferenda].referendumCount);
+  const refCount: u32 = useCall(api.query[palletReferenda].referendumCount);
   const refActive = useMemo(
     () => calcActive(grouped),
     [grouped]

--- a/packages/page-scheduler/src/DispatchQueue.tsx
+++ b/packages/page-scheduler/src/DispatchQueue.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-scheduler authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveDispatch } from '@polkadot/api-derive/types';
-
 import React, { useMemo, useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
@@ -19,7 +17,7 @@ function DispatchQueue ({ className }: Props): React.ReactElement<Props> | null 
   const { t } = useTranslation();
   const { api } = useApi();
   const bestNumber = useBestNumber();
-  const queued = useCall<DeriveDispatch[]>(api.derive.democracy.dispatchQueue);
+  const queued = useCall(api.derive.democracy.dispatchQueue);
 
   const filtered = useMemo(
     () => bestNumber && queued &&

--- a/packages/page-scheduler/src/Scheduler.tsx
+++ b/packages/page-scheduler/src/Scheduler.tsx
@@ -82,7 +82,7 @@ function Schedule ({ className = '' }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const bestNumber = useBestNumber();
-  const items = useCall<ScheduledExt[]>(api.query.scheduler.agenda.entries, undefined, OPT_SCHED);
+  const items = useCall(api.query.scheduler.agenda.entries, undefined, OPT_SCHED);
 
   const filtered = useMemo(
     () => bestNumber && items &&

--- a/packages/page-society/src/Candidates/Bids.tsx
+++ b/packages/page-society/src/Candidates/Bids.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-society authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PalletSocietyBid } from '@polkadot/types/lookup';
-
 import React, { useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
@@ -18,7 +16,7 @@ interface Props {
 function Bids ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const bids = useCall<PalletSocietyBid[]>(api.query.society.bids);
+  const bids = useCall(api.query.society.bids);
 
   const headerRef = useRef<[React.ReactNode?, string?, number?][]>([
     [t<string>('bids'), 'start'],

--- a/packages/page-society/src/Candidates/Candidate.tsx
+++ b/packages/page-society/src/Candidates/Candidate.tsx
@@ -28,7 +28,7 @@ function Candidate ({ allMembers, isMember, ownMembers, value: { accountId, kind
     () => [allMembers.map((memberId): [AccountId, string] => [accountId, memberId])],
     [accountId, allMembers]
   );
-  const votes = useCall<VoteType[]>(api.query.society.votes.multi, keys, {
+  const votes: VoteType[] = useCall(api.query.society.votes.multi, keys, {
     transform: (voteOpts: Option<SocietyVote>[]): VoteType[] =>
       voteOpts
         .map((voteOpt, index): [string, Option<SocietyVote>] => [allMembers[index], voteOpt])

--- a/packages/page-society/src/Overview/Defender.tsx
+++ b/packages/page-society/src/Overview/Defender.tsx
@@ -31,7 +31,7 @@ const OPT_VOTES = {
 function Defender ({ className = '', info, isMember, ownMembers }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const votes = useCall<VoteType[]>(api.derive.society.members, undefined, OPT_VOTES);
+  const votes = useCall(api.derive.society.members, undefined, OPT_VOTES);
 
   const headerRef = useRef<[React.ReactNode?, string?, number?][]>([
     [t<string>('defender'), 'start'],

--- a/packages/page-society/src/Overview/Summary.tsx
+++ b/packages/page-society/src/Overview/Summary.tsx
@@ -21,7 +21,7 @@ interface Props {
 function Summary ({ className = '', info, payoutTotal }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const members = useCall<unknown[]>(api.derive.society.members);
+  const members = useCall(api.derive.society.members);
   const bestNumber = useBestNumber();
 
   const pot = useMemo(

--- a/packages/page-society/src/Suspended/index.tsx
+++ b/packages/page-society/src/Suspended/index.tsx
@@ -46,8 +46,8 @@ const OPT_ACC = {
 function Suspended ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const candidates = useCall<CandidateSuspend[]>(api.query.society.suspendedCandidates.entries, undefined, OPT_CAN);
-  const members = useCall<AccountId[]>(api.query.society.suspendedMembers.keys, undefined, OPT_ACC);
+  const candidates = useCall(api.query.society.suspendedCandidates.entries, undefined, OPT_CAN);
+  const members = useCall(api.query.society.suspendedMembers.keys, undefined, OPT_ACC);
 
   const headerRef = useRef({
     candidates: [

--- a/packages/page-society/src/index.tsx
+++ b/packages/page-society/src/index.tsx
@@ -84,8 +84,8 @@ function SocietyApp ({ basePath, className }: Props): React.ReactElement<Props> 
   const { api } = useApi();
   const candidateCount = useCounter();
   const { allMembers, isMember, ownMembers } = useMembers();
-  const info = useCall<DeriveSociety>(api.derive.society.info);
-  const members = useCall<DeriveSocietyMember[]>(api.derive.society.members);
+  const info = useCall(api.derive.society.info);
+  const members = useCall(api.derive.society.members);
   const { candidates, skeptics, voters } = useVoters();
 
   const [mapMembers, payoutTotal] = useMemo(

--- a/packages/page-society/src/useCounter.ts
+++ b/packages/page-society/src/useCounter.ts
@@ -1,13 +1,11 @@
 // Copyright 2017-2023 @polkadot/app-society authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Bid } from '@polkadot/types/interfaces';
-
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useCounterImpl (): number {
   const { api } = useApi();
-  const bids = useCall<Bid[]>(api.query.society?.candidates);
+  const bids = useCall(api.query.society?.candidates);
 
   return bids?.length || 0;
 }

--- a/packages/page-society/src/useMembers.ts
+++ b/packages/page-society/src/useMembers.ts
@@ -23,7 +23,7 @@ function useMembersImpl (): OwnMembers {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
   const [state, setState] = useState<OwnMembers>(EMPTY_MEMBERS);
-  const members = useCall<DeriveSocietyMember[]>(api.derive.society.members);
+  const members = useCall(api.derive.society.members);
 
   useEffect((): void => {
     allAccounts && members && setState(

--- a/packages/page-society/src/useVoters.ts
+++ b/packages/page-society/src/useVoters.ts
@@ -42,7 +42,7 @@ async function getVoters (api: ApiPromise, candidates: DeriveSocietyCandidate[])
 function useVotersImpl (): Voters {
   const { api } = useApi();
   const voteTrigger = useEventTrigger([api.events.society.Vote]);
-  const candidates = useCall<DeriveSocietyCandidate[]>(api.derive.society.candidates);
+  const candidates = useCall(api.derive.society.candidates);
   const [state, setState] = useState<Voters>(EMPTY_VOTERS);
 
   useEffect((): void => {

--- a/packages/page-staking/src/Actions/Account/BondExtra.tsx
+++ b/packages/page-staking/src/Actions/Account/BondExtra.tsx
@@ -41,7 +41,7 @@ function BondExtra ({ controllerId, onClose, stakingInfo, stashId }: Props): Rea
   const { api } = useApi();
   const [amountError, setAmountError] = useState<AmountValidateState | null>(null);
   const [maxAdditional, setMaxAdditional] = useState<BN | undefined>();
-  const stashBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [stashId]);
+  const stashBalance = useCall(api.derive.balances?.all, [stashId]);
   const currentAmount = useMemo(
     () => stakingInfo && stakingInfo.stakingLedger?.active?.unwrap(),
     [stakingInfo]

--- a/packages/page-staking/src/Actions/Account/InputValidateAmount.tsx
+++ b/packages/page-staking/src/Actions/Account/InputValidateAmount.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { AmountValidateState } from '../types.js';
 
 import React, { useEffect, useState } from 'react';
@@ -48,7 +47,7 @@ function formatExistential (value: BN): string {
 function ValidateAmount ({ currentAmount, isNominating, minNominated, minNominatorBond, minValidatorBond, onError, stashId, value }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const stashBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [stashId]);
+  const stashBalance = useCall(api.derive.balances?.all, [stashId]);
   const [{ error, warning }, setResult] = useState<AmountValidateState>({ error: null, warning: null });
 
   useEffect((): void => {

--- a/packages/page-staking/src/Actions/Account/InputValidationController.tsx
+++ b/packages/page-staking/src/Actions/Account/InputValidationController.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { Option } from '@polkadot/types';
 import type { AccountId, StakingLedger } from '@polkadot/types/interfaces';
 
@@ -41,9 +40,9 @@ const OPT_STASH = {
 function ValidateController ({ accountId, controllerId, defaultController, onError }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const bondedId = useCall<string | null>(controllerId ? api.query.staking.bonded : null, [controllerId], OPT_BOND);
-  const stashId = useCall<string | null>(controllerId ? api.query.staking.ledger : null, [controllerId], OPT_STASH);
-  const allBalances = useCall<DeriveBalancesAll>(controllerId ? api.derive.balances?.all : null, [controllerId]);
+  const bondedId = useCall(controllerId ? api.query.staking.bonded : null, [controllerId], OPT_BOND);
+  const stashId = useCall(controllerId ? api.query.staking.ledger : null, [controllerId], OPT_STASH);
+  const allBalances = useCall(controllerId ? api.derive.balances?.all : null, [controllerId]);
   const [{ error, isFatal }, setError] = useState<ErrorState>({ error: null, isFatal: false });
 
   useEffect((): void => {

--- a/packages/page-staking/src/Actions/Account/KickNominees.tsx
+++ b/packages/page-staking/src/Actions/Account/KickNominees.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
-import type { DeriveStakingQuery } from '@polkadot/api-derive/types';
 
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -31,7 +30,7 @@ function KickNominees ({ className = '', controllerId, nominating, onClose, stas
   const { api } = useApi();
   const [selected, setSelected] = useState<string[]>([]);
   const [{ kickTx }, setTx] = useState<{ kickTx?: null | SubmittableExtrinsic<'promise'> }>({});
-  const queryInfo = useCall<DeriveStakingQuery>(api.derive.staking.query, [stashId, accountOpts]);
+  const queryInfo = useCall(api.derive.staking.query, [stashId, accountOpts]);
 
   const nominators = useMemo(
     () => queryInfo?.exposure?.others.map(({ who }) => who.toString()),

--- a/packages/page-staking/src/Actions/Account/ListNominees.tsx
+++ b/packages/page-staking/src/Actions/Account/ListNominees.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveEraExposure, DeriveSessionIndexes } from '@polkadot/api-derive/types';
+import type { DeriveEraExposure } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import React, { useMemo } from 'react';
@@ -69,8 +69,8 @@ function ListNominees ({ nominating, stashId }: Props): React.ReactElement<Props
   const { t } = useTranslation();
   const { api } = useApi();
   const { nomsActive, nomsChilled, nomsInactive, nomsOver, nomsWaiting } = useInactives(stashId, nominating);
-  const sessionInfo = useCall<DeriveSessionIndexes>(api.query.staking && api.derive.session?.indexes);
-  const eraExposure = useCall<DeriveEraExposure>(isFunction(api.query.staking.erasStakers) && api.derive.staking.eraExposure, [sessionInfo?.activeEra]);
+  const sessionInfo = useCall(api.query.staking && api.derive.session?.indexes);
+  const eraExposure = useCall(isFunction(api.query.staking.erasStakers) && api.derive.staking.eraExposure, [sessionInfo?.activeEra]);
 
   const [renActive, renChilled, renInactive, renOver, renWaiting] = useMemo(
     () => [renderNominators(stashId, nomsActive, eraExposure), renderNominators(stashId, nomsChilled), renderNominators(stashId, nomsInactive), renderNominators(stashId, nomsOver), renderNominators(stashId, nomsWaiting)],

--- a/packages/page-staking/src/Actions/Account/SetRewardDestination.tsx
+++ b/packages/page-staking/src/Actions/Account/SetRewardDestination.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { RewardDestination } from '@polkadot/types/interfaces';
 import type { DestinationType } from '../types.js';
 
@@ -26,7 +25,7 @@ function SetRewardDestination ({ controllerId, defaultDestination, onClose, stas
   const { api } = useApi();
   const [destination, setDestination] = useState<DestinationType>(() => ((defaultDestination?.isAccount ? 'Account' : defaultDestination?.toString()) || 'Staked') as 'Staked');
   const [destAccount, setDestAccount] = useState<string | null>(() => defaultDestination?.isAccount ? defaultDestination.asAccount.toString() : null);
-  const destBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [destAccount]);
+  const destBalance = useCall(api.derive.balances?.all, [destAccount]);
 
   const options = useMemo(
     () => createDestCurr(t),

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ApiPromise } from '@polkadot/api';
-import type { DeriveBalancesAll, DeriveStakingAccount } from '@polkadot/api-derive/types';
 import type { StakerState } from '@polkadot/react-hooks/types';
 import type { PalletStakingUnappliedSlash } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
@@ -54,8 +53,8 @@ function extractSlashes (stashId: string, allSlashes: [BN, PalletStakingUnapplie
 
 function useStashCalls (api: ApiPromise, stashId: string) {
   const params = useMemo(() => [stashId], [stashId]);
-  const balancesAll = useCall<DeriveBalancesAll>(api.derive.balances?.all, params);
-  const stakingAccount = useCall<DeriveStakingAccount>(api.derive.staking.account, params);
+  const balancesAll = useCall(api.derive.balances?.all, params);
+  const stakingAccount = useCall(api.derive.staking.account, params);
   const spanCount = useSlashingSpans(stashId);
 
   return { balancesAll, spanCount, stakingAccount };

--- a/packages/page-staking/src/Actions/Pools.tsx
+++ b/packages/page-staking/src/Actions/Pools.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import type { OwnPool } from '@polkadot/app-staking2/Pools/types';
 import type { PalletStakingUnappliedSlash } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
@@ -27,7 +26,7 @@ interface Props {
 function Pools ({ className, list, targets }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const sessionProgress = useCall<DeriveSessionProgress>(api.derive.session.progress);
+  const sessionProgress = useCall(api.derive.session.progress);
 
   const hdrRef = useRef<[React.ReactNode?, string?, number?][]>([
     [t<string>('pools'), 'start', 2],

--- a/packages/page-staking/src/Actions/partials/Bond.tsx
+++ b/packages/page-staking/src/Actions/partials/Bond.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 import type { AmountValidateState, DestinationType } from '../types.js';
 import type { BondInfo } from './types.js';
@@ -46,8 +45,8 @@ function Bond ({ className = '', isNominating, minNominated, minNominatorBond, m
   const [destAccount, setDestAccount] = useState<string | null>(null);
   const [stashId, setStashId] = useState<string | null>(null);
   const [startBalance, setStartBalance] = useState<BN | null>(null);
-  const stashBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [stashId]);
-  const destBalance = useCall<DeriveBalancesAll>(api.derive.balances?.all, [destAccount]);
+  const stashBalance = useCall(api.derive.balances?.all, [stashId]);
+  const destBalance = useCall(api.derive.balances?.all, [destAccount]);
   const bondedBlocks = useUnbondDuration();
 
   const needsController = useMemo(

--- a/packages/page-staking/src/Actions/useInactives.ts
+++ b/packages/page-staking/src/Actions/useInactives.ts
@@ -92,7 +92,7 @@ function useInactivesImpl (stashId: string, nominees?: string[]): Inactives {
   const { api } = useApi();
   const mountedRef = useIsMountedRef();
   const [state, setState] = useState<Inactives>({});
-  const indexes = useCall<DeriveSessionIndexes>(api.derive.session.indexes);
+  const indexes = useCall(api.derive.session.indexes);
 
   useEffect((): () => void => {
     let unsub: (() => void) | undefined;

--- a/packages/page-staking/src/Actions/useSlashingSpans.ts
+++ b/packages/page-staking/src/Actions/useSlashingSpans.ts
@@ -16,7 +16,7 @@ const OPT_SPAN = {
 function useSlashingSpansImpl (stashId: string): number {
   const { api } = useApi();
 
-  return useCall<number>(api.query.staking.slashingSpans, [stashId], OPT_SPAN) || 0;
+  return useCall(api.query.staking.slashingSpans, [stashId], OPT_SPAN) || 0;
 }
 
 export default createNamedHook('useSlashingSpans', useSlashingSpansImpl);

--- a/packages/page-staking/src/Actions/useUnbondDuration.ts
+++ b/packages/page-staking/src/Actions/useUnbondDuration.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionInfo } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import { useMemo } from 'react';
@@ -11,7 +10,7 @@ import { BN_ONE } from '@polkadot/util';
 
 function useUnbondDurationImpl (): BN | undefined {
   const { api } = useApi();
-  const sessionInfo = useCall<DeriveSessionInfo>(api.derive.session.info);
+  const sessionInfo = useCall(api.derive.session.info);
 
   return useMemo(
     () => (sessionInfo && sessionInfo.sessionLength.gt(BN_ONE))

--- a/packages/page-staking/src/Bags/Summary.tsx
+++ b/packages/page-staking/src/Bags/Summary.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BN } from '@polkadot/util';
 import type { BagMap } from './types.js';
 
 import React, { useMemo } from 'react';
@@ -22,7 +21,7 @@ interface Props {
 function Summary ({ bags, className = '', mapOwn }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const mod = useQueryModule();
-  const total = useCall<BN>(mod.counterForListNodes);
+  const total = useCall(mod.counterForListNodes);
 
   const myCount = useMemo(
     () => mapOwn && Object.values(mapOwn).reduce((count, n) => count + n.length, 0),

--- a/packages/page-staking/src/Bags/useBagEntries.tsx
+++ b/packages/page-staking/src/Bags/useBagEntries.tsx
@@ -1,9 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
 import type { AccountId32 } from '@polkadot/types/interfaces';
-import type { PalletBagsListListNode } from '@polkadot/types/lookup';
 
 import { useEffect, useState } from 'react';
 
@@ -22,7 +20,7 @@ const EMPTY_LIST: AccountId32[] = [];
 function useBagEntriesImpl (headId: AccountId32 | null, trigger: number): [boolean, AccountId32[]] {
   const mod = useQueryModule();
   const [[currId, { isCompleted, list }], setCurrent] = useState<[AccountId32 | null, Result]>(EMPTY);
-  const node = useCall<Option<PalletBagsListListNode>>(!!currId && mod.listNodes, [currId]);
+  const node = useCall(!!currId && mod.listNodes, [currId]);
 
   useEffect(
     () => setCurrent(

--- a/packages/page-staking/src/Payouts/index.tsx
+++ b/packages/page-staking/src/Payouts/index.tsx
@@ -163,7 +163,7 @@ function Payouts ({ className = '', historyDepth, isInElection, ownPools, ownVal
   const [hasOwnValidators] = useState(() => ownValidators.length !== 0);
   const [myStashesIndex, setMyStashesIndex] = useState(() => hasOwnValidators ? 0 : 1);
   const [eraSelectionIndex, setEraSelectionIndex] = useState(0);
-  const eraLength = useCall<BN>(api.derive.session.eraLength);
+  const eraLength = useCall(api.derive.session.eraLength);
   const blockTime = useBlockInterval();
 
   const poolStashes = useMemo(

--- a/packages/page-staking/src/Payouts/useEraBlocks.ts
+++ b/packages/page-staking/src/Payouts/useEraBlocks.ts
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionProgress } from '@polkadot/api-derive/types';
-import type { Forcing } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 
 import { useMemo } from 'react';
@@ -12,8 +10,8 @@ import { BN_ONE } from '@polkadot/util';
 
 function useEraBlocksImpl (historyDepth?: BN, era?: BN): BN | undefined {
   const { api } = useApi();
-  const progress = useCall<DeriveSessionProgress>(api.derive.session.progress);
-  const forcing = useCall<Forcing>(api.query.staking.forceEra);
+  const progress = useCall(api.derive.session.progress);
+  const forcing = useCall(api.query.staking.forceEra);
 
   return useMemo(
     () => (historyDepth && era && forcing && progress && progress.sessionLength.gt(BN_ONE))

--- a/packages/page-staking/src/Query/ChartPoints.tsx
+++ b/packages/page-staking/src/Query/ChartPoints.tsx
@@ -43,8 +43,8 @@ function extractPoints (labels: string[], points: DeriveStakerPoints[]): LineDat
 function ChartPoints ({ labels, validatorId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const params = useMemo(() => [validatorId, false], [validatorId]);
-  const stakerPoints = useCall<DeriveStakerPoints[]>(api.derive.staking.stakerPoints, params);
+  const params = useMemo(() => [validatorId, false] as const, [validatorId]);
+  const stakerPoints = useCall(api.derive.staking.stakerPoints, params);
   const [values, setValues] = useState<LineData>([]);
 
   useEffect(

--- a/packages/page-staking/src/Query/ChartPrefs.tsx
+++ b/packages/page-staking/src/Query/ChartPrefs.tsx
@@ -48,8 +48,8 @@ function extractPrefs (labels: string[], prefs: DeriveStakerPrefs[]): LineData {
 function ChartPrefs ({ labels, validatorId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const params = useMemo(() => [validatorId, false], [validatorId]);
-  const stakerPrefs = useCall<DeriveStakerPrefs[]>(api.derive.staking.stakerPrefs, params);
+  const params = useMemo(() => [validatorId, false] as const, [validatorId]);
+  const stakerPrefs = useCall(api.derive.staking.stakerPrefs, params);
   const [values, setValues] = useState<LineData>([]);
 
   useEffect(

--- a/packages/page-staking/src/Query/ChartRewards.tsx
+++ b/packages/page-staking/src/Query/ChartRewards.tsx
@@ -60,10 +60,10 @@ function extractRewards (labels: string[], erasRewards: DeriveEraRewards[], ownS
 function ChartRewards ({ labels, validatorId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const params = useMemo(() => [validatorId, false], [validatorId]);
-  const ownSlashes = useCall<DeriveOwnSlashes[]>(api.derive.staking.ownSlashes, params);
-  const erasRewards = useCall<DeriveEraRewards[]>(api.derive.staking.erasRewards);
-  const stakerPoints = useCall<DeriveStakerPoints[]>(api.derive.staking.stakerPoints, params);
+  const params = useMemo(() => [validatorId, false] as const, [validatorId]);
+  const ownSlashes = useCall(api.derive.staking.ownSlashes, params);
+  const erasRewards = useCall(api.derive.staking.erasRewards);
+  const stakerPoints = useCall(api.derive.staking.stakerPoints, params);
   const [values, setValues] = useState<LineData>([]);
 
   const { currency, divisor } = useMemo(

--- a/packages/page-staking/src/Query/ChartStake.tsx
+++ b/packages/page-staking/src/Query/ChartStake.tsx
@@ -52,8 +52,8 @@ function extractStake (labels: string[], exposures: DeriveOwnExposure[], divisor
 function ChartStake ({ labels, validatorId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const params = useMemo(() => [validatorId, false], [validatorId]);
-  const ownExposures = useCall<DeriveOwnExposure[]>(api.derive.staking.ownExposures, params);
+  const params = useMemo(() => [validatorId, false] as const, [validatorId]);
+  const ownExposures = useCall(api.derive.staking.ownExposures, params);
   const [values, setValues] = useState<LineData>([]);
 
   const { currency, divisor } = useMemo(

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { INumber } from '@polkadot/types/types';
-
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -27,10 +25,10 @@ function Query ({ className }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const { value } = useParams<{ value: string }>();
   const [validatorId, setValidatorId] = useState<string | null>(value || null);
-  const eras = useCall<INumber[]>(api.derive.staking.erasHistoric);
+  const eras = useCall(api.derive.staking.erasHistoric);
 
   const labels = useMemo(
-    () => eras && eras.map((e) => e.toHuman() as string),
+    () => eras && eras.map((e) => e.toHuman()),
     [eras]
   );
 

--- a/packages/page-staking/src/Query/useBlockCounts.tsx
+++ b/packages/page-staking/src/Query/useBlockCounts.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionIndexes } from '@polkadot/api-derive/types';
 import type { u32 } from '@polkadot/types';
 import type { SessionRewards } from '../types.js';
 
@@ -13,8 +12,8 @@ import { BN_ONE, BN_ZERO, isFunction } from '@polkadot/util';
 function useBlockCountsImpl (accountId: string, sessionRewards: SessionRewards[]): u32[] {
   const { api } = useApi();
   const mountedRef = useIsMountedRef();
-  const indexes = useCall<DeriveSessionIndexes>(api.derive.session?.indexes);
-  const current = useCall<u32>(api.query.imOnline?.authoredBlocks, [indexes?.currentIndex, accountId]);
+  const indexes = useCall(api.derive.session?.indexes);
+  const current = useCall(api.query.imOnline?.authoredBlocks, [indexes?.currentIndex, accountId]);
   const [counts, setCounts] = useState<u32[]>([]);
   const [historic, setHistoric] = useState<u32[]>([]);
 

--- a/packages/page-staking/src/Slashes/Summary.tsx
+++ b/packages/page-staking/src/Slashes/Summary.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import type { SlashEra } from './types.js';
 
 import React, { useMemo } from 'react';
@@ -20,7 +19,7 @@ interface Props {
 function Summary ({ slash: { era, nominators, reporters, total, validators } }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session?.progress);
+  const sessionInfo = useCall(api.derive.session?.progress);
 
   const [blockProgress, blockEnd] = useMemo(
     () => sessionInfo

--- a/packages/page-staking/src/Targets/Summary.tsx
+++ b/packages/page-staking/src/Targets/Summary.tsx
@@ -52,7 +52,7 @@ function getProgressInfo (value?: BN, total?: BN): ProgressInfo {
 function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minNominatorBond, stakedReturn, totalIssuance, totalStaked }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const lastReward = useCall<BN>(lastEra && api.query.staking.erasValidatorReward, [lastEra], OPT_REWARD);
+  const lastReward = useCall(lastEra && api.query.staking.erasValidatorReward, [lastEra], OPT_REWARD);
 
   const progressStake = useMemo(
     () => getProgressInfo(totalStaked, totalIssuance),

--- a/packages/page-staking/src/Validators/Address/index.tsx
+++ b/packages/page-staking/src/Validators/Address/index.tsx
@@ -83,9 +83,9 @@ const transformSlashes = {
 };
 
 function useAddressCalls (api: ApiPromise, address: string, isMain?: boolean) {
-  const params = useMemo(() => [address], [address]);
+  const params = useMemo(() => [address] as const, [address]);
   const accountInfo = useDeriveAccountInfo(address);
-  const slashingSpans = useCall<SlashingSpans | null>(!isMain && api.query.staking.slashingSpans, params, transformSlashes);
+  const slashingSpans = useCall(!isMain && api.query.staking.slashingSpans, params, transformSlashes);
 
   return { accountInfo, slashingSpans };
 }

--- a/packages/page-staking/src/Validators/index.tsx
+++ b/packages/page-staking/src/Validators/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveHeartbeats, DeriveStakingOverview } from '@polkadot/api-derive/types';
+import type { DeriveStakingOverview } from '@polkadot/api-derive/types';
 import type { StakerState } from '@polkadot/react-hooks/types';
 import type { BN } from '@polkadot/util';
 import type { NominatedByMap, SortedTargets } from '../types.js';
@@ -42,7 +42,7 @@ function Overview ({ className = '', favorites, hasAccounts, hasQueries, minComm
   const { byAuthor, eraPoints } = useBlockAuthors();
   const [intentIndex, _setIntentIndex] = useState(0);
   const [typeIndex, setTypeIndex] = useState(1);
-  const recentlyOnline = useCall<DeriveHeartbeats>(api.derive.imOnline?.receivedHeartbeats);
+  const recentlyOnline = useCall(api.derive.imOnline?.receivedHeartbeats);
 
   const setIntentIndex = useCallback(
     (index: number): void => {

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveStakingOverview } from '@polkadot/api-derive/types';
 import type { AppProps as Props } from '@polkadot/react-components/types';
 import type { ElectionStatus, ParaValidatorIndex, ValidatorId } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
@@ -52,7 +51,7 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
   const [favorites, toggleFavorite] = useFavorites(STORE_FAVS_BASE);
   const [loadNominations, setLoadNominations] = useState(false);
   const nominatedBy = useNominations(loadNominations);
-  const stakingOverview = useCall<DeriveStakingOverview>(api.derive.staking.overview);
+  const stakingOverview = useCall(api.derive.staking.overview);
   const [isInElection, minCommission, paraValidators] = useCallMulti<[boolean, BN | undefined, Record<string, boolean>]>([
     api.query.staking.eraElectionStatus,
     api.query.staking.minCommission,

--- a/packages/page-staking/src/useIdentities.ts
+++ b/packages/page-staking/src/useIdentities.ts
@@ -22,7 +22,7 @@ const OPT_CALL = {
 
 function useIdentitiesImpl (validatorIds: string[] = []): Result | undefined {
   const { api } = useApi();
-  const allIdentity = useCall<Result>(api.derive.accounts.hasIdentityMulti, [validatorIds], OPT_CALL);
+  const allIdentity = useCall(api.derive.accounts.hasIdentityMulti, [validatorIds], OPT_CALL);
 
   return allIdentity;
 }

--- a/packages/page-staking/src/useNominations.ts
+++ b/packages/page-staking/src/useNominations.ts
@@ -36,7 +36,7 @@ function extractNominators (nominations: [StorageKey, Option<Nominations>][]): N
 
 function useNominationsImpl (isActive = true): NominatedByMap | undefined {
   const { api } = useApi();
-  const nominators = useCall<[StorageKey, Option<Nominations>][]>(isActive && api.query.staking.nominators.entries);
+  const nominators: [StorageKey, Option<Nominations>][] = useCall(isActive && api.query.staking.nominators.entries);
 
   return useMemo(
     () => nominators && extractNominators(nominators),

--- a/packages/page-staking/src/useSortedTargets.ts
+++ b/packages/page-staking/src/useSortedTargets.ts
@@ -284,9 +284,9 @@ function useSortedTargetsImpl (favorites: string[], withLedger: boolean): Sorted
     api.query.staking.minValidatorBond,
     api.query.balances?.totalIssuance
   ], OPT_MULTI);
-  const electedInfo = useCall<DeriveStakingElected>(api.derive.staking.electedInfo, [{ ...DEFAULT_FLAGS_ELECTED, withLedger }]);
-  const waitingInfo = useCall<DeriveStakingWaiting>(api.derive.staking.waitingInfo, [{ ...DEFAULT_FLAGS_WAITING, withLedger }]);
-  const lastEraInfo = useCall<LastEra>(api.derive.session.info, undefined, OPT_ERA);
+  const electedInfo = useCall(api.derive.staking.electedInfo, [{ ...DEFAULT_FLAGS_ELECTED, withLedger }]);
+  const waitingInfo = useCall(api.derive.staking.waitingInfo, [{ ...DEFAULT_FLAGS_WAITING, withLedger }]);
+  const lastEraInfo = useCall(api.derive.session.info, undefined, OPT_ERA);
 
   const baseInfo = useMemo(
     () => electedInfo && lastEraInfo && totalIssuance && waitingInfo

--- a/packages/page-staking2/src/Pools/useAmountError.ts
+++ b/packages/page-staking2/src/Pools/useAmountError.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import { useMemo } from 'react';
@@ -10,7 +9,7 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 function useAmountErrorImpl (accountId?: string | null, amount?: BN | null, minAmount?: BN | null): boolean {
   const { api } = useApi();
-  const balances = useCall<DeriveBalancesAll>(!!accountId && api.derive.balances.all, [accountId]);
+  const balances = useCall(!!accountId && api.derive.balances.all, [accountId]);
 
   return useMemo(
     () => !amount || amount.isZero() || !minAmount || minAmount.gt(amount) || (

--- a/packages/page-staking2/src/useSessionInfo.ts
+++ b/packages/page-staking2/src/useSessionInfo.ts
@@ -26,7 +26,7 @@ function useSessionInfoImpl (): SessionInfo {
   const { api } = useApi();
   const activeEra = useCall(api.query.staking.activeEra, undefined, OPT_ACTIVEERA);
   const currentEra = useCall(api.query.staking.currentEra, undefined, OPT_CURRENTERA);
-  const currentSession = useCall<u32>(api.query.session.currentIndex);
+  const currentSession = useCall(api.query.session.currentIndex);
 
   return useMemo(
     () => ({ activeEra, currentEra, currentSession }),

--- a/packages/page-tech-comm/src/App.tsx
+++ b/packages/page-tech-comm/src/App.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CollectiveType } from '@polkadot/react-hooks/types';
-import type { Hash } from '@polkadot/types/interfaces';
 
 import React, { useMemo } from 'react';
 import { Route, Routes } from 'react-router';
@@ -27,8 +26,8 @@ function TechCommApp ({ basePath, className, type }: Props): React.ReactElement<
   const { t } = useTranslation();
   const { api } = useApi();
   const { isMember, members, prime } = useCollectiveMembers(type);
-  const hasProposals = useCall<boolean>(api.derive[type].hasProposals);
-  const proposalHashes = useCall<Hash[]>(api.derive[type].proposalHashes);
+  const hasProposals = useCall(api.derive[type].hasProposals);
+  const proposalHashes = useCall(api.derive[type].proposalHashes);
 
   const items = useMemo(() => [
     {

--- a/packages/page-tech-comm/src/Overview/Summary.tsx
+++ b/packages/page-tech-comm/src/Overview/Summary.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-tech-comm authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { u32 } from '@polkadot/types';
 import type { ComponentProps as Props } from '../types.js';
 
 import React from 'react';
@@ -15,7 +14,7 @@ import { useTranslation } from '../translate.js';
 function Summary ({ className = '', members, proposalHashes, type }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const proposalCount = useCall<u32>(api.derive[type].proposalCount);
+  const proposalCount = useCall(api.derive[type].proposalCount);
 
   return (
     <SummaryBox className={className}>

--- a/packages/page-tech-comm/src/Proposals/Proposal.tsx
+++ b/packages/page-tech-comm/src/Proposals/Proposal.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-tech-comm authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveCollectiveProposal } from '@polkadot/api-derive/types';
 import type { CollectiveType } from '@polkadot/react-hooks/types';
 import type { Hash } from '@polkadot/types/interfaces';
 
@@ -27,7 +26,7 @@ interface Props {
 
 function Proposal ({ className = '', imageHash, isMember, members, prime, type }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const derive = useCall<DeriveCollectiveProposal>(api.derive[type as 'technicalCommittee'].proposal, [imageHash]);
+  const derive = useCall(api.derive[type as 'technicalCommittee'].proposal, [imageHash]);
   const { hasFailed, isCloseable, isVoteable, remainingBlocks } = useVotingStatus(derive?.votes, members.length, type);
   const modLocation = useCollectiveInstance(type);
 

--- a/packages/page-tech-comm/src/useCounter.ts
+++ b/packages/page-tech-comm/src/useCounter.ts
@@ -11,7 +11,7 @@ const OPT = {
 
 function useCounterImpl (): number {
   const { api, isApiReady } = useApi();
-  const counter = useCall<number>(isApiReady && api.derive.technicalCommittee?.proposals, undefined, OPT) || 0;
+  const counter = useCall(isApiReady && api.derive.technicalCommittee?.proposals, undefined, OPT) || 0;
 
   return counter;
 }

--- a/packages/page-treasury/src/Overview/Summary.tsx
+++ b/packages/page-treasury/src/Overview/Summary.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-treasury authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BN } from '@polkadot/util';
-
 import React, { useMemo } from 'react';
 
 import { CardSummary, SummaryBox } from '@polkadot/react-components';
@@ -21,7 +19,7 @@ function Summary ({ approvalCount, proposalCount }: Props): React.ReactElement<P
   const { t } = useTranslation();
   const { api } = useApi();
   const bestNumber = useBestNumber();
-  const totalProposals = useCall<BN>(api.query.treasury.proposalCount);
+  const totalProposals = useCall(api.query.treasury.proposalCount);
   const { burn, pendingBounties, pendingProposals, spendPeriod, value } = useTreasury();
 
   const spendable = useMemo(

--- a/packages/page-treasury/src/Overview/index.tsx
+++ b/packages/page-treasury/src/Overview/index.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-treasury authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveTreasuryProposals } from '@polkadot/api-derive/types';
-
 import React from 'react';
 
 import { Button } from '@polkadot/react-components';
@@ -20,7 +18,7 @@ interface Props {
 
 function Overview ({ className, isMember, members }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const info = useCall<DeriveTreasuryProposals>(api.derive.treasury.proposals);
+  const info = useCall(api.derive.treasury.proposals);
 
   return (
     <div className={className}>

--- a/packages/page-treasury/src/Tips/TipEndorse.tsx
+++ b/packages/page-treasury/src/Tips/TipEndorse.tsx
@@ -32,7 +32,7 @@ function TipEndorse ({ defaultId, hash, isMember, isTipped, median, members, rec
   const [isOpen, toggleOpen] = useToggle();
   const [accountId, setAccountId] = useState<string | null>(defaultId);
   const [value, setValue] = useState<BN | undefined>();
-  const totalBalance = useCall<BN>(api.derive.balances?.all, [recipient], OPT);
+  const totalBalance = useCall(api.derive.balances?.all, [recipient], OPT);
 
   const tipTx = (api.tx.tips || api.tx.treasury).tip;
 

--- a/packages/page-treasury/src/Tips/TipReason.tsx
+++ b/packages/page-treasury/src/Tips/TipReason.tsx
@@ -22,7 +22,7 @@ const OPT = {
 
 function TipReason ({ hash }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const reasonText = useCall<string | null>((api.query.tips || api.query.treasury).reasons, [hash], OPT);
+  const reasonText = useCall((api.query.tips || api.query.treasury).reasons, [hash], OPT);
 
   return (
     <td className='start all'>{reasonText || hash.toHex()}</td>

--- a/packages/page-treasury/src/Tips/Tips.tsx
+++ b/packages/page-treasury/src/Tips/Tips.tsx
@@ -53,7 +53,7 @@ function Tips ({ className = '', defaultId, hashes, isMember, members, onSelectT
   const { api } = useApi();
   const [onlyUntipped, setOnlyUntipped] = useState(false);
   const bestNumber = useBestNumber();
-  const tipsWithHashes = useCall<[[string[]], Option<PalletTipsOpenTip>[]]>(hashes && (api.query.tips || api.query.treasury).tips.multi, [hashes], TIP_OPTS);
+  const tipsWithHashes: [[string[]], Option<PalletTipsOpenTip>[]] = useCall(hashes && (api.query.tips || api.query.treasury).tips.multi, [hashes], TIP_OPTS);
 
   const tips = useMemo(
     () => extractTips(tipsWithHashes, hashes),

--- a/packages/page-treasury/src/useCounter.ts
+++ b/packages/page-treasury/src/useCounter.ts
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/app-treasury authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveTreasuryProposals } from '@polkadot/api-derive/types';
-
 import { useMemo } from 'react';
 
 import { createNamedHook, useAccounts, useApi, useCall } from '@polkadot/react-hooks';
@@ -10,7 +8,7 @@ import { createNamedHook, useAccounts, useApi, useCall } from '@polkadot/react-h
 function useCounterImpl (): number {
   const { hasAccounts } = useAccounts();
   const { api, isApiReady } = useApi();
-  const proposals = useCall<DeriveTreasuryProposals>(isApiReady && hasAccounts && api.derive.treasury?.proposals);
+  const proposals = useCall(isApiReady && hasAccounts && api.derive.treasury?.proposals);
 
   return useMemo(
     () => proposals?.proposals.length || 0,

--- a/packages/react-components/src/StakingRedeemable.tsx
+++ b/packages/react-components/src/StakingRedeemable.tsx
@@ -37,7 +37,7 @@ function StakingRedeemable ({ className = '', isPool, stakingInfo }: Props): Rea
   const { api } = useApi();
   const { allAccounts } = useAccounts();
   const { t } = useTranslation();
-  const spanCount = useCall<number>(api.query.staking.slashingSpans, [stakingInfo?.stashId], OPT_SPAN);
+  const spanCount = useCall(api.query.staking.slashingSpans, [stakingInfo?.stashId], OPT_SPAN);
 
   if (!stakingInfo?.redeemable?.gtn(0)) {
     return null;

--- a/packages/react-components/src/StakingUnbonding.tsx
+++ b/packages/react-components/src/StakingUnbonding.tsx
@@ -67,7 +67,7 @@ function extractTotals (stakingInfo?: DeriveStakingAccountPartial, progress?: De
 
 function StakingUnbonding ({ className = '', iconPosition = 'left', stakingInfo }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const progress = useCall<DeriveSessionProgress>(api.derive.session.progress);
+  const progress = useCall(api.derive.session.progress);
   const { t } = useTranslation();
 
   const [mapped, total, isStalled] = useMemo(

--- a/packages/react-components/src/VoteValue.tsx
+++ b/packages/react-components/src/VoteValue.tsx
@@ -85,7 +85,7 @@ function getValues (selectedId: string | null | undefined, noDefault: boolean | 
 function VoteValue ({ accountId, autoFocus, label, noDefault, onChange }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [accountId]);
+  const allBalances = useCall(api.derive.balances?.all, [accountId]);
   const [{ defaultValue, maxValue, selectedId, value }, setValue] = useState<ValueState>({ defaultValue: BN_ZERO, maxValue: BN_ZERO, value: BN_ZERO });
 
   useEffect((): void => {

--- a/packages/react-components/src/modals/Transfer.tsx
+++ b/packages/react-components/src/modals/Transfer.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { AccountInfoWithProviders, AccountInfoWithRefCount } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 
@@ -57,8 +56,8 @@ function Transfer ({ className = '', onClose, recipientId: propRecipientId, send
   const [recipientId, setRecipientId] = useState<string | null>(null);
   const [senderId, setSenderId] = useState<string | null>(null);
   const [[, recipientPhish], setPhishing] = useState<[string | null, string | null]>([null, null]);
-  const balances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [propSenderId || senderId]);
-  const accountInfo = useCall<AccountInfoWithProviders | AccountInfoWithRefCount>(api.query.system.account, [propSenderId || senderId]);
+  const balances = useCall(api.derive.balances?.all, [propSenderId || senderId]);
+  const accountInfo = useCall(api.query.system.account, [propSenderId || senderId]);
 
   useEffect((): void => {
     const fromId = propSenderId || senderId as string;

--- a/packages/react-hooks/src/ctx/BlockAuthors.tsx
+++ b/packages/react-hooks/src/ctx/BlockAuthors.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HeaderExtended } from '@polkadot/api-derive/types';
-import type { EraRewardPoints } from '@polkadot/types/interfaces';
 import type { BlockAuthors } from './types.js';
 
 import React, { useEffect, useState } from 'react';
@@ -25,7 +24,7 @@ export const BlockAuthorsCtx = React.createContext<BlockAuthors>(EMPTY_STATE);
 
 export function BlockAuthorsCtxRoot ({ children }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
-  const queryPoints = useCall<EraRewardPoints>(isApiReady && api.derive.staking?.currentPoints);
+  const queryPoints = useCall(isApiReady && api.derive.staking?.currentPoints);
   const [state, setState] = useState<BlockAuthors>(EMPTY_STATE);
 
   // No unsub, global context - destroyed on app close

--- a/packages/react-hooks/src/ctx/BlockEvents.tsx
+++ b/packages/react-hooks/src/ctx/BlockEvents.tsx
@@ -104,7 +104,7 @@ async function manageEvents (api: ApiPromise, prev: PrevHashes, records: Vec<Eve
 export function BlockEventsCtxRoot ({ children }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
   const [state, setState] = useState<BlockEvents>(DEFAULT_EVENTS);
-  const records = useCall<Vec<EventRecord>>(isApiReady && api.query.system.events);
+  const records = useCall(isApiReady && api.query.system.events);
   const prevHashes = useRef({ block: null, event: null });
 
   useEffect((): void => {

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -36,6 +36,16 @@ export type TxSource<T extends TxDefs> = [T, boolean];
 
 export type CollectiveType = 'alliance' | 'council' | 'membership' | 'technicalCommittee';
 
+export type Diverge<TType, TIntersect> = TType extends infer TDiverge & TIntersect ? TDiverge : TType
+
+export type Leading<T extends any[]> = T extends [...infer Leading, any] ? Leading : []
+
+export type NullablePartial<T> = { [P in keyof T]?: T[P] | null; }
+
+export type PickKnownKeys<T> = {
+  [P in keyof T as string extends P ? never : number extends P ? never : P]: T[P]
+}
+
 export interface ModalState {
   isOpen: boolean;
   onOpen: () => void;

--- a/packages/react-hooks/src/useAccountInfo.ts
+++ b/packages/react-hooks/src/useAccountInfo.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Nominations, ValidatorPrefs } from '@polkadot/types/interfaces';
 import type { KeyringJson$Meta } from '@polkadot/ui-keyring/types';
 import type { AddressFlags, AddressIdentity, UseAccountInfo } from './types.js';
 
@@ -43,8 +42,8 @@ function useAccountInfoImpl (value: string | null, isContract = false): UseAccou
   const { accounts: { isAccount }, addresses: { isAddress } } = useKeyring();
   const accountInfo = useDeriveAccountInfo(value);
   const accountFlags = useDeriveAccountFlags(value);
-  const nominator = useCall<Nominations>(api.query.staking?.nominators, [value]);
-  const validator = useCall<ValidatorPrefs>(api.query.staking?.validators, [value]);
+  const nominator = useCall(api.query.staking?.nominators, [value]);
+  const validator = useCall(api.query.staking?.validators, [value]);
   const [accountIndex, setAccountIndex] = useState<string | undefined>(undefined);
   const [tags, setSortedTags] = useState<string[]>([]);
   const [name, setName] = useState('');

--- a/packages/react-hooks/src/useAvailableSlashes.ts
+++ b/packages/react-hooks/src/useAvailableSlashes.ts
@@ -19,8 +19,8 @@ type Unsub = () => void;
 
 function useAvailableSlashesImpl (): [BN, PalletStakingUnappliedSlash[]][] {
   const { api } = useApi();
-  const indexes = useCall<DeriveSessionIndexes>(api.derive.session?.indexes);
-  const earliestSlash = useCall<Option<EraIndex>>(api.query.staking?.earliestUnappliedSlash);
+  const indexes: DeriveSessionIndexes = useCall(api.derive.session?.indexes);
+  const earliestSlash: Option<EraIndex> = useCall(api.query.staking?.earliestUnappliedSlash);
   const mountedRef = useIsMountedRef();
   const [slashes, setSlashes] = useState<[BN, PalletStakingUnappliedSlash[]][]>([]);
 

--- a/packages/react-hooks/src/useBalancesAll.ts
+++ b/packages/react-hooks/src/useBalancesAll.ts
@@ -16,7 +16,7 @@ import { useCall } from './useCall.js';
 function useBalancesAllImpl (accountAddress: string): DeriveBalancesAll | undefined {
   const { api } = useApi();
 
-  return useCall<DeriveBalancesAll>(api.derive.balances?.all, [accountAddress]);
+  return useCall(api.derive.balances?.all, [accountAddress]);
 }
 
 export const useBalancesAll = createNamedHook('useBalancesAll', useBalancesAllImpl);

--- a/packages/react-hooks/src/useBestHash.ts
+++ b/packages/react-hooks/src/useBestHash.ts
@@ -14,7 +14,7 @@ const OPT = {
 function useBestHashImpl (): string | undefined {
   const { api } = useApi();
 
-  return useCall<string>(api.rpc.chain.subscribeNewHeads, undefined, OPT);
+  return useCall(api.rpc.chain.subscribeNewHeads, undefined, OPT);
 }
 
 export const useBestHash = createNamedHook('useBestHash', useBestHashImpl);

--- a/packages/react-hooks/src/useBestNumber.ts
+++ b/packages/react-hooks/src/useBestNumber.ts
@@ -1,16 +1,14 @@
 // Copyright 2017-2023 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BlockNumber } from '@polkadot/types/interfaces';
-
 import { createNamedHook } from './createNamedHook.js';
 import { useApi } from './useApi.js';
 import { useCall } from './useCall.js';
 
-function useBestNumberImpl (): BlockNumber | undefined {
+function useBestNumberImpl () {
   const { api } = useApi();
 
-  return useCall<BlockNumber>(api.derive.chain.bestNumber);
+  return useCall(api.derive.chain.bestNumber);
 }
 
 export const useBestNumber = createNamedHook('useBestNumber', useBestNumberImpl);

--- a/packages/react-hooks/src/useCall.ts
+++ b/packages/react-hooks/src/useCall.ts
@@ -164,7 +164,7 @@ export function useCall<
   TFunc extends TrackFn | undefined | null | boolean,
   TDivergedFunc extends Diverge<Exclude<TFunc, undefined | null | boolean>, StorageEntryPromiseOverloads & QueryableStorageEntry<any, any> & PromiseResult<GenericStorageEntryFunction>>,
   TParams extends TDivergedFunc extends AnyFunction
-    ? NullablePartial<Leading<Parameters<TDivergedFunc>>>
+    ? Readonly<NullablePartial<Leading<Parameters<TDivergedFunc>>>>
     : any[],
   TFuncResult extends TDivergedFunc extends AnyFunction
     ? TDivergedFunc extends PromiseResult< (...args: any) => Observable<infer TResult>>

--- a/packages/react-hooks/src/useDelegations.ts
+++ b/packages/react-hooks/src/useDelegations.ts
@@ -7,11 +7,11 @@ import { useAccounts, useApi, useCall } from '@polkadot/react-hooks';
 
 import { createNamedHook } from './createNamedHook.js';
 
-function useDelegationsImpl (): PalletDemocracyVoteVoting[] | undefined {
+function useDelegationsImpl () {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
 
-  return useCall<PalletDemocracyVoteVoting[]>(api.query.democracy?.votingOf?.multi, [allAccounts]);
+  return useCall(api.query.democracy?.votingOf?.multi, [allAccounts]);
 }
 
 export const useDelegations = createNamedHook('useDelegations', useDelegationsImpl);

--- a/packages/react-hooks/src/useDelegations.ts
+++ b/packages/react-hooks/src/useDelegations.ts
@@ -7,11 +7,11 @@ import { useAccounts, useApi, useCall } from '@polkadot/react-hooks';
 
 import { createNamedHook } from './createNamedHook.js';
 
-function useDelegationsImpl () {
+function useDelegationsImpl (): PalletDemocracyVoteVoting[] {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
 
-  return useCall(api.query.democracy?.votingOf?.multi, [allAccounts]);
+  return useCall(api.query.democracy?.votingOf?.multi, [allAccounts]) as PalletDemocracyVoteVoting[];
 }
 
 export const useDelegations = createNamedHook('useDelegations', useDelegationsImpl);

--- a/packages/react-hooks/src/useDeriveAccountInfo.ts
+++ b/packages/react-hooks/src/useDeriveAccountInfo.ts
@@ -11,7 +11,7 @@ import { useSystemApi } from './useSystemApi.js';
 function useDeriveAccountInfoImpl (value?: AccountId | AccountIndex | Address | Uint8Array | string | null): DeriveAccountInfo | undefined {
   const api = useSystemApi();
 
-  return useCall<DeriveAccountInfo>(api && api.derive.accounts.info, [value]);
+  return useCall(api && api.derive.accounts.info, [value]);
 }
 
 export const useDeriveAccountInfo = createNamedHook('useDeriveAccountInfo', useDeriveAccountInfoImpl);

--- a/packages/react-hooks/src/useEventTrigger.ts
+++ b/packages/react-hooks/src/useEventTrigger.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AugmentedEvent } from '@polkadot/api/types';
-import type { Vec } from '@polkadot/types';
 import type { EventRecord } from '@polkadot/types/interfaces';
 
 import { useEffect, useState } from 'react';
@@ -32,7 +31,7 @@ function useEventTriggerImpl (checks: EventCheck[], filter: (record: EventRecord
   const [state, setState] = useState(() => EMPTY_RESULT);
   const memoChecks = useMemoValue(checks);
   const mountedRef = useIsMountedRef();
-  const eventRecords = useCall<Vec<EventRecord>>(api.query.system.events);
+  const eventRecords = useCall(api.query.system.events);
 
   useEffect((): void => {
     if (mountedRef.current && eventRecords) {

--- a/packages/react-hooks/src/useExtrinsicTrigger.ts
+++ b/packages/react-hooks/src/useExtrinsicTrigger.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
-import type { SignedBlockExtended } from '@polkadot/api-derive/types';
 
 import { useEffect, useState } from 'react';
 
@@ -19,7 +18,7 @@ function useExtrinsicTriggerImpl (checks: ExtrinsicCheck[]): string {
   const [trigger, setTrigger] = useState('0');
   const mountedRef = useIsMountedRef();
   const memoChecks = useMemoValue(checks);
-  const block = useCall<SignedBlockExtended>(api.derive.chain.subscribeNewBlocks);
+  const block = useCall(api.derive.chain.subscribeNewBlocks);
 
   useEffect((): void => {
     mountedRef.current && block && block.extrinsics && block.extrinsics.filter(({ extrinsic }) =>

--- a/packages/react-hooks/src/useInflation.ts
+++ b/packages/react-hooks/src/useInflation.ts
@@ -46,8 +46,8 @@ function calcInflation (api: ApiPromise, totalStaked: BN, totalIssuance: BN, num
 
 function useInflationImpl (totalStaked?: BN): Inflation {
   const { api } = useApi();
-  const totalIssuance = useCall<BN>(api.query.balances?.totalIssuance);
-  const auctionCounter = useCall<BN>(api.query.auctions?.auctionCounter);
+  const totalIssuance: BN = useCall(api.query.balances?.totalIssuance);
+  const auctionCounter: BN = useCall(api.query.auctions?.auctionCounter);
   const [state, setState] = useState<Inflation>(EMPTY);
 
   useEffect((): void => {

--- a/packages/react-hooks/src/useOwnEraRewards.ts
+++ b/packages/react-hooks/src/useOwnEraRewards.ts
@@ -105,12 +105,12 @@ function useOwnEraRewardsImpl (maxEras?: number, ownValidators?: StakerState[], 
   const { api } = useApi();
   const mountedRef = useIsMountedRef();
   const stashIds = useOwnStashIds(additional);
-  const allEras = useCall<EraIndex[]>(api.derive.staking?.erasHistoric);
+  const allEras: EraIndex[] = useCall(api.derive.staking?.erasHistoric);
   const [{ filteredEras, validatorEras }, setFiltered] = useState<Filtered>(EMPTY_FILTERED);
   const [state, setState] = useState<State>(EMPTY_STATE);
-  const stakerRewards = useCall<[[string[]], DeriveStakerReward[][]]>(!ownValidators?.length && !!filteredEras.length && stashIds && api.derive.staking?.stakerRewardsMultiEras, [stashIds, filteredEras], OPT_REWARDS);
-  const erasPoints = useCall<DeriveEraPoints[]>(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasPoints, [filteredEras, false]);
-  const erasRewards = useCall<DeriveEraRewards[]>(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasRewards, [filteredEras, false]);
+  const stakerRewards: [[string[]], DeriveStakerReward[][]] = useCall(!ownValidators?.length && !!filteredEras.length && stashIds && api.derive.staking?.stakerRewardsMultiEras, [stashIds, filteredEras], OPT_REWARDS);
+  const erasPoints: DeriveEraPoints[] = useCall(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasPoints, [filteredEras, false]);
+  const erasRewards: DeriveEraRewards[] = useCall(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasRewards, [filteredEras, false]);
 
   useEffect((): void => {
     setState({ allRewards: null, isLoadingRewards: true, rewardCount: 0 });

--- a/packages/react-hooks/src/useOwnStashes.ts
+++ b/packages/react-hooks/src/useOwnStashes.ts
@@ -40,8 +40,8 @@ function useOwnStashesImpl (additional?: string[]): [string, IsInKeyring][] | un
     [allAccounts, additional]
   );
 
-  const ownBonded = useCall<Option<AccountId>[]>(ids.length !== 0 && api.query.staking?.bonded.multi, [ids]);
-  const ownLedger = useCall<Option<StakingLedger>[]>(ids.length !== 0 && api.query.staking?.ledger.multi, [ids]);
+  const ownBonded: Option<AccountId>[] = useCall(ids.length !== 0 && api.query.staking?.bonded.multi, [ids]);
+  const ownLedger: Option<StakingLedger>[] = useCall(ids.length !== 0 && api.query.staking?.ledger.multi, [ids]);
 
   return useMemo(
     () => ids.length

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -207,7 +207,7 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
     [api, hashOrBounded]
   );
 
-  const optStatus = useCall<Option<PalletPreimageRequestStatus>>(!inlineData && paramsStatus && api.query.preimage?.statusFor, paramsStatus);
+  const optStatus: Option<PalletPreimageRequestStatus> = useCall(!inlineData && paramsStatus && api.query.preimage?.statusFor, paramsStatus);
 
   // from the retrieved status (if any), get the on-chain stored bytes
   const { paramsBytes, resultPreimageFor } = useMemo(
@@ -217,7 +217,7 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
     [optStatus, resultPreimageHash]
   );
 
-  const optBytes = useCall<Option<Bytes>>(paramsBytes && api.query.preimage?.preimageFor, paramsBytes);
+  const optBytes: Option<Bytes> = useCall(paramsBytes && api.query.preimage?.preimageFor, paramsBytes);
 
   // extract all the preimage info we have retrieved
   return useMemo(

--- a/packages/react-hooks/src/useProxies.ts
+++ b/packages/react-hooks/src/useProxies.ts
@@ -24,11 +24,11 @@ const OPTS = {
       )
 };
 
-function useProxiesImpl (): [PalletProxyProxyDefinition[], BN][] | undefined {
+function useProxiesImpl () {
   const { api } = useApi();
   const { allAccounts } = useAccounts();
 
-  return useCall<[PalletProxyProxyDefinition[], BN][]>(api.query.proxy?.proxies.multi, [allAccounts], OPTS);
+  return useCall(api.query.proxy?.proxies.multi, [allAccounts], OPTS);
 }
 
 export const useProxies = createNamedHook('useProxies', useProxiesImpl);

--- a/packages/react-hooks/src/useRegistrars.ts
+++ b/packages/react-hooks/src/useRegistrars.ts
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
-import type { RegistrarInfo } from '@polkadot/types/interfaces';
 import type { Registrar } from './types.js';
 
 import { useMemo } from 'react';
@@ -26,7 +24,7 @@ interface State {
 function useRegistrarsImpl (skipQuery?: boolean): State {
   const { api } = useApi();
   const { allAccounts, hasAccounts } = useAccounts();
-  const query = useCall<Option<RegistrarInfo>[]>(!skipQuery && api.query.identity?.registrars);
+  const query = useCall(!skipQuery && api.query.identity?.registrars);
 
   // determine if we have a registrar or not - registrars are allowed to approve
   return useMemo(

--- a/packages/react-hooks/src/useStakingInfo.ts
+++ b/packages/react-hooks/src/useStakingInfo.ts
@@ -1,16 +1,14 @@
 // Copyright 2017-2023 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveStakingAccount } from '@polkadot/api-derive/types';
-
 import { createNamedHook } from './createNamedHook.js';
 import { useApi } from './useApi.js';
 import { useCall } from './useCall.js';
 
-function useStakingInfoImpl (accountId: string | null): DeriveStakingAccount | undefined {
+function useStakingInfoImpl (accountId: string | null) {
   const { api } = useApi();
 
-  return useCall<DeriveStakingAccount>(api.derive.staking?.account, [accountId]);
+  return useCall(api.derive.staking?.account, [accountId]);
 }
 
 export const useStakingInfo = createNamedHook('useStakingInfo', useStakingInfoImpl);

--- a/packages/react-hooks/src/useSubidentities.ts
+++ b/packages/react-hooks/src/useSubidentities.ts
@@ -1,16 +1,14 @@
 // Copyright 2017-2023 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountId, BalanceOf } from '@polkadot/types/interfaces';
-
 import { createNamedHook } from './createNamedHook.js';
 import { useApi } from './useApi.js';
 import { useCall } from './useCall.js';
 
-function useSubidentitiesImpl (address: string): AccountId[] | undefined {
+function useSubidentitiesImpl (address: string) {
   const { api } = useApi();
 
-  return useCall<[BalanceOf, AccountId[]]>(api.query.identity?.subsOf, [address])?.[1];
+  return useCall(api.query.identity?.subsOf, [address])?.[1];
 }
 
 export const useSubidentities = createNamedHook('useSubidentities', useSubidentitiesImpl);

--- a/packages/react-hooks/src/useSudo.ts
+++ b/packages/react-hooks/src/useSudo.ts
@@ -18,7 +18,7 @@ const OPT = {
 function useSudoImpl (): UseSudo {
   const { api } = useApi();
   const { allAccounts, hasAccounts } = useAccounts();
-  const sudoKey = useCall<string>(hasAccounts && api.query.sudo?.key, undefined, OPT);
+  const sudoKey = useCall(hasAccounts && api.query.sudo?.key, undefined, OPT);
   const [hasSudoKey, setHasSudoKey] = useState(false);
 
   useEffect((): void => {

--- a/packages/react-hooks/src/useTeleport.ts
+++ b/packages/react-hooks/src/useTeleport.ts
@@ -64,7 +64,7 @@ function extractRelayDestinations (relayGenesis: string, filter: (l: ExtLinkOpti
 
 function useTeleportImpl (): Teleport {
   const { api, apiUrl, isApiReady } = useApi();
-  const paraId = useCall<ParaId>(isApiReady && api.query.parachainInfo?.parachainId);
+  const paraId: ParaId = useCall(isApiReady && api.query.parachainInfo?.parachainId);
   const [state, setState] = useState<Teleport>(() => ({ ...DEFAULT_STATE }));
 
   useEffect((): void => {

--- a/packages/react-hooks/src/useTreasury.ts
+++ b/packages/react-hooks/src/useTreasury.ts
@@ -40,9 +40,9 @@ function useTreasuryImpl (): Result {
       EMPTY_U8A_32
     ).subarray(0, 32)
   }));
-  const bounties = useCall<DeriveBounties>(api.derive.bounties?.bounties);
-  const treasuryProposals = useCall<DeriveTreasuryProposals>(api.derive.treasury.proposals);
-  const treasuryBalance = useCall<DeriveBalancesAccount>(api.derive.balances?.account, [result.treasuryAccount]);
+  const bounties: DeriveBounties = useCall(api.derive.bounties?.bounties);
+  const treasuryProposals: DeriveTreasuryProposals = useCall(api.derive.treasury.proposals);
+  const treasuryBalance: DeriveBalancesAccount = useCall(api.derive.balances?.account, [result.treasuryAccount]);
 
   useEffect((): void => {
     treasuryBalance && api.consts.treasury &&

--- a/packages/react-query/src/Available.tsx
+++ b/packages/react-query/src/Available.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function AvailableDisplay ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
+  const allBalances: DeriveBalancesAll = useCall(api.derive.balances?.all, [params]);
 
   return (
     <FormatBalance

--- a/packages/react-query/src/Balance.tsx
+++ b/packages/react-query/src/Balance.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function BalanceDisplay ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
+  const allBalances: DeriveBalancesAll = useCall(api.derive.balances?.all, [params]);
 
   return (
     <FormatBalance

--- a/packages/react-query/src/BalanceFree.tsx
+++ b/packages/react-query/src/BalanceFree.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function BalanceFree ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
+  const allBalances: DeriveBalancesAll = useCall(api.derive.balances?.all, [params]);
 
   return (
     <FormatBalance

--- a/packages/react-query/src/BalanceVoting.tsx
+++ b/packages/react-query/src/BalanceVoting.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function BalanceVoting ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
+  const allBalances: DeriveBalancesAll = useCall(api.derive.balances?.all, [params]);
 
   return (
     <FormatBalance

--- a/packages/react-query/src/BestFinalized.tsx
+++ b/packages/react-query/src/BestFinalized.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BlockNumber } from '@polkadot/types/interfaces';
-
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -16,7 +14,7 @@ interface Props {
 
 function BestFinalized ({ children, className = '', label }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const bestNumberFinalized = useCall<BlockNumber>(api.derive.chain.bestNumberFinalized);
+  const bestNumberFinalized = useCall(api.derive.chain.bestNumberFinalized);
 
   return (
     <div className={`${className} ${bestNumberFinalized ? '' : '--tmp'}`}>

--- a/packages/react-query/src/BestNumber.tsx
+++ b/packages/react-query/src/BestNumber.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BlockNumber } from '@polkadot/types/interfaces';
-
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -18,7 +16,7 @@ interface Props {
 
 function BestNumber ({ children, className = '', isFinalized, label, withPound }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
-  const bestNumber = useCall<BlockNumber>(isApiReady && (isFinalized ? api.derive.chain.bestNumberFinalized : api.derive.chain.bestNumber));
+  const bestNumber = useCall(isApiReady && (isFinalized ? api.derive.chain.bestNumberFinalized : api.derive.chain.bestNumber));
 
   return (
     <div className={`${className} ${bestNumber ? '' : '--tmp'}`}>

--- a/packages/react-query/src/Bonded.tsx
+++ b/packages/react-query/src/Bonded.tsx
@@ -27,8 +27,8 @@ const OPT_L = {
 
 function BondedDisplay ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const controllerId = useCall<AccountId | null>(api.query.staking?.bonded, [params], OPT_C);
-  const stakingLedger = useCall<StakingLedger | null>(controllerId && api.query.staking?.ledger, [controllerId], OPT_L);
+  const controllerId: AccountId | null = useCall(api.query.staking?.bonded, [params], OPT_C);
+  const stakingLedger: StakingLedger | null = useCall(controllerId && api.query.staking?.ledger, [controllerId], OPT_L);
 
   return (
     <FormatBalance

--- a/packages/react-query/src/LockedVote.tsx
+++ b/packages/react-query/src/LockedVote.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function LockedVote ({ children, className = '', label, params }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const info = useCall<DeriveCouncilVote>(api.derive.council.votesOf, [params]);
+  const info: DeriveCouncilVote = useCall(api.derive.council.votesOf, [params]);
 
   if (!info?.stake.gtn(0)) {
     return null;

--- a/packages/react-query/src/Nonce.tsx
+++ b/packages/react-query/src/Nonce.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import React from 'react';
@@ -19,7 +18,7 @@ interface Props {
 
 function Nonce ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
+  const allBalances = useCall(api.derive.balances?.all, [params]);
 
   return (
     <div className={className}>

--- a/packages/react-query/src/SessionToTime.tsx
+++ b/packages/react-query/src/SessionToTime.tsx
@@ -1,7 +1,6 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import type { BN } from '@polkadot/util';
 
 import React, { useMemo } from 'react';
@@ -21,7 +20,7 @@ interface Props {
 
 function SessionToTime ({ children, className, isInline, label, value }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
+  const sessionInfo = useCall(api.derive.session.progress);
 
   const blocks = useMemo(
     () => sessionInfo && value && sessionInfo.currentIndex.lt(value)

--- a/packages/react-query/src/TimeNow.tsx
+++ b/packages/react-query/src/TimeNow.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 function TimeNow ({ children, className = '', label, value }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const timestamp = useCall<Moment>(!value && api.query.timestamp?.now);
+  const timestamp = useCall(!value && api.query.timestamp?.now);
 
   const [now, hasValue] = useMemo(
     () => [value || timestamp, !!(value || timestamp)],

--- a/packages/react-query/src/TotalInactive.tsx
+++ b/packages/react-query/src/TotalInactive.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 function TotalInactive ({ children, className = '', label }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const inactiveIssuance = useCall<string>(api.query.balances?.inactiveIssuance);
+  const inactiveIssuance = useCall(api.query.balances?.inactiveIssuance);
 
   return (
     <div className={className}>

--- a/packages/react-query/src/TotalIssuance.tsx
+++ b/packages/react-query/src/TotalIssuance.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 function TotalIssuance ({ children, className = '', label }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const totalIssuance = useCall<string>(api.query.balances?.totalIssuance);
+  const totalIssuance = useCall(api.query.balances?.totalIssuance);
 
   return (
     <div className={className}>

--- a/packages/react-signer/src/PaymentInfo.tsx
+++ b/packages/react-signer/src/PaymentInfo.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { RuntimeDispatchInfo } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 
@@ -28,7 +27,7 @@ function PaymentInfo ({ accountId, className = '', extrinsic, isHeader }: Props)
   const { t } = useTranslation();
   const { api } = useApi();
   const [dispatchInfo, setDispatchInfo] = useState<RuntimeDispatchInfo | null>(null);
-  const balances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [accountId]);
+  const balances = useCall(api.derive.balances?.all, [accountId]);
   const mountedRef = useIsMountedRef();
 
   useEffect((): void => {


### PR DESCRIPTION
Automatically infer return & parameters type from query & derive storage calls.

## Caveat

As of now this doesn’t yet infer typing for `.multi`.