### PR TITLE
Use `forceBatch` in Staking Payout

### DIFF
--- a/packages/page-staking/src/Payouts/PayButton.tsx
+++ b/packages/page-staking/src/Payouts/PayButton.tsx
@@ -3,6 +3,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import type { BatchOptions } from '@polkadot/react-hooks/types';
 import type { u32 } from '@polkadot/types';
 import type { EraIndex } from '@polkadot/types/interfaces';
 import type { PayoutValidator } from './types.js';
@@ -13,7 +14,6 @@ import { AddressMini, Button, InputAddress, Modal, Static, styled, TxButton } fr
 import { useApi, useToggle, useTxBatch } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
-import type { BatchOptions } from '@polkadot/react-hooks/types';
 
 interface Props {
   className?: string;
@@ -64,7 +64,7 @@ function PayButton ({ className, isAll, isDisabled, payout }: Props): React.Reac
   const batchOpts = useMemo<BatchOptions>(
     () => ({
       max: 36 * 64 / ((api.consts.staking.maxNominatorRewardedPerValidator as u32)?.toNumber() || 64),
-      type: "force"
+      type: 'force'
     }),
     [api]
   );

--- a/packages/page-staking/src/Payouts/PayButton.tsx
+++ b/packages/page-staking/src/Payouts/PayButton.tsx
@@ -13,6 +13,7 @@ import { AddressMini, Button, InputAddress, Modal, Static, styled, TxButton } fr
 import { useApi, useToggle, useTxBatch } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
+import type { BatchOptions } from '@polkadot/react-hooks/types';
 
 interface Props {
   className?: string;
@@ -60,9 +61,10 @@ function PayButton ({ className, isAll, isDisabled, payout }: Props): React.Reac
   const [isVisible, togglePayout] = useToggle();
   const [accountId, setAccount] = useState<string | null>(null);
   const [txs, setTxs] = useState<SubmittableExtrinsic<'promise'>[] | null>(null);
-  const batchOpts = useMemo(
+  const batchOpts = useMemo<BatchOptions>(
     () => ({
-      max: 36 * 64 / ((api.consts.staking.maxNominatorRewardedPerValidator as u32)?.toNumber() || 64)
+      max: 36 * 64 / ((api.consts.staking.maxNominatorRewardedPerValidator as u32)?.toNumber() || 64),
+      type: "force"
     }),
     [api]
   );


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/10712

I tested it locally with `fast-runtime` to be sure. Seems to do what it's supposed to do.

---

![Screenshot 2024-07-08 at 13 03 00](https://github.com/polkadot-js/apps/assets/12039224/197bb2f6-32c8-43b2-b935-02fe89d4d0d8)

---

![Screenshot 2024-07-08 at 13 04 46](https://github.com/polkadot-js/apps/assets/12039224/658b79ba-1e6c-41b4-a55d-b473a293cfa0)
