### PR TITLE
Add Phala (PoC6)

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -663,6 +663,16 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    info: 'phala',
+    providers: {
+      'Phala Network': 'wss://poc6.phala.network/ws'
+    },
+    text: 'Phala (PoC 6)',
+    ui: {
+      logo: nodesPhalaSVG
+    }
+  },
+  {
     info: 'phoenix',
     providers: {
       // 'phoenix Protocol': 'wss://phoenix-ws.coinid.pro/' // https://github.com/polkadot-js/apps/issues/6181


### PR DESCRIPTION
Phala is setting up new testnet PoC6. Later we will deprecate PoC5.