### PR TITLE
Fix Preimage failure of Null amount for Tangle

### DIFF
--- a/packages/page-preimages/src/Preimages/Call.tsx
+++ b/packages/page-preimages/src/Preimages/Call.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { AddressMini, MarkError, MarkWarning } from '@polkadot/react-components';
 import { ZERO_ACCOUNT } from '@polkadot/react-hooks/useWeight';
 import { CallExpander } from '@polkadot/react-params';
+import { Null } from '@polkadot/types-codec';
 
 import { useTranslation } from '../translate.js';
 
@@ -48,7 +49,9 @@ function PreimageCall ({ className = '', value }: Props): React.ReactElement<Pro
           ? value.deposit
             ? (
               <AddressMini
-                balance={value.deposit.amount}
+                // HACK: In the rare case that the value is passed down as a Null Codec type as seen with Tangle
+                // We ensure to handle that case. ref: https://github.com/polkadot-js/apps/issues/10793
+                balance={!(value.deposit.amount instanceof Null) ? value.deposit.amount : undefined}
                 value={value.deposit.who}
                 withBalance
               />

--- a/packages/react-query/src/FormatBalance.tsx
+++ b/packages/react-query/src/FormatBalance.tsx
@@ -9,6 +9,7 @@ import React, { useMemo } from 'react';
 
 import { styled } from '@polkadot/react-components/styled';
 import { useApi } from '@polkadot/react-hooks';
+import { Null } from '@polkadot/types-codec';
 import { formatBalance, isString } from '@polkadot/util';
 
 import { useTranslation } from './translate.js';
@@ -59,6 +60,7 @@ function splitFormat (value: string, label?: LabelPost, isShort?: boolean): Reac
 }
 
 function applyFormat (value: Compact<any> | BN | string | number, [decimals, token]: [number, string], withCurrency = true, withSi?: boolean, _isShort?: boolean, labelPost?: LabelPost): React.ReactNode {
+  console.log('Value: ', value);
   const [prefix, postfix] = formatBalance(value, { decimals, forceUnit: '-', withSi: false }).split('.');
   const isShort = _isShort || (withSi && prefix.length >= K_LENGTH);
   const unitPost = withCurrency ? token : '';
@@ -93,7 +95,9 @@ function FormatBalance ({ children, className = '', format, formatIndex, isShort
       >{
           valueFormatted
             ? splitFormat(valueFormatted, labelPost, isShort)
-            : value
+            // HACK: In the rare case that the value is passed down as a Null Codec type as seen with Tangle
+            // We ensure to handle that case. ref: https://github.com/polkadot-js/apps/issues/10793
+            : value && !(value instanceof Null)
               ? value === 'all'
                 ? <>{t('everything')}{labelPost || ''}</>
                 : applyFormat(value, formatInfo, withCurrency, withSi, isShort, labelPost)

--- a/packages/react-query/src/FormatBalance.tsx
+++ b/packages/react-query/src/FormatBalance.tsx
@@ -59,7 +59,6 @@ function splitFormat (value: string, label?: LabelPost, isShort?: boolean): Reac
 }
 
 function applyFormat (value: Compact<any> | BN | string | number, [decimals, token]: [number, string], withCurrency = true, withSi?: boolean, _isShort?: boolean, labelPost?: LabelPost): React.ReactNode {
-  console.log('Value: ', value);
   const [prefix, postfix] = formatBalance(value, { decimals, forceUnit: '-', withSi: false }).split('.');
   const isShort = _isShort || (withSi && prefix.length >= K_LENGTH);
   const unitPost = withCurrency ? token : '';

--- a/packages/react-query/src/FormatBalance.tsx
+++ b/packages/react-query/src/FormatBalance.tsx
@@ -9,7 +9,6 @@ import React, { useMemo } from 'react';
 
 import { styled } from '@polkadot/react-components/styled';
 import { useApi } from '@polkadot/react-hooks';
-import { Null } from '@polkadot/types-codec';
 import { formatBalance, isString } from '@polkadot/util';
 
 import { useTranslation } from './translate.js';
@@ -95,9 +94,7 @@ function FormatBalance ({ children, className = '', format, formatIndex, isShort
       >{
           valueFormatted
             ? splitFormat(valueFormatted, labelPost, isShort)
-            // HACK: In the rare case that the value is passed down as a Null Codec type as seen with Tangle
-            // We ensure to handle that case. ref: https://github.com/polkadot-js/apps/issues/10793
-            : value && !(value instanceof Null)
+            : value
               ? value === 'all'
                 ? <>{t('everything')}{labelPost || ''}</>
                 : applyFormat(value, formatInfo, withCurrency, withSi, isShort, labelPost)


### PR DESCRIPTION
closes: https://github.com/polkadot-js/apps/issues/10793

`info.deposit.amount` is returning a Null type for Tangle which breaks `FormatBalance`. The original fix I made was in `FormatBalance` but I figured we would get to the source of the exception which was in `PreimageCall`.