### PR TITLE
Update Creditcoin WS endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -123,7 +123,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'creditcoin',
     providers: {
-      'Creditcoin Foundation': 'wss://rpc.mainnet.creditcoin.network/ws'
+      'Creditcoin Foundation': 'wss://mainnet.creditcoin.network/ws'
     },
     text: 'Creditcoin',
     ui: {


### PR DESCRIPTION
This PR replaces `wss://rpc.mainnet.creditcoin.network/ws`, one of the RPC endpoints provided by the Creditcoin Foundation, with `wss://mainnet.creditcoin.network/ws`, which routes connections through the foundation's load balancer in order to better serve users.