### PR TITLE
Add Helikon public RPC endpoint for Polimec

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -597,6 +597,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'polimec',
     paraId: 3344,
     providers: {
+      Helikon: 'wss://rpc.helikon.io/polimec',
       'Polimec Foundation': 'wss://rpc.polimec.org'
     },
     text: 'Polimec',


### PR DESCRIPTION
This PR adds Helikon public RPC endpoint for Polimec.

Polimec RPC endpoint is load balanced with two archive nodes on NVMe drives on a 500Mbps symmetrical network. All services run on owned hardware in a data center in central Istanbul, and are monitored 24/7 at software (node), hardware (disk, CPU, memory) and network level.

Nodes can be viewed [here](https://telemetry.w3f.community/#list/0x7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd) on the W3F Telemetry instance.

Helikon is a member of the IBP GeoDNS and provides public RPC endpoints for Kusama, Westend, Polkadot, all system parachains, Phala, Khala and HydraDX. We also run boot nodes for all the chains mentioned in this PR.

Thanks!