### PR TITLE
Backwards compatibility for identityOf

### DIFF
--- a/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
+++ b/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
@@ -44,7 +44,7 @@ const OPT_ID = {
     return !id
       ? null
       : Array.isArray(id)
-        ? optId.unwrap()[0].info.hash.toHex()
+        ? id[0].info.hash.toHex()
         : (id as unknown as PalletIdentityRegistration).info.hash.toHex();
   }
 };

--- a/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
+++ b/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
@@ -41,9 +41,11 @@ const OPT_ID = {
       : null;
 
     // Backwards compatibility - https://github.com/polkadot-js/apps/issues/10493
-    return Array.isArray(id)
-      ? optId.unwrap()[0].info.hash.toHex()
-      : (id as unknown as PalletIdentityRegistration).info.hash.toHex();
+    return !id
+      ? null
+      : Array.isArray(id)
+        ? optId.unwrap()[0].info.hash.toHex()
+        : (id as unknown as PalletIdentityRegistration).info.hash.toHex();
   }
 };
 

--- a/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
+++ b/packages/react-components/src/AccountSidebar/RegistrarJudgement.tsx
@@ -35,10 +35,16 @@ const JUDGEMENT_ENUM = [
 ];
 
 const OPT_ID = {
-  transform: (optId: Option<ITuple<[PalletIdentityRegistration, Option<Bytes>]>>): HexString | null =>
-    optId.isSome
+  transform: (optId: Option<ITuple<[PalletIdentityRegistration, Option<Bytes>]>>): HexString | null => {
+    const id = optId.isSome
+      ? optId.unwrap()
+      : null;
+
+    // Backwards compatibility - https://github.com/polkadot-js/apps/issues/10493
+    return Array.isArray(id)
       ? optId.unwrap()[0].info.hash.toHex()
-      : null
+      : (id as unknown as PalletIdentityRegistration).info.hash.toHex();
+  }
 };
 
 function RegistrarJudgement ({ address, registrars, toggleJudgement }: Props): React.ReactElement<Props> {


### PR DESCRIPTION
rel: https://github.com/polkadot-js/apps/issues/10493

https://github.com/polkadot-js/apps/pull/10491 broke backwards compatibility for chains that did not update their identity pallets. This ensures that there is both forward and backwards compatibility