### PR TITLE
Stakeworld people chain rpc endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -980,7 +980,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     info: 'kusamaPeople',
     paraId: 1004,
     providers: {
-      Parity: 'wss://kusama-people-rpc.polkadot.io'
+      Parity: 'wss://kusama-people-rpc.polkadot.io',
+      Stakeworld: 'wss://ksm-rpc.stakeworld.io/people'
     },
     teleport: [-1],
     text: 'People',


### PR DESCRIPTION
I would like to add a people chain rpc endpoint, its using the most current [chain-spec](https://raw.githubusercontent.com/paritytech/polkadot-sdk/930b0462d347d56d9d8751b1ca42b210ed6d9c51/cumulus/parachains/chain-specs/people-kusama.json).