### PR TITLE
Add Helikon RPC public endpoints for Phala, Khala and HydraDX

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -323,6 +323,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 2004,
     providers: {
       Dwellir: 'wss://khala-rpc.dwellir.com',
+      Helikon: 'wss://rpc.helikon.io/khala',
       OnFinality: 'wss://khala.api.onfinality.io/public-ws',
       Phala: 'wss://khala-api.phala.network/ws'
     },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -311,7 +311,8 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 2034,
     providers: {
       Dwellir: 'wss://hydradx-rpc.dwellir.com',
-      'Galactic Council': 'wss://rpc.hydradx.cloud'
+      'Galactic Council': 'wss://rpc.hydradx.cloud',
+      Helikon: 'wss://rpc.helikon.io/hydradx'
       // OnFinality: 'wss://hydradx.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/9986
       // ZeePrime: 'wss://rpc-lb.data6.zp-labs.net:8443/hydradx/ws/?token=2ZGuGivPJJAxXiT1hR1Yg2MXGjMrhEBYFjgbdPi' // https://github.com/polkadot-js/apps/issues/9760
     },
@@ -581,6 +582,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 2035,
     providers: {
       Dwellir: 'wss://phala-rpc.dwellir.com',
+      Helikon: 'wss://rpc.helikon.io/phala',
       OnFinality: 'wss://phala.api.onfinality.io/public-ws',
       Phala: 'wss://api.phala.network/ws'
     },


### PR DESCRIPTION
This PR adds Helikon public RPC endpoints for Khala, Phala and HydraDX networks.

All endpoints are load balanced with two archive nodes on NVMe drives on a 500Mbps symmetrical network. All services run on owned hardware in a data center in central Istanbul, and are monitored 24/7 at software (node), hardware (disk, CPU, memory) and network level.

Nodes can be viewed on the W3F Telemetry instance, viewable for [Khala](https://telemetry.w3f.community/#list/0xd43540ba6d3eb4897c28a77d48cb5b729fea37603cbbfc7a86a73b72adb3be8d), [Phala](https://telemetry.w3f.community/#list/0x1bb969d85965e4bb5a651abbedf21a54b6b31a21f66b5401cc3f1e286268d736) and [HydraDX](https://telemetry.w3f.community/#list/0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d).

Helikon is a member of the IBP GeoDNS and provides public RPC endpoints for Kusama, Westend and Polkadot and all system parachains on these relay chains. We also run boot nodes for all the chains mentioned in this PR.

Thanks!