### PR TITLE
fix: :lipstick: dropdown options not visible for metadata upgradable extensions

### DIFF
--- a/packages/page-settings/src/Metadata/Extensions.tsx
+++ b/packages/page-settings/src/Metadata/Extensions.tsx
@@ -93,6 +93,7 @@ function Extensions ({ chainInfo, className }: Props): React.ReactElement<Props>
 const StyledTable = styled(Table)`
   table {
     overflow: visible;
+    z-index: 2;
   }
 `;
 


### PR DESCRIPTION
This bug has been annoying me for a while now lol, increased the z-index to 2.
Thank you for all the awesome work guys.

Before:

![image](https://github.com/polkadot-js/apps/assets/48833948/9523f07a-9b64-40c2-b5af-6129f9ae9ae3)

After:

![image](https://github.com/polkadot-js/apps/assets/48833948/26357ec8-980b-4eba-8e7d-8f9723cccd47)
