### PR TITLE
Add joyutils RPC endpoint for Joystream

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -270,8 +270,8 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'joystream',
     providers: {
-      Jsgenesis: 'wss://rpc.joystream.org',
-      Joyutils: 'wss://rpc.joyutils.org'
+      Joyutils: 'wss://rpc.joyutils.org',
+      Jsgenesis: 'wss://rpc.joystream.org'
     },
     text: 'Joystream',
     ui: {

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -270,7 +270,8 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'joystream',
     providers: {
-      Jsgenesis: 'wss://rpc.joystream.org'
+      Jsgenesis: 'wss://rpc.joystream.org',
+      Joyutils: 'wss://rpc.joyutils.org'
     },
     text: 'Joystream',
     ui: {


### PR DESCRIPTION
`wss://rpc.joyutils.org` is a load-balanced Joystream RPC endpoint with 2 high-availability backing nodes. `joyutils` is operated by senior Joystream DAO member with staked roles in the DAO.