### PR TITLE
Remove Automata 1RPC from Kusama

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -971,7 +971,7 @@ export const prodRelayKusama: EndpointOption = {
   ],
   providers: {
     // 'Geometry Labs': 'wss://kusama.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
-    'Automata 1RPC': 'wss://1rpc.io/ksm',
+    // 'Automata 1RPC': 'wss://1rpc.io/ksm',
     Blockops: 'wss://kusama-public-rpc.blockops.network/ws', // https://github.com/polkadot-js/apps/issues/9840
     Dwellir: 'wss://kusama-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',


### PR DESCRIPTION
The Automata 1RPC was previously removed from Polkadot RPC endpoint list, due to constant re-connects (see https://github.com/polkadot-js/apps/pull/10366 ). The same issue also occurs on their Kusama endpoint and I recommend to remove this as well.