### PR TITLE
Adding RadiumBlock as Polkadot People Endpoint provider 

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -906,7 +906,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     isPeopleForIdentity: false,
     paraId: 1004,
     providers: {
-      Parity: 'wss://polkadot-people-rpc.polkadot.io'
+      Parity: 'wss://polkadot-people-rpc.polkadot.io',
       RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws'
     },
     relayName: 'polkadot',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -907,6 +907,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1004,
     providers: {
       Parity: 'wss://polkadot-people-rpc.polkadot.io'
+      RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws'
     },
     relayName: 'polkadot',
     teleport: [-1],


### PR DESCRIPTION
RadiumBlock would like to bring up our Polkadot People endpoints in Curie. Our high performance, highly distributed Endpoint Delivery Network.