### PR TITLE
Fixes #9260: Corrects calculation of remaining locking period for referendums

### DIFF
--- a/packages/page-referenda/src/useAccountLocks.ts
+++ b/packages/page-referenda/src/useAccountLocks.ts
@@ -9,6 +9,7 @@ import type { Lock, PalletReferenda, PalletVote } from './types.js';
 
 import { useMemo } from 'react';
 
+import { CONVICTIONS } from '@polkadot/react-components/ConvictionDropdown';
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 import { BN_MAX_INTEGER } from '@polkadot/util';
 
@@ -84,8 +85,9 @@ function getLocks (api: ApiPromise, palletVote: PalletVote, votes: [classId: BN,
         const [, tally] = refInfo;
         let total: BN | undefined;
         let endBlock: BN| undefined;
-        let conviction = 0;
+        let convictionIndex = 0;
         let locked = 'None';
+        const durationIndex = 1;
 
         if (accountVote.isStandard) {
           const { balance, vote } = accountVote.asStandard;
@@ -93,7 +95,7 @@ function getLocks (api: ApiPromise, palletVote: PalletVote, votes: [classId: BN,
           total = balance;
 
           if ((tally.isApproved && vote.isAye) || (tally.isRejected && vote.isNay)) {
-            conviction = vote.conviction.index;
+            convictionIndex = vote.conviction.index;
             locked = vote.conviction.type;
           }
         } else if (accountVote.isSplit) {
@@ -118,7 +120,7 @@ function getLocks (api: ApiPromise, palletVote: PalletVote, votes: [classId: BN,
             : tally.asTimedOut[0];
         } else if (tally.isApproved || tally.isRejected) {
           endBlock = lockPeriod
-            .muln(conviction)
+            .muln(convictionIndex ? CONVICTIONS[convictionIndex - 1][durationIndex] : 0)
             .add(
               tally.isApproved
                 ? tally.asApproved[0]

--- a/packages/react-components/src/ConvictionDropdown.tsx
+++ b/packages/react-components/src/ConvictionDropdown.tsx
@@ -18,7 +18,7 @@ export interface Props {
   voteLockingPeriod: BN;
 }
 
-const CONVICTIONS = [1, 2, 4, 8, 16, 32].map((lock, index): [value: number, duration: number, durationBn: BN] => [index + 1, lock, new BN(lock)]);
+export const CONVICTIONS = [1, 2, 4, 8, 16, 32].map((lock, index): [value: number, duration: number, durationBn: BN] => [index + 1, lock, new BN(lock)]);
 
 function createOptions (blockTime: BN, voteLockingPeriod: BN, t: (key: string, options?: { replace: Record<string, unknown> }) => string): { text: string; value: number }[] {
   return [


### PR DESCRIPTION
### Issue

Closes #9260

### Description

This PR fixes the issue reported in #9260. The problem was related to the incorrect calculation of the remaining locking period for tokens that are locked in referendums. The account menu on the apps was displaying inaccurate data. For example, when a user cast their vote on a Kusama referendum with a conviction of 6x, the displayed locking period was only 42 days instead of the expected 224 days (6 multiplied by 7). This PR addresses the issue and ensures that the correct locking period is displayed.

### Changes Made

 - Previously, the lock period was incorrectly multiplied by the conviction index. We have updated it to be multiplied by the conviction duration.

### Screenshots

- Before

<img width="1244" alt="Screenshot 2023-11-01 at 4 00 45 in the afternoon" src="https://github.com/polkadot-js/apps/assets/46442452/9f620cb4-8eb6-49f9-a414-569b3d312687">


- After(Corrected)

<img width="1242" alt="Screenshot 2023-11-01 at 4 01 19 in the afternoon" src="https://github.com/polkadot-js/apps/assets/46442452/26e5ce15-9768-4822-88db-b06af370f455">



### Checklist

- [x] Tested the changes locally
- [x] Ensured that the code follows the project's coding standards

