### PR TITLE
Update testingRelayWestend.ts

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -187,7 +187,7 @@ export const testRelayWestend: EndpointOption = {
     LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
-    // RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/9712
+    RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', 
     Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'
   },

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -187,7 +187,7 @@ export const testRelayWestend: EndpointOption = {
     LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
-    RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', 
+    RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws',
     Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'
   },


### PR DESCRIPTION
We have root caused this westend issue (https://github.com/polkadot-js/apps/issues/9712) to a reverse proxy configuration issue form when we recently tried to switch http to port 9944 from 9933.

Please re-enable the endpoint, we will keep a closer watch as it comes online.