### PR TITLE
add zondax paseo rpc endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -211,7 +211,8 @@ export const testRelayPaseo: EndpointOption = {
     Dwellir: 'wss://paseo-rpc.dwellir.com',
     IBP1: 'wss://rpc.ibp.network/paseo',
     IBP2: 'wss://rpc.dotters.network/paseo',
-    StakeWorld: 'wss://pas-rpc.stakeworld.io'
+    StakeWorld: 'wss://pas-rpc.stakeworld.io',
+    Zondax: 'wss://api.zondax.ch/paso/node/rpc'
     // 'light client': 'light://substrate-connect/paseo'
   },
   teleport: getTeleports(testParasPaseoCommon),

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -212,7 +212,7 @@ export const testRelayPaseo: EndpointOption = {
     IBP1: 'wss://rpc.ibp.network/paseo',
     IBP2: 'wss://rpc.dotters.network/paseo',
     StakeWorld: 'wss://pas-rpc.stakeworld.io',
-    Zondax: 'wss://api.zondax.ch/paso/node/rpc'
+    Zondax: 'wss://api.zondax.ch/pas/node/rpc'
     // 'light client': 'light://substrate-connect/paseo'
   },
   teleport: getTeleports(testParasPaseoCommon),


### PR DESCRIPTION
Hello there! 
Emmanuel from Zondax, currently part of the teams that maintain paseo network.
We would like to contribute here to Polkadot-JS adding our archival paseo node to the available ones to use. 