### PR TITLE
Allow pool metadata to display UTF-8 emojis

### DIFF
--- a/packages/page-staking2/src/Pools/usePoolInfo.ts
+++ b/packages/page-staking2/src/Pools/usePoolInfo.ts
@@ -36,7 +36,7 @@ const OPT_MULTI = {
 };
 
 function transformName(input: string): string {
-  return input.replace(/[^\x20-\x7E\uD83C-\uDBFF\uDC00-\uDFFF]/g, '');
+  return input.replace(/[^\x20-\x7E\uD83C[\uDF00-\uDFFF]]/g, '');
 }
 
 function usePoolInfoImpl (poolId: BN): PoolInfo | null | undefined {

--- a/packages/page-staking2/src/Pools/usePoolInfo.ts
+++ b/packages/page-staking2/src/Pools/usePoolInfo.ts
@@ -35,8 +35,8 @@ const OPT_MULTI = {
       : null
 };
 
-function transformName (input: string): string {
-  return input.replace(/[^\x20-\x7E]/g, '');
+function transformName(input: string): string {
+  return input.replace(/[^\x20-\x7E\uD83C-\uDBFF\uDC00-\uDFFF]/g, '');
 }
 
 function usePoolInfoImpl (poolId: BN): PoolInfo | null | undefined {


### PR DESCRIPTION
Currently Polkadot-js allows for UTF-8 emojis to be displayed on both the validators page and address identities. However, the pools page currently strips any non-standard characters from pool names.

For consistency this pull request adjusts the `transformName` regex to allow for UTF-8 emojis, as is also the case on staking.polkadot.network/#/pools.