### PR TITLE
Identity fix. Username has been introduced in identity pallet. 

### DIFF
--- a/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
+++ b/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2024 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
+import type { Bytes, Option } from '@polkadot/types';
 import type { PalletIdentityRegistration } from '@polkadot/types/lookup';
 import type { ITuple } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
@@ -35,7 +35,7 @@ const JUDGEMENT_ENUM = [
 ];
 
 const OPT_ID = {
-  transform: (optId: Option<ITuple<[PalletIdentityRegistration]>>): HexString | null =>
+  transform: (optId: Option<ITuple<[PalletIdentityRegistration, Option<Bytes>]>>): HexString | null =>
     optId.isSome
       ? optId.unwrap()[0].info.hash.toHex()
       : null

--- a/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
+++ b/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
@@ -3,6 +3,7 @@
 
 import type { Option } from '@polkadot/types';
 import type { PalletIdentityRegistration } from '@polkadot/types/lookup';
+import type { ITuple } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
 
 import React, { useEffect, useState } from 'react';
@@ -34,9 +35,9 @@ const JUDGEMENT_ENUM = [
 ];
 
 const OPT_ID = {
-  transform: (optId: Option<PalletIdentityRegistration>): HexString | null =>
+  transform: (optId: Option<ITuple<[PalletIdentityRegistration]>>): HexString | null =>
     optId.isSome
-      ? optId.unwrap().info.hash.toHex()
+      ? optId.unwrap()[0].info.hash.toHex()
       : null
 };
 


### PR DESCRIPTION
identity.identityOf call now returning a tuple with username. Based on this [commit](https://github.com/paritytech/polkadot-sdk/commit/d1f678c0ec44e9734cf242247dab90c2678774a9#diff-4a95a3948151a729b1fa4e91da9c72cdc6cd2d1611842fca6f177efeed34fd1aR221) 