### PR TITLE
Add new Snowbridge forks

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -460,12 +460,23 @@ export const testParasRococo: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
-    info: 'snowbridge',
+    info: 'snowbridgeBridgeHub',
     paraId: 3016,
     providers: {
-      // Snowfork: 'wss://rococo-rpc.snowbridge.network' // https://github.com/polkadot-js/apps/issues/8723
+      // Snowfork: 'wss://rococo-rpc.snowbridge.network/bridgehub' // https://github.com/polkadot-js/apps/issues/8723
     },
-    text: 'Snowbridge',
+    text: 'Snowbridge Bridge Hub',
+    ui: {
+      logo: chainsSnowbridgePNG
+    }
+  },
+  {
+    info: 'snowbridgeAssetHub',
+    paraId: 3416,
+    providers: {
+      // Snowfork: 'wss://rococo-rpc.snowbridge.network/assethub' // https://github.com/polkadot-js/apps/issues/8723
+    },
+    text: 'Snowbridge Asset Hub',
     ui: {
       logo: chainsSnowbridgePNG
     }

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -463,7 +463,7 @@ export const testParasRococo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'snowbridgeBridgeHub',
     paraId: 3016,
     providers: {
-      // Snowfork: 'wss://rococo-rpc.snowbridge.network/bridgehub' // https://github.com/polkadot-js/apps/issues/8723
+      Snowfork: 'wss://rococo-rpc.snowbridge.network/bridgehub'
     },
     text: 'Snowbridge Bridge Hub',
     ui: {
@@ -474,7 +474,7 @@ export const testParasRococo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'snowbridgeAssetHub',
     paraId: 3416,
     providers: {
-      // Snowfork: 'wss://rococo-rpc.snowbridge.network/assethub' // https://github.com/polkadot-js/apps/issues/8723
+      Snowfork: 'wss://rococo-rpc.snowbridge.network/assethub'
     },
     text: 'Snowbridge Asset Hub',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayRococo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayRococo.ts
@@ -460,23 +460,23 @@ export const testParasRococo: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
-    info: 'snowbridgeBridgeHub',
-    paraId: 3016,
-    providers: {
-      Snowfork: 'wss://rococo-rpc.snowbridge.network/bridgehub'
-    },
-    text: 'Snowbridge Bridge Hub',
-    ui: {
-      logo: chainsSnowbridgePNG
-    }
-  },
-  {
     info: 'snowbridgeAssetHub',
     paraId: 3416,
     providers: {
       Snowfork: 'wss://rococo-rpc.snowbridge.network/assethub'
     },
     text: 'Snowbridge Asset Hub',
+    ui: {
+      logo: chainsSnowbridgePNG
+    }
+  },
+  {
+    info: 'snowbridgeBridgeHub',
+    paraId: 3016,
+    providers: {
+      Snowfork: 'wss://rococo-rpc.snowbridge.network/bridgehub'
+    },
+    text: 'Snowbridge Bridge Hub',
     ui: {
       logo: chainsSnowbridgePNG
     }


### PR DESCRIPTION
Added forks of asset hub and bridge hub required to test Snowbridge. We have added forks as we want to test the bridge without merging our changes upstream to bridge hub and asset hub.

TODO:
- [x] Bring up and test wss endpoints