### PR TITLE
Change Logion ParaId

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -422,7 +422,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
   {
     homepage: 'https://logion.network/',
     info: 'logion',
-    paraId: 3341,
+    paraId: 3354,
     providers: {},
     text: 'Logion',
     ui: {


### PR DESCRIPTION
We had to register a new ParaId for Logion following an error (wrong lease period) in our current crowdloan.