### PR TITLE
Enable parity endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -147,9 +147,9 @@ export const testParasWestendCommon: EndpointOption[] = [
     info: 'westendBridgeHub',
     paraId: 1002,
     providers: {
-      Parity: 'wss://westend-bridge-hub-rpc.polkadot.io',
       'IBP-GeoDNS1': 'wss://sys.ibp.network/bridgehub-westend',
-      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend'
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend',
+      Parity: 'wss://westend-bridge-hub-rpc.polkadot.io'
     },
     text: 'BridgeHub',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -162,7 +162,7 @@ export const testParasWestendCommon: EndpointOption[] = [
     providers: {
       'IBP-GeoDNS1': 'wss://sys.ibp.network/collectives-westend',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/collectives-westend',
-       Parity: 'wss://westend-collectives-rpc.polkadot.io'
+      Parity: 'wss://westend-collectives-rpc.polkadot.io'
     },
     teleport: [-1],
     text: 'Collectives',

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -147,7 +147,7 @@ export const testParasWestendCommon: EndpointOption[] = [
     info: 'westendBridgeHub',
     paraId: 1002,
     providers: {
-      // Parity: 'wss://westend-bridge-hub-rpc.polkadot.io', // https://github.com/polkadot-js/apps/issues/9348
+      Parity: 'wss://westend-bridge-hub-rpc.polkadot.io',
       'IBP-GeoDNS1': 'wss://sys.ibp.network/bridgehub-westend',
       'IBP-GeoDNS2': 'wss://sys.dotters.network/bridgehub-westend'
     },
@@ -161,8 +161,8 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1001,
     providers: {
       'IBP-GeoDNS1': 'wss://sys.ibp.network/collectives-westend',
-      'IBP-GeoDNS2': 'wss://sys.dotters.network/collectives-westend'
-      // Parity: 'wss://westend-collectives-rpc.polkadot.io' // https://github.com/polkadot-js/apps/issues/9357
+      'IBP-GeoDNS2': 'wss://sys.dotters.network/collectives-westend',
+       Parity: 'wss://westend-collectives-rpc.polkadot.io'
     },
     teleport: [-1],
     text: 'Collectives',


### PR DESCRIPTION
we increased replicas behind endpoints and also improved the monitoring. The nodes should be more stable now. 