### PR TITLE
Show parachain names in Paseo

### DIFF
--- a/packages/apps-config/src/api/constants.ts
+++ b/packages/apps-config/src/api/constants.ts
@@ -23,7 +23,7 @@ export const POLKADOT_DENOM_BLOCK = new BN(1248328);
 
 export const ROCOCO_GENESIS = getGenesis('rococo');
 
-export const PASEO_GENESIS = '0x74300973617e2936e22d46e94fee5016a1a514747ae108277b770d02b47d37d9';
+export const PASEO_GENESIS = '0x77afd6190f1554ad45fd0d31aee62aacc33c6db0ea801129acb813f913e0764f';
 
 export const WESTEND_GENESIS = getGenesis('westend');
 

--- a/packages/apps-config/src/ui/identityIcons/index.ts
+++ b/packages/apps-config/src/ui/identityIcons/index.ts
@@ -18,7 +18,8 @@ export const identitySpec: Record<string, string> = [
   ['kusama', 'polkadot'],
   ['polkadot', 'polkadot'],
   ['rococo', 'polkadot'],
-  ['westend', 'polkadot']
+  ['westend', 'polkadot'],
+  ['paseo', 'polkadot']
 ].reduce((icons, [spec, icon]): Record<string, string> => ({
   ...icons,
   [spec.toLowerCase().replace(/-/g, ' ')]: icon


### PR DESCRIPTION
This change fixes parachain names not showing in Paseo testnet.

After the fix:
![image](https://github.com/polkadot-js/apps/assets/11448715/6b10c919-f894-4a9a-a7cb-09cc2e47bac0)
The validator set is still not properly displayed in any relay :thinking: 
