### PR TITLE
Fix transfer button disappearance

### DIFF
--- a/packages/page-accounts/src/Accounts/Account.tsx
+++ b/packages/page-accounts/src/Accounts/Account.tsx
@@ -677,7 +677,7 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
         </td>
         <td className='actions button'>
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
+            {(isFunction(api.api.tx.balances?.transferAllowDeath) || isFunction(api.api.tx.balances?.transfer)) && (
               <Button
                 className='send-button'
                 icon='paper-plane'

--- a/packages/page-accounts/src/Accounts/Account.tsx
+++ b/packages/page-accounts/src/Accounts/Account.tsx
@@ -677,7 +677,7 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
         </td>
         <td className='actions button'>
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transfer) && (
+            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
               <Button
                 className='send-button'
                 icon='paper-plane'

--- a/packages/page-addresses/src/Contacts/Address.tsx
+++ b/packages/page-addresses/src/Contacts/Address.tsx
@@ -211,7 +211,7 @@ function Address ({ address, className = '', filter, isFavorite, toggleFavorite 
         </td>
         <td className='actions button'>
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
+            {(isFunction(api.api.tx.balances?.transferAllowDeath) || isFunction(api.api.tx.balances?.transfer)) && (
               <Button
                 className='send-button'
                 icon='paper-plane'

--- a/packages/page-addresses/src/Contacts/Address.tsx
+++ b/packages/page-addresses/src/Contacts/Address.tsx
@@ -211,7 +211,7 @@ function Address ({ address, className = '', filter, isFavorite, toggleFavorite 
         </td>
         <td className='actions button'>
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transfer) && (
+            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
               <Button
                 className='send-button'
                 icon='paper-plane'

--- a/packages/react-components/src/AccountSidebar/AccountMenuButtons.tsx
+++ b/packages/react-components/src/AccountSidebar/AccountMenuButtons.tsx
@@ -89,7 +89,7 @@ function AccountMenuButtons ({ className = '', flags, isEditing, isEditingName, 
         )
         : (
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transfer) && (
+            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
               <Button
                 icon='paper-plane'
                 isDisabled={isEditing}

--- a/packages/react-components/src/AccountSidebar/AccountMenuButtons.tsx
+++ b/packages/react-components/src/AccountSidebar/AccountMenuButtons.tsx
@@ -89,7 +89,7 @@ function AccountMenuButtons ({ className = '', flags, isEditing, isEditingName, 
         )
         : (
           <Button.Group>
-            {isFunction(api.api.tx.balances?.transferAllowDeath) && (
+            {(isFunction(api.api.tx.balances?.transferAllowDeath) || isFunction(api.api.tx.balances?.transfer)) && (
               <Button
                 icon='paper-plane'
                 isDisabled={isEditing}


### PR DESCRIPTION
Removed `transfer` call in polkadot v1.2 causing the transfer button disappearance.
See: https://github.com/paritytech/polkadot-sdk/pull/1226/files#diff-5dfe6adcc3c44280fc10cd49830df408a491c768a54f47835d822a0d1334d385L737

This bug causes the transfer button to be missing on chains upgraded to Polkadot ^1.2.0, like [Phala](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fphala.api.onfinality.io%2Fpublic-ws#/accounts).