### PR TITLE
Add missing & specifier to status

### DIFF
--- a/packages/react-components/src/Status/index.tsx
+++ b/packages/react-components/src/Status/index.tsx
@@ -189,7 +189,7 @@ const StyledDiv = styled.div`
   width: 4.5rem;
   z-index: 1001;
 
-  :hover {
+  &:hover {
     transform: scale(1);
     width: 23rem;
 


### PR DESCRIPTION
The previous style is fine in styled-components 5.x, but not anymore in 6.x (As a bonus, also check for other occurrences or bare `:hover` - none found)

Closes https://github.com/polkadot-js/apps/issues/9804