### PR TITLE
Archive Logion solochain and switch testnet

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -332,10 +332,9 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'logion',
     providers: {
-      'Logion 1': 'wss://rpc01.logion.network',
-      'Logion 2': 'wss://rpc02.logion.network'
+      'Logion 1': 'wss://rpc01.logion.network'
     },
-    text: 'Logion Standalone',
+    text: 'Logion Solochain (Archive)',
     ui: {
       color: 'rgb(21, 38, 101)',
       logo: chainsLogionPNG

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -583,9 +583,9 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'logion',
     providers: {
-      Logion: 'wss://test-rpc01.logion.network'
+      Logion: 'wss://test-para-rpc01.logion.network'
     },
-    text: 'logion Standalone Testnet',
+    text: 'Logion Testnet',
     ui: {
       color: 'rgb(21, 38, 101)',
       logo: chainsLogionPNG


### PR DESCRIPTION
* Logion solochain is now archived, a single RPC node remains.
* Logion solochain testnet has been retired.

logion-network/logion-internal#1209