### PR TITLE
Fix apps-routing for staking (Westend)

### DIFF
--- a/packages/apps-routing/src/staking.ts
+++ b/packages/apps-routing/src/staking.ts
@@ -51,9 +51,18 @@ function needsApiCheck (api: ApiPromise): boolean {
       { claimedRewards: [1, 2, 3] }
     );
 
-    assert((v as unknown as { claimedRewards: Vec<u32> }).claimedRewards.eq([1, 2, 3]), 'Needs a claimedRewards array');
+    if ((v as unknown as { claimedRewards: Vec<u32> }).claimedRewards) {
+      assert((v as unknown as { claimedRewards: Vec<u32> }).claimedRewards.eq([1, 2, 3]), 'Needs a claimedRewards array');
+    } else {
+      const v = api.registry.createType<PalletStakingStakingLedger>(
+        unwrapStorageType(api.registry, api.query.staking.ledger.creator.meta.type),
+        { legacyClaimedRewards: [1, 2, 3] }
+      );
+
+      assert(v.legacyClaimedRewards.eq([1, 2, 3]), 'Needs a legacyClaimedRewards array');
+    }
   } catch {
-    console.warn('No known claimedRewards inside staking ledger, disabling staking route');
+    console.warn('No known legacyClaimedRewards or claimedRewards inside staking ledger, disabling staking route');
 
     return false;
   }

--- a/packages/apps-routing/src/staking.ts
+++ b/packages/apps-routing/src/staking.ts
@@ -45,6 +45,7 @@ function needsApiCheck (api: ApiPromise): boolean {
     return false;
   }
 
+  // For compatibility - `api.query.staking.ledger` returns `legacyClaimedRewards` instead of `claimedRewards` as of v1.4
   try {
     const v = api.registry.createType<PalletStakingStakingLedger>(
       unwrapStorageType(api.registry, api.query.staking.ledger.creator.meta.type),


### PR DESCRIPTION
rel: https://github.com/polkadot-js/apps/issues/10004


Since `api.query.staking.ledger` returns `legacyClaimedRewards` now instead of `claimedRewards` it was stopping westend from showing up. 

Therefore we added some compatibility logic inside of apps-routing for staking.

There will also need to be follow up work done to get the rest of the calls compatible.

closes: https://github.com/polkadot-js/apps/issues/10388