### PR TITLE
Enable `withSignedTransaction` for signing and sending payloads

### DIFF
--- a/packages/react-signer/src/TxSigned.tsx
+++ b/packages/react-signer/src/TxSigned.tsx
@@ -326,7 +326,7 @@ function TxSigned ({ className, currentItem, isQueueSubmit, queueSize, requestAd
       if (senderInfo.signAddress) {
         const [tx, [status, pairOrAddress, options, isMockSign]] = await Promise.all([
           wrapTx(api, currentItem, senderInfo),
-          extractParams(api, senderInfo.signAddress, { nonce: -1, tip }, getLedger, setQrState)
+          extractParams(api, senderInfo.signAddress, { nonce: -1, tip, withSignedTransaction: true }, getLedger, setQrState)
         ]);
 
         queueSetTxStatus(currentItem.id, status);
@@ -342,7 +342,7 @@ function TxSigned ({ className, currentItem, isQueueSubmit, queueSize, requestAd
       if (senderInfo.signAddress) {
         const [tx, [, pairOrAddress, options, isMockSign]] = await Promise.all([
           wrapTx(api, currentItem, senderInfo),
-          extractParams(api, senderInfo.signAddress, { ...signedOptions, tip }, getLedger, setQrState)
+          extractParams(api, senderInfo.signAddress, { ...signedOptions, tip, withSignedTransaction: true }, getLedger, setQrState)
         ]);
 
         setSignedTx(await signAsync(queueSetTxStatus, currentItem, tx, pairOrAddress, options, api, isMockSign));

--- a/packages/test-support/src/transaction/execute.ts
+++ b/packages/test-support/src/transaction/execute.ts
@@ -35,6 +35,6 @@ export async function execute (extrinsic: SubmittableExtrinsic<'promise'>, signe
     }
   }
 
-  await extrinsic.signAndSend(signer, sendStatusCb);
+  await extrinsic.signAndSend(signer, { withSignedTransaction: true }, sendStatusCb);
   await waitFor(() => currentTxDone, { timeout: 20000 });
 }

--- a/packages/test-support/src/transaction/execute.ts
+++ b/packages/test-support/src/transaction/execute.ts
@@ -35,6 +35,6 @@ export async function execute (extrinsic: SubmittableExtrinsic<'promise'>, signe
     }
   }
 
-  await extrinsic.signAndSend(signer, { withSignedTransaction: true }, sendStatusCb);
+  await extrinsic.signAndSend(signer, sendStatusCb);
   await waitFor(() => currentTxDone, { timeout: 20000 });
 }


### PR DESCRIPTION
This PR enables `withSignedTransaction` for signers. Please refer to the following PR's for more information: 

https://github.com/polkadot-js/api/pull/5920
https://github.com/polkadot-js/api/pull/5922