### PR TITLE
Fix the way we read the nft's metadata

### DIFF
--- a/packages/page-nfts/src/AccountItems/useItemsInfos.ts
+++ b/packages/page-nfts/src/AccountItems/useItemsInfos.ts
@@ -72,7 +72,7 @@ function useItemsInfosImpl (accountItems: AccountItem[]): ItemInfo[] | undefined
     if (metadata && metadata[1].length) {
       return metadata[1].map((o) =>
         o.isSome
-          ? o.unwrap().data.toString()
+          ? o.unwrap().data.toPrimitive() as string
           : ''
       );
     }

--- a/packages/page-nfts/src/useCollectionInfos.ts
+++ b/packages/page-nfts/src/useCollectionInfos.ts
@@ -71,7 +71,7 @@ function extractInfo (allAccounts: string[], id: BN, optDetails: Option<PalletUn
 }
 
 const addIpfsData = (ipfsData: IpfsData) => (collectionInfo: CollectionInfo): CollectionInfo => {
-  const ipfsHash = collectionInfo.metadata && collectionInfo.metadata.data?.toString();
+  const ipfsHash = collectionInfo.metadata && collectionInfo.metadata.data?.toPrimitive() as string;
 
   return {
     ...collectionInfo,
@@ -90,7 +90,7 @@ function useCollectionInfosImpl (ids?: BN[]): CollectionInfo[] | undefined {
     () => metadata && metadata[1].length
       ? metadata[1].map((o) =>
         o.isSome
-          ? o.unwrap().data.toString()
+          ? o.unwrap().data.toPrimitive() as string
           : ''
       )
       : [],


### PR DESCRIPTION
On the nfts page the metadata disappeared because of the way we extract it. `metadata.data.toString()` was previously converting from u8a to string under the hood, while now it converts u8a to hex and produces the wrong result