### PR TITLE
Update translation.json

### DIFF
--- a/packages/apps/public/locales/fr/translation.json
+++ b/packages/apps/public/locales/fr/translation.json
@@ -865,7 +865,7 @@
   "Unable to retrieve the specified block details. {{error}}": "Impossible de récupérer les détails du bloc spécifié. {{error}}",
   "Unbid": "Retierer l'enchère",
   "Unbond": "Délier",
-  "Unbond funds": "Fonds déliés",
+  "Unbond funds": "Délier fonds",
   "Unbonding {{value}}": "Déliaison {{value}}",
   "Uncaught error. Something went wrong with the query and rendering of this component. {{message}}": "Une erreur non interceptée. Une erreur s'est produite avec la requête et le rendu de ce composant. {{message}}",
   "Undelegate": "Supprimer la déléguation",


### PR DESCRIPTION
Made en update on "Unbond funds", translation was not correct, using preterit instead of present.