### PR TITLE
Rename StakeTechnologies to Astar

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -658,7 +658,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
       Blast: 'wss://shiden.public.blastapi.io',
       Dwellir: 'wss://shiden-rpc.dwellir.com',
       OnFinality: 'wss://shiden.api.onfinality.io/public-ws',
-      StakeTechnologies: 'wss://rpc.shiden.astar.network',
+      Astar: 'wss://rpc.shiden.astar.network',
       'light client': 'light://substrate-connect/kusama/shiden'
     },
     text: 'Shiden',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -655,10 +655,10 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     info: 'shiden',
     paraId: 2007,
     providers: {
+      Astar: 'wss://rpc.shiden.astar.network',
       Blast: 'wss://shiden.public.blastapi.io',
       Dwellir: 'wss://shiden-rpc.dwellir.com',
       OnFinality: 'wss://shiden.api.onfinality.io/public-ws',
-      Astar: 'wss://rpc.shiden.astar.network',
       'light client': 'light://substrate-connect/kusama/shiden'
     },
     text: 'Shiden',

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -773,7 +773,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'shibuya',
     providers: {
       Dwellir: 'wss://shibuya-rpc.dwellir.com',
-      StakeTechnologies: 'wss://rpc.shibuya.astar.network'
+      Astar: 'wss://rpc.shibuya.astar.network'
     },
     text: 'Shibuya',
     ui: {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -772,8 +772,8 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'shibuya',
     providers: {
-      Dwellir: 'wss://shibuya-rpc.dwellir.com',
-      Astar: 'wss://rpc.shibuya.astar.network'
+      Astar: 'wss://rpc.shibuya.astar.network',
+      Dwellir: 'wss://shibuya-rpc.dwellir.com'
     },
     text: 'Shibuya',
     ui: {


### PR DESCRIPTION
It was a long time since Stake Technologies was rebranded to Astar. Finally, the time has came to change this on Polkadot.js

<img width="302" alt="image" src="https://github.com/polkadot-js/apps/assets/8452361/7e02bc39-c145-42c5-b3a2-3230c91f5e41">
