### PR TITLE
Fix `jsonrpc` attribute

### DIFF
--- a/packages/react-components/src/InputRpc/rpcs.ts
+++ b/packages/react-components/src/InputRpc/rpcs.ts
@@ -12,7 +12,7 @@ function toExt (section: string, input: Record<string, DefinitionRpc>): Record<s
   return Object.entries(input).reduce((output: Record<string, DefinitionRpcExt>, [method, def]): Record<string, DefinitionRpcExt> => {
     output[method] = {
       isSubscription: false,
-      jsonrpc: `${method}_${section}`,
+      jsonrpc: `${section}_${method}`,
       method,
       section,
       ...def


### PR DESCRIPTION
Fixing `jsonrpc` attribute while building full RPC record object.