### PR TITLE
Update productionRelayPolkadot.ts

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -74,7 +74,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
       Blast: 'wss://astar.public.blastapi.io',
       Dwellir: 'wss://astar-rpc.dwellir.com',
       OnFinality: 'wss://astar.api.onfinality.io/public-ws',
-      RadiumBlock: 'wss://astar.public.curie.radiumblock.co/ws', 
+      RadiumBlock: 'wss://astar.public.curie.radiumblock.co/ws',
       'light client': 'light://substrate-connect/polkadot/astar'
     },
     text: 'Astar',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -74,7 +74,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
       Blast: 'wss://astar.public.blastapi.io',
       Dwellir: 'wss://astar-rpc.dwellir.com',
       OnFinality: 'wss://astar.api.onfinality.io/public-ws',
-      // RadiumBlock: 'wss://astar.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/9748
+      RadiumBlock: 'wss://astar.public.curie.radiumblock.co/ws', 
       'light client': 'light://substrate-connect/polkadot/astar'
     },
     text: 'Astar',


### PR DESCRIPTION
The issue was load related and the unavailability had been handled, however we didn't notice the bug in polkadot-js. The endpoint has been in use directly and functioning fine. So please re-enable it on polkadotjs.