### PR TITLE
Fix issue with optional rpc parameters.

### DIFF
--- a/packages/page-rpc/src/Rpc/Selection.tsx
+++ b/packages/page-rpc/src/Rpc/Selection.tsx
@@ -72,7 +72,7 @@ function Selection ({ queueRpc }: Props): React.ReactElement<Props> {
     (): void => queueRpc({
       rpc,
       values: values
-        .filter(({ value }) => !isNull(value))
+        .filter(({ value }, idx) => !rpc.params[idx].isOptional || !isNull(value))
         .map(({ value }): any => value)
     }),
     [queueRpc, rpc, values]


### PR DESCRIPTION
This change allows correct handling of `Option<T>` rpc parameter types.  The filter was removing all `null` values, but those are needed for `Option<T>` parameters.  The `isOptional: true` can't be used when mixing optional parameters with required parameters.