### PR TITLE
Change Creditcoin Mainnet Name Ahead of New Mainnet Release

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -146,11 +146,11 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
-    info: 'creditcoin',
+    info: 'creditcoin-classic',
     providers: {
       'Creditcoin Foundation': 'wss://mainnet.creditcoin.network/ws'
     },
-    text: 'Creditcoin',
+    text: 'Creditcoin Classic',
     ui: {
       color: '#2D353F',
       logo: chainsCreditcoinPNG


### PR DESCRIPTION
A new Creditcoin mainnet is being launched, preserving existing account balances. To prevent any confusion about network continuity, the following names were chosen:

Old network: `Creditcoin` -> `Creditcoin Classic`
New netowork: `Creditcoin`

I'll post another PR in about a week and a half to establish an endpoint for the new Creditcoin network in Polkadot.js.