### PR TITLE
Enable Watr mainnet RPC

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -688,7 +688,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'watr',
     paraId: 2058,
     providers: {
-      // Watr: 'wss://rpc.watr.org' // https://github.com/polkadot-js/apps/issues/9361
+      Watr: 'wss://watr-rpc.watr-api.network'
     },
     text: 'Watr Network',
     ui: {


### PR DESCRIPTION
After Watr's successful mainnet launch this PR re-enables the corresponding RPC endpoint.