### PR TITLE
Update Logion RPCs

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -316,9 +316,11 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'logion',
     providers: {
-      // Logion: 'wss://rpc01.logion.network' // https://github.com/polkadot-js/apps/issues/10195
+      'Logion 1': 'wss://rpc01.logion.network',
+      'Logion 2': 'wss://rpc02.logion.network',
+      'Logion 3': 'wss://rpc03.logion.network'
     },
-    text: 'logion Standalone',
+    text: 'Logion Standalone',
     ui: {
       color: 'rgb(21, 38, 101)',
       logo: chainsLogionPNG


### PR DESCRIPTION
* `rpc01.logion.network` was unavailable because the max number of connections was reached (was set to 100) and additional connections were refused
* Max number of connections was increased to 300 (there are currently 200 connections on average)
* Additional RPCs are added to spread the load and improve availability
* The number of connections on our RPCs will be monitored more closely on our side