### PR TITLE
Add altlayer's ethereum dev chain to `ethereumChains`

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -13,6 +13,7 @@ export const ethereumChains = [
   'moonsama',
   'moonshadow',
   'altbeacon',
+  'altbeacon-dev',
   'alt-producer',
   'flash-layer',
   'armonia-eva',


### PR DESCRIPTION
we (altlayer) support one runtime spec-name for ethereum chain:
1. altbeacon-dev