### PR TITLE
Add IBP BridgeHub support in Polkadot & Westend

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -699,6 +699,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     info: 'polkadotBridgeHub',
     paraId: 1002,
     providers: {
+      'IBP-GeoDNS1': 'wss://sys.ibp.network/bridgehub-polkadot',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-polkadot',
       LuckyFriday: 'wss://rpc-bridge-hub-polkadot.luckyfriday.io',
       Parity: 'wss://polkadot-bridge-hub-rpc.polkadot.io',
       Stakeworld: 'wss://dot-rpc.stakeworld.io/bridgehub'

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -147,6 +147,8 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1002,
     providers: {
       // Parity: 'wss://westend-bridge-hub-rpc.polkadot.io' // https://github.com/polkadot-js/apps/issues/9348
+      'IBP-GeoDNS1': 'wss://sys.ibp.network/bridgehub-westend',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend',
     },
     text: 'BridgeHub',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -146,9 +146,9 @@ export const testParasWestendCommon: EndpointOption[] = [
     info: 'westendBridgeHub',
     paraId: 1002,
     providers: {
-      // Parity: 'wss://westend-bridge-hub-rpc.polkadot.io' // https://github.com/polkadot-js/apps/issues/9348
+      // Parity: 'wss://westend-bridge-hub-rpc.polkadot.io', // https://github.com/polkadot-js/apps/issues/9348
       'IBP-GeoDNS1': 'wss://sys.ibp.network/bridgehub-westend',
-      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend',
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend'
     },
     text: 'BridgeHub',
     ui: {


### PR DESCRIPTION
Dear @jacogr, dear team, 

Please consider this Pull Request to add endpoint support from the Infrastructure Builders' Programme ([IBP](https://ibp.network/)) to the following chains:

- Polkadot BridgeHub
- Westend BridgeHub

The endpoints are currently provided by a network of 07 independent RPC providers in geo-diverse locations (working towards having 12 worldwide locations soon) each location is comprised of at least 2x archive nodes serving requests in failure-resistant and load-balancing mode.

Many thanks!

Best regards

Milos

