### PR TITLE
Higher precision of referenda graphs

### DIFF
--- a/packages/page-referenda/src/Referenda/Referendum.tsx
+++ b/packages/page-referenda/src/Referenda/Referendum.tsx
@@ -143,14 +143,14 @@ function getChartResult (totalEligible: BN, isConvictionVote: boolean, info: Pal
 
       // Bringing it to a higher precision.
       // Otherwise, graphs with short periods (on dev chains) are invalid.
-      const stepWithPrecision = x[x.length - 1].sub(x[0]).muln(100).divn(x.length)
+      const stepWithPrecision = x[x.length - 1].sub(x[0]).muln(100).divn(x.length);
       const lastIndex = x.length - 1;
       const lastBlock = endConfirm?.add(track.minEnactmentPeriod);
 
       // if the confirmation end is later than shown on our graph, we extend it
-      if (lastBlock?.gt(since.add(x[lastIndex]))) { 
+      if (lastBlock?.gt(since.add(x[lastIndex]))) {
         let currentBlockWithPrecision = x[lastIndex].add(since).muln(100).add(stepWithPrecision);
-        let currentBlock = currentBlockWithPrecision.divn(100)
+        let currentBlock = currentBlockWithPrecision.divn(100);
 
         do {
           labels.push(formatNumber(currentBlock));
@@ -167,7 +167,7 @@ function getChartResult (totalEligible: BN, isConvictionVote: boolean, info: Pal
           values[1][2].push(values[1][2][lastIndex]);
 
           currentBlockWithPrecision = currentBlockWithPrecision.add(stepWithPrecision);
-          currentBlock = currentBlockWithPrecision.divn(100)
+          currentBlock = currentBlockWithPrecision.divn(100);
         } while (currentBlock.lt(lastBlock));
       }
 

--- a/packages/page-referenda/src/Referenda/Referendum.tsx
+++ b/packages/page-referenda/src/Referenda/Referendum.tsx
@@ -141,13 +141,16 @@ function getChartResult (totalEligible: BN, isConvictionVote: boolean, info: Pal
         supx = (supn || supx !== -1) ? supx : i;
       }
 
-      const step = x[1].sub(x[0]);
+      // Bringing it to a higher precision.
+      // Otherwise, graphs with short periods (on dev chains) are invalid.
+      const stepWithPrecision = x[x.length - 1].sub(x[0]).muln(100).divn(x.length)
       const lastIndex = x.length - 1;
       const lastBlock = endConfirm?.add(track.minEnactmentPeriod);
 
       // if the confirmation end is later than shown on our graph, we extend it
-      if (lastBlock?.gt(since.add(x[lastIndex]))) {
-        let currentBlock = x[lastIndex].add(since).add(step);
+      if (lastBlock?.gt(since.add(x[lastIndex]))) { 
+        let currentBlockWithPrecision = x[lastIndex].add(since).muln(100).add(stepWithPrecision);
+        let currentBlock = currentBlockWithPrecision.divn(100)
 
         do {
           labels.push(formatNumber(currentBlock));
@@ -163,7 +166,8 @@ function getChartResult (totalEligible: BN, isConvictionVote: boolean, info: Pal
           values[1][1].push(values[1][1][lastIndex]);
           values[1][2].push(values[1][2][lastIndex]);
 
-          currentBlock = currentBlock.add(step);
+          currentBlockWithPrecision = currentBlockWithPrecision.add(stepWithPrecision);
+          currentBlock = currentBlockWithPrecision.divn(100)
         } while (currentBlock.lt(lastBlock));
       }
 

--- a/packages/page-referenda/src/util.ts
+++ b/packages/page-referenda/src/util.ts
@@ -227,16 +227,19 @@ export function calcCurves ({ decisionPeriod, minApproval, minSupport }: PalletR
   const approval = new Array<BN>(CURVE_LENGTH);
   const support = new Array<BN>(CURVE_LENGTH);
   const x = new Array<BN>(CURVE_LENGTH);
-  const step = decisionPeriod.divn(CURVE_LENGTH);
   const last = CURVE_LENGTH - 1;
-  let current = new BN(0);
+  // Bringing it to a higher precision before dividing by curve length.
+  // Otherwise, graphs with short periods (on dev chains) are invalid.
+  const stepWithPrecision = decisionPeriod.muln(100).divn(CURVE_LENGTH);
+  let currentWithPrecision = new BN(0);
 
   for (let i = 0; i < last; i++) {
+    const current = currentWithPrecision.divn(100)
     approval[i] = curveThreshold(minApproval, current, decisionPeriod);
     support[i] = curveThreshold(minSupport, current, decisionPeriod);
     x[i] = current;
 
-    current = current.add(step);
+    currentWithPrecision = currentWithPrecision.add(stepWithPrecision);
   }
 
   // since we may be lossy with the step, we explicitly calc the final point at 100%

--- a/packages/page-referenda/src/util.ts
+++ b/packages/page-referenda/src/util.ts
@@ -234,7 +234,8 @@ export function calcCurves ({ decisionPeriod, minApproval, minSupport }: PalletR
   let currentWithPrecision = new BN(0);
 
   for (let i = 0; i < last; i++) {
-    const current = currentWithPrecision.divn(100)
+    const current = currentWithPrecision.divn(100);
+
     approval[i] = curveThreshold(minApproval, current, decisionPeriod);
     support[i] = curveThreshold(minSupport, current, decisionPeriod);
     x[i] = current;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/apps/issues/9963

Currently, the UI is not prepared to display graphs of referenda with short timeframes (which exist on development chains).

For example [here](https://github.com/polkadot-js/apps/blob/6b8e76edbd2024ee10671ed1a80300e9e8e8da8d/packages/page-referenda/src/util.ts#L230), if the decision period is short enough, the division will bring the `step` to `0` and no graph will work.

It causes the graphs to be botched, and even freezes the UI in an infinite loop in some cases (when the confirmation period overruns the usual decision period).

In the PR, I'm bringing the precision up by multiplying by `100` first, and dividing back by `100` after relevant calculations.

It fixes the graphs on local development chains.

I also compared side-by-side the changed UI with un-changed version, looking at current Polkadot referenda - all seems good to me.