### PR TITLE
dry run transactions prior to execution

### DIFF
--- a/packages/react-signer/src/PaymentInfo.tsx
+++ b/packages/react-signer/src/PaymentInfo.tsx
@@ -80,7 +80,7 @@ function PaymentInfo ({ accountId, className = '', extrinsic, isHeader }: Props)
         <MarkWarning content={t('The account does not have enough free funds (excluding locked/bonded/reserved) available to cover the transaction fees without dropping the balance below the account existential amount.')} />
       )}
       {isDryRunError && (
-        <MarkError content={t('The transaction would not be successfully executed')} />
+        <MarkError content={t('The transaction did not pass a dry run and would likely not be successfully executed')} />
       )}
     </>
   );


### PR DESCRIPTION
This PR adds dry run check prior to extrinsic submission and prints an alert if the extrinsic would fail in its execution. Useful to warn the user before needlessly spending network fees.


Screenshots:


<img width="1171" alt="Screenshot 2024-03-18 at 08 47 48" src="https://github.com/polkadot-js/apps/assets/2722756/2ade3625-0877-4a55-961a-d7489d92294c">
