### PR TITLE
Add metadata for NeuroWeb crowdloan

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -494,6 +494,20 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    homepage: 'https://neuroweb.ai',
+    info: 'neuroweb',
+    paraId: 3360,
+    providers: {
+      Dwellir: 'wss://origintrail-rpc.dwellir.com',
+      TraceLabs: 'wss://parachain-rpc.origin-trail.network'
+    },
+    text: 'NeuroWeb',
+    ui: {
+      color: '#000000',
+      logo: chainsNeurowebPNG
+    }
+  },
+  {
     homepage: 'https://nodle.com',
     info: 'nodle',
     paraId: 2026,

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -497,10 +497,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     homepage: 'https://neuroweb.ai',
     info: 'neuroweb',
     paraId: 3360,
-    providers: {
-      Dwellir: 'wss://origintrail-rpc.dwellir.com',
-      TraceLabs: 'wss://parachain-rpc.origin-trail.network'
-    },
+    providers: {},
     text: 'NeuroWeb',
     ui: {
       color: '#000000',


### PR DESCRIPTION
NeuroWeb opened new crowdloan for extending its slot, more info available [here](https://docs.neuroweb.ai/polkadot/crowdloan). We are adding this metadata so it is easier for contributors to find our crowdloan as we opened it under new parachain id 3360 (you can confirm in the docs that this is NeuroWeb para id for this auction). This metadata will be removed once auction slot is won and we perform swap of leases.