### PR TITLE
Remove Automata 1RPC from Polkadot Relay Chain RPC list

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -881,7 +881,7 @@ export const prodRelayPolkadot: EndpointOption = {
   ],
   providers: {
     // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
-    'Automata 1RPC': 'wss://1rpc.io/dot',
+    // 'Automata 1RPC': 'wss://1rpc.io/dot',
     Blockops: 'wss://polkadot-public-rpc.blockops.network/ws', // https://github.com/polkadot-js/apps/issues/9840
     Dwellir: 'wss://polkadot-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',


### PR DESCRIPTION
This endpoint does not work; it keeps disconnecting and re-connecting. 

This has been ongoing for a while and a cause of complaints in the ecosystem, so I recommend we remove it until this problem is fixed.

I notice that it has already been commented out from prodParasPolkadot but this would also remove it from the prodRelayPolkadot list.