### PR TITLE
Add Subspace Gemini 3h Nova endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -963,7 +963,8 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'subspace-gemini-3h-nova',
     providers: {
-      Subspace: 'wss://nova-0.gemini-3h.subspace.network/ws'
+      EU1: 'wss://nova-0.gemini-3h.subspace.network/ws',
+      EU2: 'wss://nova-1.gemini-3h.subspace.network/ws'
     },
     text: 'Subspace Gemini 3h Nova',
     ui: {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -961,6 +961,17 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    info: 'subspace-gemini-3h-nova',
+    providers: {
+      Subspace: 'wss://nova-0.gemini-3h.subspace.network/ws'
+    },
+    text: 'Subspace Gemini 3h Nova',
+    ui: {
+      color: '#562b8e',
+      logo: nodesSubspacePNG
+    }
+  },
+  {
     info: 'subspace',
     providers: {
       // 'Subspace Network': 'wss://test-rpc.subspace.network' // https://github.com/polkadot-js/apps/issues/8598


### PR DESCRIPTION
Add the Subspace Gemini 3h Nova endpoint to the list of available test networks.