### PR TITLE
Add `klaos` to ethereum chains list

### DIFF
--- a/packages/apps-config/src/settings/ethereumChains.ts
+++ b/packages/apps-config/src/settings/ethereumChains.ts
@@ -35,5 +35,6 @@ export const ethereumChains = [
   'innovatorchain',
   'masverse',
   'laos',
+  'klaos',
   'muse'
 ];


### PR DESCRIPTION
similar to #10219, `klaos` and `laos` runtimes are separated, so we need both of them to be recognized as an EVM chain
