### PR TITLE
Not show identify in account page for failed set identity txs.

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -299,7 +299,7 @@ export function ApiCtxRoot ({ apiUrl, children, isElectron, store: keyringStore 
     [apiUrl, isElectron]
   );
   // TODO: Once the people migration is complete for polkadot, we can remove the polkadot check at the end.
-  const enableIdentity = apiEndpoint?.isPeople || (isNumber(apiEndpoint?.paraId) && (apiEndpoint?.paraId >= 2000)) || apiEndpoint?.info?.toLowerCase() === 'polkadot' || apiEndpoint?.info?.toLowerCase() === 'paseo';
+  const enableIdentity = apiEndpoint?.isPeople || (isNumber(apiEndpoint?.paraId) && (apiEndpoint?.paraId >= 2000)) || apiEndpoint?.info?.toLowerCase() === 'paseo';
   // TODO remove `(apiEndpoint?.relayName === 'polkadot' && !apiEndpoint?.isRelay && apiRelay)` once polkadot is migrated over to the people chain for identities.
   const value = useMemo<ApiProps>(
     () => objectSpread({}, state, { api: statics.api, apiEndpoint, apiError, apiIdentity: (apiEndpoint?.relayName === 'polkadot' && !apiEndpoint?.isRelay && apiRelay) || ((apiEndpoint?.isPeopleForIdentity && apiSystemPeople) || statics.api), apiRelay, apiSystemPeople, apiUrl, createLink, enableIdentity, extensions, isApiConnected, isApiInitialized, isElectron, isLocalFork, isWaitingInjected: !extensions }),


### PR DESCRIPTION
Failed transactions, https://polkadot.subscan.io/extrinsic?module=identity&call=set_identity

UI after the fix:
<img width="544" alt="image" src="https://github.com/polkadot-js/apps/assets/10568673/dcb9ccd8-db69-402a-80f7-43c2fc3eafc1">

