### PR TITLE
Query slot duration for block interval

### DIFF
--- a/packages/react-hooks/src/useBlockInterval.ts
+++ b/packages/react-hooks/src/useBlockInterval.ts
@@ -30,7 +30,7 @@ function calcInterval (api: ApiPromise): BN {
         ? api.consts.timestamp.minimumPeriod.mul(BN_TWO)
         : api.query.parachainSystem
           // default guess for a parachain
-          ? DEFAULT_TIME.mul(BN_TWO)
+          ? api.consts.aura?.slotDuration ?? DEFAULT_TIME.mul(BN_TWO)
           // default guess for others
           : DEFAULT_TIME
     )


### PR DESCRIPTION
Currently the target block for async-backing-enabled parachain does not work correctly. The [async backing guide](https://wiki.polkadot.network/docs/maintain-guides-async-backing#phase-3---activate-async-backing) clearly states parachains must set `pallet_timestamp`'s `MinimumPeriod` to zero, yet this yields an error in PolkadotJS, displaying 12-second block times when blocks are actually being produced every 6 seconds.

<img width="1048" alt="Screenshot 2024-04-10 at 11 50 15" src="https://github.com/polkadot-js/apps/assets/2722756/63270c98-5c19-4066-a613-c2d37b8c3c9c">

After [exposing `SlotDuration` as a constant](https://github.com/paritytech/polkadot-sdk/commit/463ccb8f9028ebf5f7fc53d7e835c21f43172253) on polkadot-v1.10.0 we can use this value to calculate the interval between blocks and hence correctly display the value in the UI.