### PR TITLE
Update chain text. (thebifrost network)

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -516,7 +516,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
       'Pilab #1': 'wss://public-01.mainnet.bifrostnetwork.com/wss',
       'Pilab #2': 'wss://public-02.mainnet.bifrostnetwork.com/wss'
     },
-    text: 'The Bifrost Mainnet',
+    text: 'Bifrost Mainnet',
     ui: {
       color: '#FF474C',
       logo: nodesThebifrostPNG

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -65,6 +65,18 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    info: 'thebifrost-mainnet',
+    providers: {
+      'Pilab #1': 'wss://public-01.mainnet.bifrostnetwork.com/wss',
+      'Pilab #2': 'wss://public-02.mainnet.bifrostnetwork.com/wss'
+    },
+    text: 'Bifrost Mainnet',
+    ui: {
+      color: '#FF474C',
+      logo: nodesThebifrostPNG
+    }
+  },
+  {
     info: 'bittensor',
     providers: {
       'Opentensor Fdn (Archive)': 'wss://entrypoint-finney.opentensor.ai:443'
@@ -508,18 +520,6 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     ui: {
       color: '#d622ff',
       logo: nodesTernoaSVG
-    }
-  },
-  {
-    info: 'thebifrost-mainnet',
-    providers: {
-      'Pilab #1': 'wss://public-01.mainnet.bifrostnetwork.com/wss',
-      'Pilab #2': 'wss://public-02.mainnet.bifrostnetwork.com/wss'
-    },
-    text: 'Bifrost Mainnet',
-    ui: {
-      color: '#FF474C',
-      logo: nodesThebifrostPNG
     }
   },
   {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -128,6 +128,18 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    info: 'thebifrost-testnet',
+    providers: {
+      'Pilab #1': 'wss://public-01.testnet.bifrostnetwork.com/wss',
+      'Pilab #2': 'wss://public-02.testnet.bifrostnetwork.com/wss'
+    },
+    text: 'Bifrost Testnet',
+    ui: {
+      color: '#FF474C',
+      logo: nodesThebifrostPNG
+    }
+  },
+  {
     info: 'cere',
     providers: {
       // 'Cere Network': 'wss://archive.testnet.cere.network/ws' // https://github.com/polkadot-js/apps/issues/9712
@@ -936,18 +948,6 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     text: 'Tewai',
     ui: {
       logo: nodesBitcountryPNG
-    }
-  },
-  {
-    info: 'thebifrost-testnet',
-    providers: {
-      'Pilab #1': 'wss://public-01.testnet.bifrostnetwork.com/wss',
-      'Pilab #2': 'wss://public-02.testnet.bifrostnetwork.com/wss'
-    },
-    text: 'Bifrost Testnet',
-    ui: {
-      color: '#FF474C',
-      logo: nodesThebifrostPNG
     }
   },
   {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -944,7 +944,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
       'Pilab #1': 'wss://public-01.testnet.bifrostnetwork.com/wss',
       'Pilab #2': 'wss://public-02.testnet.bifrostnetwork.com/wss'
     },
-    text: 'The Bifrost Testnet',
+    text: 'Bifrost Testnet',
     ui: {
       color: '#FF474C',
       logo: nodesThebifrostPNG


### PR DESCRIPTION
The bifrost.finance team and our bifrost network are unrelated projects, so we added 'the' to avoid confusion before.

However, the two chains are located in different sections, removing 'the' to unify the name convention with other apps on the bifrost network.