### PR TITLE
Fix MAX_SIGNATORIES

### DIFF
--- a/packages/page-accounts/src/modals/MultisigCreate.tsx
+++ b/packages/page-accounts/src/modals/MultisigCreate.tsx
@@ -34,7 +34,7 @@ interface UploadedFileData {
   uploadedSignatories: string[];
 }
 
-const MAX_SIGNATORIES = 16;
+const MAX_SIGNATORIES = 100;
 const BN_TWO = new BN(2);
 
 const acceptedFormats = ['application/json'];


### PR DESCRIPTION
Polkadot allows for multisig account with up to 100 signatories (see [`api.consts.multisig.maxSignatories`](https://polkadot.js.org/docs/polkadot/constants#maxsignatories-u32))