### PR TITLE
Fix delegation with x0.1 conviction and typo

### DIFF
--- a/packages/page-referenda/src/Referenda/Delegate/Activity.tsx
+++ b/packages/page-referenda/src/Referenda/Delegate/Activity.tsx
@@ -58,7 +58,7 @@ function Activity ({ allowEmpty, className, palletReferenda, tracks, value }: Pr
             ))}
           </Table>
         )
-        : <MarkWarning content={t<string>('This account has no voting/delating activity in the chain state')} />
+        : <MarkWarning content={t<string>('This account has no voting/delegating activity in the chain state')} />
       }
       {!allowEmpty && infos.some(([{ delegating }]) => delegating) && (
         <MarkWarning content={t<string>('This account has some delegations in itself')} />

--- a/packages/page-referenda/src/Referenda/Delegate/index.tsx
+++ b/packages/page-referenda/src/Referenda/Delegate/index.tsx
@@ -93,7 +93,7 @@ function Delegate ({ className, palletReferenda, palletVote, tracks }: Props): R
   );
 
   const extrinsic = useMemo(
-    () => balance && conviction && toAccount && includeTracks
+    () => balance && conviction >= 0 && toAccount && includeTracks
       ? isAllTracks
         ? api.tx.utility.forceBatch(includeTracks.map((trackId) =>
           api.tx[palletVote as 'convictionVoting'].delegate(trackId, toAccount, conviction, balance)
@@ -103,7 +103,7 @@ function Delegate ({ className, palletReferenda, palletVote, tracks }: Props): R
     [api, balance, conviction, includeTracks, isAllTracks, palletVote, toAccount, trackId]
   );
 
-  const isStep1Valid = !!(accountId && activityFrom && includeTracks && (includeTracks.length > 0));
+  const isStep1Valid = !!(accountId && includeTracks && (includeTracks.length > 0));
   const isStep2Valid = !!(toAccount && activityTo);
 
   return (

--- a/packages/page-referenda/src/Referenda/Delegate/index.tsx
+++ b/packages/page-referenda/src/Referenda/Delegate/index.tsx
@@ -104,7 +104,7 @@ function Delegate ({ className, palletReferenda, palletVote, tracks }: Props): R
   );
 
   const isStep1Valid = !!(accountId && includeTracks && (includeTracks.length > 0));
-  const isStep2Valid = !!(toAccount && activityTo);
+  const isStep2Valid = !!(toAccount && activityTo && (activityTo.length > 0));
 
   return (
     <>

--- a/packages/page-referenda/src/Referenda/Delegate/index.tsx
+++ b/packages/page-referenda/src/Referenda/Delegate/index.tsx
@@ -104,7 +104,7 @@ function Delegate ({ className, palletReferenda, palletVote, tracks }: Props): R
   );
 
   const isStep1Valid = !!(accountId && activityFrom && includeTracks && (includeTracks.length > 0));
-  const isStep2Valid = !!(toAccount && activityTo && (activityTo.length > 0));
+  const isStep2Valid = !!(toAccount && activityTo);
 
   return (
     <>

--- a/packages/page-referenda/src/Referenda/Delegate/index.tsx
+++ b/packages/page-referenda/src/Referenda/Delegate/index.tsx
@@ -103,7 +103,7 @@ function Delegate ({ className, palletReferenda, palletVote, tracks }: Props): R
     [api, balance, conviction, includeTracks, isAllTracks, palletVote, toAccount, trackId]
   );
 
-  const isStep1Valid = !!(accountId && includeTracks && (includeTracks.length > 0));
+  const isStep1Valid = !!(accountId && activityFrom && includeTracks && (includeTracks.length > 0));
   const isStep2Valid = !!(toAccount && activityTo && (activityTo.length > 0));
 
   return (


### PR DESCRIPTION
Fixes the following
- Delegation with x0.1 conviction (conviction === 0) sets the extrinsic to `null` and the `TxButton` to disabled.
- Typo on delegation

Remarks:
- Also the type of `activityTo` is `VoteResultItem[] | null | undefined` but is set by default to `[]` which is truthy. This result in step 2 being valid even if the selected account has no activity. Is this expected or do you intend to check for `.length`?