### PR TITLE
Add proof size summary

### DIFF
--- a/packages/page-explorer/src/BlockInfo/ByHash.tsx
+++ b/packages/page-explorer/src/BlockInfo/ByHash.tsx
@@ -3,6 +3,7 @@
 
 import type { HeaderExtended } from '@polkadot/api-derive/types';
 import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
+import type { V2Weight } from '@polkadot/react-hooks/useWeight';
 import type { EventRecord, RuntimeVersionPartial, SignedBlock } from '@polkadot/types/interfaces';
 
 import React, { useEffect, useMemo, useState } from 'react';
@@ -59,7 +60,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
   const [isVersionCurrent, maxBlockWeight] = useMemo(
     () => [
       !!runtimeVersion && api.runtimeVersion.specName.eq(runtimeVersion.specName) && api.runtimeVersion.specVersion.eq(runtimeVersion.specVersion),
-      api.consts.system.blockWeights && api.consts.system.blockWeights.maxBlock && convertWeight(api.consts.system.blockWeights.maxBlock).v1Weight
+      api.consts.system.blockWeights && api.consts.system.blockWeights.maxBlock && convertWeight(api.consts.system.blockWeights.maxBlock).v2Weight
     ],
     [api, runtimeVersion]
   );
@@ -123,7 +124,8 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
     <div className={className}>
       <Summary
         events={events}
-        maxBlockWeight={maxBlockWeight}
+        maxBlockWeight={(maxBlockWeight as V2Weight).refTime.toBn()}
+        maxProofSize={(maxBlockWeight as V2Weight).proofSize.toBn()}
         signedBlock={getBlock}
       />
       <Table header={header}>
@@ -167,7 +169,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
           <Extrinsics
             blockNumber={blockNumber}
             events={events}
-            maxBlockWeight={maxBlockWeight}
+            maxBlockWeight={(maxBlockWeight as V2Weight).refTime.toBn()}
             value={getBlock.block.extrinsics}
             withLink={isVersionCurrent}
           />

--- a/packages/page-explorer/src/BlockInfo/Summary.tsx
+++ b/packages/page-explorer/src/BlockInfo/Summary.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
+import type { V2Weight } from '@polkadot/react-hooks/useWeight';
 import type { Balance, DispatchInfo, SignedBlock } from '@polkadot/types/interfaces';
 
 import React, { useMemo } from 'react';
@@ -10,41 +11,47 @@ import { CardSummary, SummaryBox } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
 import { FormatBalance } from '@polkadot/react-query';
-import { BN, BN_ONE, BN_THREE, BN_TWO, formatNumber } from '@polkadot/util';
+import { BN, BN_ONE, BN_THREE, BN_TWO, BN_ZERO, formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
 
 interface Props {
   events?: KeyedEvent[] | null;
   maxBlockWeight?: BN;
+  maxProofSize?: BN;
   signedBlock?: SignedBlock;
 }
 
-function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?] {
+function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?] {
   return events
-    ? events.reduce(([deposits, transfers, weight], { record: { event: { data, method, section } } }) => [
-      section === 'balances' && method === 'Deposit'
-        ? deposits.iadd(data[1] as Balance)
-        : deposits,
-      section === 'balances' && method === 'Transfer'
-        ? transfers.iadd(data[2] as Balance)
-        : transfers,
-      section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
-        ? weight.iadd(
-          convertWeight(
+    ? events.reduce(([deposits, transfers, weight], { record: { event: { data, method, section } } }) => {
+      return [
+        section === 'balances' && method === 'Deposit'
+          ? deposits.iadd(data[1] as Balance)
+          : deposits,
+        section === 'balances' && method === 'Transfer'
+          ? transfers.iadd(data[2] as Balance)
+          : transfers,
+        section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
+          ? weight.iadd(convertWeight(
             ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo).weight
-          ).v1Weight
-        )
-        : weight
-    ], [new BN(0), new BN(0), new BN(0)])
+          ).v1Weight)
+          : weight,
+        section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
+          ? (convertWeight(
+            ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo).weight
+          ).v2Weight as V2Weight).proofSize.toBn()
+          : BN_ZERO
+      ];
+    }, [new BN(0), new BN(0), new BN(0), new BN(0)])
     : [];
 }
 
-function Summary ({ events, maxBlockWeight, signedBlock }: Props): React.ReactElement<Props> | null {
+function Summary ({ events, maxBlockWeight, maxProofSize, signedBlock }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
 
-  const [deposits, transfers, weight] = useMemo(
+  const [deposits, transfers, weight, size] = useMemo(
     () => extractEventDetails(events),
     [events]
   );
@@ -86,6 +93,18 @@ function Summary ({ events, maxBlockWeight, signedBlock }: Props): React.ReactEl
             ? formatNumber(weight)
             : <span className='--tmp'>999,999,999</span>}
         </CardSummary>
+        {maxProofSize && size &&
+          <CardSummary
+            label={t('proof size')}
+            progress={{
+              hideValue: true,
+              isBlurred: false,
+              total: maxProofSize,
+              value: size
+            }}
+          >
+            {formatNumber(size)}
+          </CardSummary>}
       </section>
       <section className='media--900'>
         <CardSummary label={t('event count')}>

--- a/packages/react-hooks/src/useWeight.ts
+++ b/packages/react-hooks/src/useWeight.ts
@@ -16,7 +16,7 @@ import { useIsMountedRef } from './useIsMountedRef.js';
 
 type V1Weight = INumber;
 
-interface V2Weight {
+export interface V2Weight {
   refTime: ICompact<INumber>;
   proofSize: ICompact<INumber>;
 }
@@ -48,13 +48,13 @@ export function convertWeight (weight: V1Weight | V2Weight): WeightResult {
     // V1.5 weight (when not converted)
     const refTime = (weight as V2Weight).refTime.toBn();
 
-    return { v1Weight: refTime, v2Weight: { refTime } };
+    return { v1Weight: refTime, v2Weight: { proofSize: BN_ZERO, refTime } };
   }
 
   // V1 weight
   const refTime = (weight as V1Weight).toBn();
 
-  return { v1Weight: refTime, v2Weight: { refTime } };
+  return { v1Weight: refTime, v2Weight: { proofSize: BN_ZERO, refTime } };
 }
 
 // for a given call, calculate the weight


### PR DESCRIPTION
# Description

This PR includes the proof size as a summary along with the consumed weight. 

## Rationale
When checking the weights, there could be occasions when one would expect a block to be fully utilized, while weight consumption is low. This is due to the fact that the PoV is quite large, since weights in V2 are two-dimensional. The main idea is to display both dimensions of the weight, and not just one.

## Screenshots

<img width="1143" alt="Screenshot 2024-06-04 at 15 03 59" src="https://github.com/polkadot-js/apps/assets/2722756/b26ab54e-24ae-437b-8995-68fd9343561f">
