### PR TITLE
Add ethTransaction type for shiden

### DIFF
--- a/packages/apps-config/src/api/spec/shiden.ts
+++ b/packages/apps-config/src/api/spec/shiden.ts
@@ -23,6 +23,7 @@ const definitions: OverrideBundleDefinition = {
             Wasm: 'AccountId'
           }
         },
+        EthTransaction: 'LegacyTransaction',
         EraStakingPoints: {
           total: 'Balance',
           stakers: 'BTreeMap<AccountId, Balance>',

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -95767,6 +95767,7 @@ export const typesBundle = {
                 "Wasm": "AccountId"
               }
             },
+            "EthTransaction": "LegacyTransaction",
             "EraStakingPoints": {
               "total": "Balance",
               "stakers": "BTreeMap<AccountId, Balance>",


### PR DESCRIPTION
Currently, having issue like https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fshiden.api.onfinality.io%2Fpublic-ws#/explorer/query/339618 because of type error.

so, adding `EthTransaction: 'LegacyTransaction' property to typeDefinition in shiden

