### PR TITLE
Support requestStatusFor for usePreimage

### DIFF
--- a/packages/apps-routing/src/preimages.ts
+++ b/packages/apps-routing/src/preimages.ts
@@ -11,6 +11,7 @@ export default function create (t: TFunction): Route {
     display: {
       needsAccounts: true,
       needsApi: [
+        'query.preimage.requestStatusFor',
         'query.preimage.statusFor',
         'tx.preimage.notePreimage'
       ]

--- a/packages/page-preimages/src/Preimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/Preimage.tsx
@@ -20,8 +20,6 @@ interface Props {
 function Preimage ({ className, value }: Props): React.ReactElement<Props> {
   const info = usePreimage(value);
 
-  console.log('INFO: ', info);
-
   return (
     <tr className={className}>
       <Hash value={value} />

--- a/packages/page-preimages/src/Preimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/Preimage.tsx
@@ -20,6 +20,8 @@ interface Props {
 function Preimage ({ className, value }: Props): React.ReactElement<Props> {
   const info = usePreimage(value);
 
+  console.log('INFO: ', info);
+
   return (
     <tr className={className}>
       <Hash value={value} />

--- a/packages/page-preimages/src/usePreimages.ts
+++ b/packages/page-preimages/src/usePreimages.ts
@@ -34,11 +34,12 @@ function filter (records: EventRecord[]): Changes<Hash> {
 
 function usePreimagesImpl (): HexString[] | undefined {
   const { api } = useApi();
-  const startValue = useMapKeys(api.query.preimage.statusFor, EMPTY_PARAMS, OPT_HASH);
+  const startValueStatusFor = useMapKeys(api.query.preimage.statusFor, EMPTY_PARAMS, OPT_HASH);
+  const startvalueRequstStatusFor = useMapKeys(api.query.preimage.requestStatusFor, EMPTY_PARAMS, OPT_HASH);
   const hashes = useEventChanges([
     api.events.preimage.Cleared,
     api.events.preimage.Noted
-  ], filter, startValue);
+  ], filter, startValueStatusFor?.concat(startvalueRequstStatusFor || []));
 
   return useMemo(
     () => hashes?.map((h) => h.toHex()),

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -218,6 +218,8 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
     [api, hashOrBounded]
   );
 
+  // api.query.preimage.statusFor has been deprecated in favor of api.query.preimage.requestStatusFor.
+  // To ensure we get all preimages correctly we query both storages. see: https://github.com/polkadot-js/apps/pull/10310
   const optStatus = useCall<Option<PalletPreimageRequestStatus>>(!inlineData && paramsStatus && api.query.preimage?.statusFor, paramsStatus);
   const optRequstStatus = useCall<Option<PalletPreimageRequestStatus>>(!inlineData && paramsStatus && api.query.preimage?.requestStatusFor, paramsStatus);
   const someOptStatus = optStatus?.isSome ? optStatus : optRequstStatus;


### PR DESCRIPTION
closes: https://github.com/polkadot-js/apps/issues/10288, https://github.com/polkadot-js/apps/issues/10141

Due to the deprecation of `StatusFor` given https://github.com/paritytech/polkadot-sdk/pull/1363 the `usePreimage` hook needs to support both `StatusFor` and `RequestStatusFor` calls when gathering data for preimage hashes.