### PR TITLE
Set Kusama People as identity provider for Kreivo

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -438,8 +438,8 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
       Kippu: 'wss://kreivo.kippu.rocks/',
       Virto: 'wss://kreivo.io/'
     },
-    text: 'Kreivo - By Virto',
     relayName: 'kusama',
+    text: 'Kreivo - By Virto',
     ui: {
       color: '#294940',
       identityIcon: 'polkadot',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -432,12 +432,14 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
   {
     homepage: 'https://virto.network/',
     info: 'kreivo',
+    isPeopleForIdentity: true,
     paraId: 2281,
     providers: {
       Kippu: 'wss://kreivo.kippu.rocks/',
       Virto: 'wss://kreivo.io/'
     },
     text: 'Kreivo - By Virto',
+    relayName: 'kusama',
     ui: {
       color: '#294940',
       identityIcon: 'polkadot',


### PR DESCRIPTION
Following #10598, we're registering People as the identity provider for Kreivo in polkadot.js apps