### PR TITLE
Try decoding a preimage as a transaction

### DIFF
--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -9,7 +9,7 @@ import type { DisplayedJudgement } from '@polkadot/react-components/types';
 import type { Option, u32, u128, Vec } from '@polkadot/types';
 import type { AccountId, BlockNumber, Call, Hash, SessionIndex, ValidatorPrefs } from '@polkadot/types/interfaces';
 import type { PalletPreimageRequestStatus, PalletStakingRewardDestination, PalletStakingStakingLedger, SpStakingExposurePage, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
-import type { ICompact, IExtrinsic, INumber, Registry } from '@polkadot/types/types';
+import type { ICompact, IExtrinsic, INumber } from '@polkadot/types/types';
 import type { KeyringJson$Meta } from '@polkadot/ui-keyring/types';
 import type { BN } from '@polkadot/util';
 import type { HexString } from '@polkadot/util/types';
@@ -192,7 +192,6 @@ export interface PreimageStatus {
   isHashParam: boolean;
   proposalHash: HexString;
   proposalLength?: BN;
-  registry: Registry;
   status: PalletPreimageRequestStatus | null;
 }
 

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -98,7 +98,6 @@ export function getPreimageHash (api: ApiPromise, hashOrBounded: Hash | HexStrin
       isHashParam: getParamType(api) === 'hash',
       proposalHash,
       proposalLength: inlineData && new BN(inlineData.length),
-      registry: api.registry,
       status: null
     }
   };

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -104,7 +104,7 @@ export function getPreimageHash (api: ApiPromise, hashOrBounded: Hash | HexStrin
 }
 
 /** @internal Creates a final result */
-function createResult (interimResult: PreimageStatus, optBytes: Option<Bytes> | Uint8Array): Preimage {
+function createResult (api: ApiPromise, interimResult: PreimageStatus, optBytes: Option<Bytes> | Uint8Array): Preimage {
   const callData = isU8a(optBytes)
     ? optBytes
     : optBytes.unwrapOr(null);
@@ -237,14 +237,14 @@ function usePreimageImpl (hashOrBounded?: Hash | HexString | FrameSupportPreimag
   return useMemo(
     () => resultPreimageFor
       ? optBytes
-        ? createResult(resultPreimageFor, optBytes)
+        ? createResult(api, resultPreimageFor, optBytes)
         : resultPreimageFor
       : resultPreimageHash
         ? inlineData
-          ? createResult(resultPreimageHash, inlineData)
+          ? createResult(api, resultPreimageHash, inlineData)
           : resultPreimageHash
         : undefined,
-    [inlineData, optBytes, resultPreimageHash, resultPreimageFor]
+    [api, inlineData, optBytes, resultPreimageHash, resultPreimageFor]
   );
 }
 

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -3,7 +3,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { Bytes, u32, u128 } from '@polkadot/types';
-import type { AccountId, Call, Hash } from '@polkadot/types/interfaces';
+import type { AccountId, Hash } from '@polkadot/types/interfaces';
 import type { FrameSupportPreimagesBounded, PalletPreimageRequestStatus } from '@polkadot/types/lookup';
 import type { ITuple } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
@@ -13,7 +13,7 @@ import { useMemo } from 'react';
 
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 import { Option } from '@polkadot/types';
-import { BN, BN_ZERO, formatNumber, isString, isU8a, objectSpread, u8aToHex, u8aConcat, compactToU8a, u8aEq } from '@polkadot/util';
+import { BN, BN_ZERO, formatNumber, isString, isU8a, objectSpread, u8aToHex } from '@polkadot/util';
 
 type BytesParamsType = [[proposalHash: HexString, proposalLength: BN]] | [proposalHash: HexString];
 
@@ -109,13 +109,13 @@ function createResult (api: ApiPromise, interimResult: PreimageStatus, optBytes:
     ? optBytes
     : optBytes.unwrapOr(null);
 
-  const result = (preimage: Pick<Preimage, "proposal" | "proposalLength" | "proposalWarning" | "proposalError">) => objectSpread<Preimage>({}, interimResult, {
+  const result = (preimage: Pick<Preimage, 'proposal' | 'proposalLength' | 'proposalWarning' | 'proposalError'>) => objectSpread<Preimage>({}, interimResult, {
     isCompleted: true,
     ...preimage
   });
 
   if (!callData) {
-    return result({ proposalWarning: 'No preimage bytes found' })
+    return result({ proposalWarning: 'No preimage bytes found' });
   }
 
   try {
@@ -124,7 +124,7 @@ function createResult (api: ApiPromise, interimResult: PreimageStatus, optBytes:
     const proposal = api.createType('Call', tx.method);
 
     if (tx.toHex() === callData.toString()) {
-      return result({proposal})
+      return result({ proposal });
     }
   } catch {}
 
@@ -139,19 +139,19 @@ function createResult (api: ApiPromise, interimResult: PreimageStatus, optBytes:
       return result({
         proposal,
         proposalWarning: callLength !== storeLength ? `Decoded call length does not match on-chain stored preimage length (${formatNumber(callLength)} bytes vs ${formatNumber(storeLength)} bytes)` : null
-      })
+      });
     } else {
       // for the old style, we set the actual length
       return result({
         proposal,
         proposalLength: new BN(callLength)
-      })
+      });
     }
   } catch (error) {
     console.error(error);
   }
 
-  return result({proposalError: 'Unable to decode preimage bytes into a valid Call'});
+  return result({ proposalError: 'Unable to decode preimage bytes into a valid Call' });
 }
 
 /** @internal Helper to unwrap a deposit tuple into a structure */

--- a/packages/react-hooks/src/usePreimage.ts
+++ b/packages/react-hooks/src/usePreimage.ts
@@ -132,6 +132,10 @@ function createResult (api: ApiPromise, interimResult: PreimageStatus, optBytes:
 
     proposal = api.createType('Call', tx.method);
 
+    if (tx.toHex() !== callData.toString()) {
+      proposalWarning = 'Cannot decode data as extrinsic, length mismatch'
+    }
+
     return result();
   } catch {}
 


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/apps/issues/10313

First, this includes some refactoring.

A `registry` doesn't really make sense in the preimage type - replaced with `api` as a parameter to `createResult`, which gives access to `registry` needed in this function.

Next, replaced the way of returning the final result with pre-defined values with direct return of a result.

- It allows us to return earlier - reducing nesting.
- Works better with multiple attempts at decoding.
- we know exactly what's being returned at a given line.

Finally, added a new attempt at decoding - with `api.tx(callData.toString())`

It doesn't seem to help _very much_, but fixes at least two preimages that I've seen.

Besides the preimage [described in the issue](https://github.com/polkadot-js/apps/issues/10313#issuecomment-2165153954) (it doesn't exist anymore on Westend so I tested locally), it helps with one more preimage on Rococo.

### Before

![local-westend](https://github.com/user-attachments/assets/ceeb6e26-9d5c-495a-8aee-c3073fff63af)

### After

![local-westend-after](https://github.com/user-attachments/assets/73ff73d2-10b7-4b61-a692-5db9575108ad)

### Before

![rococo](https://github.com/user-attachments/assets/8c616e95-4074-4192-bb70-dce69952583e)

### After

![rococo-after](https://github.com/user-attachments/assets/66109f46-1a95-4513-9f7f-1f2257ea7ec3)

