### PR TITLE
Add subsquare user external link and support vara network

### DIFF
--- a/packages/apps-config/src/links/subsquare.ts
+++ b/packages/apps-config/src/links/subsquare.ts
@@ -29,15 +29,17 @@ export const Subsquare: ExternalDef = {
     Polkadot: 'polkadot',
     Rococo: 'rococo',
     'Turing Network': 'turing',
+    'Vara Network': 'vara',
     'Westend Collectives': 'westend-collectives',
     Zeitgeist: 'zeitgeist',
     kintsugi: 'kintsugi'
   },
   create: (chain: string, path: string, data: BN | number | string): string =>
-    `https://${chain}.subsquare.io/${path}/${data.toString()}`,
+    `https://${chain}.subsquare.io/${path}/${data.toString()}${path === 'user' ? '/votes' : ''}`,
   homepage: 'https://subsquare.io/',
   isActive: true,
   paths: {
+    address: 'user',
     bounty: 'treasury/bounty',
     council: 'council/motion',
     democracyExternal: 'democracy/external',


### PR DESCRIPTION
- Add account external link to subsquare user votes page.
- Support vara network.