### PR TITLE
Fix break in backwards compatibility with preimages

### DIFF
--- a/packages/apps-routing/src/preimages.ts
+++ b/packages/apps-routing/src/preimages.ts
@@ -11,7 +11,6 @@ export default function create (t: TFunction): Route {
     display: {
       needsAccounts: true,
       needsApi: [
-        'query.preimage.requestStatusFor',
         'query.preimage.statusFor',
         'tx.preimage.notePreimage'
       ]


### PR DESCRIPTION
https://github.com/polkadot-js/apps/pull/10310 broke backwards compatibility for chains that don't have `requestStatusFor`. This PR fixes that issue.