### PR TITLE
Allow reserved in voting balance

### DIFF
--- a/packages/page-referenda/src/Referenda/Vote/VoteStandard.tsx
+++ b/packages/page-referenda/src/Referenda/Vote/VoteStandard.tsx
@@ -43,6 +43,7 @@ function VoteStandard ({ accountId, id, isAye, onChange, voteLockingPeriod }: Pr
       <VoteValue
         accountId={accountId}
         autoFocus
+        isReferenda={true}
         label={
           isAye
             ? t('aye vote value')

--- a/packages/react-components/src/VoteValue.tsx
+++ b/packages/react-components/src/VoteValue.tsx
@@ -1,10 +1,10 @@
 // Copyright 2017-2024 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type BN from 'bn.js';
 import type { ApiPromise } from '@polkadot/api';
 import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 
-import BN from 'bn.js';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -57,7 +57,7 @@ function getValues (api: ApiPromise, selectedId: string | null | undefined, noDe
     })
     .map(({ amount }) => amount);
 
-  const maxValue = isReferenda && api.query.convictionVoting ? allBalances.votingBalance.add(allBalances ? allBalances.reservedBalance : new BN(0)) : allBalances?.votingBalance;
+  const maxValue = isReferenda && api.query.convictionVoting ? allBalances.votingBalance.add(allBalances.reservedBalance) : allBalances.votingBalance;
   let defaultValue: BN = sortedLocks[0] || allBalances.lockedBalance;
 
   if (noDefault) {

--- a/packages/react-query/src/BalanceVoting.tsx
+++ b/packages/react-query/src/BalanceVoting.tsx
@@ -27,7 +27,7 @@ function BalanceVoting ({ children, className = '', isReferenda, label, params }
     <FormatBalance
       className={className}
       label={label}
-      value={isReferenda ? allBalances?.votingBalance.add(allBalances ? allBalances.reservedBalance : new BN(0)) : allBalances?.votingBalance}
+      value={isReferenda && api.query.convictionVoting ? allBalances?.votingBalance.add(allBalances ? allBalances.reservedBalance : new BN(0)) : allBalances?.votingBalance}
     >
       {children}
     </FormatBalance>

--- a/packages/react-query/src/BalanceVoting.tsx
+++ b/packages/react-query/src/BalanceVoting.tsx
@@ -4,7 +4,6 @@
 import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { AccountId, AccountIndex, Address } from '@polkadot/types/interfaces';
 
-import BN from 'bn.js';
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -27,7 +26,7 @@ function BalanceVoting ({ children, className = '', isReferenda, label, params }
     <FormatBalance
       className={className}
       label={label}
-      value={isReferenda && api.query.convictionVoting ? allBalances?.votingBalance.add(allBalances ? allBalances.reservedBalance : new BN(0)) : allBalances?.votingBalance}
+      value={isReferenda && api.query.convictionVoting && allBalances ? allBalances.votingBalance.add(allBalances.reservedBalance) : allBalances?.votingBalance}
     >
       {children}
     </FormatBalance>

--- a/packages/react-query/src/BalanceVoting.tsx
+++ b/packages/react-query/src/BalanceVoting.tsx
@@ -4,6 +4,7 @@
 import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { AccountId, AccountIndex, Address } from '@polkadot/types/interfaces';
 
+import BN from 'bn.js';
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -13,11 +14,12 @@ import FormatBalance from './FormatBalance.js';
 interface Props {
   children?: React.ReactNode;
   className?: string;
+  isReferenda?: boolean;
   label?: React.ReactNode;
   params?: AccountId | AccountIndex | Address | string | Uint8Array | null;
 }
 
-function BalanceVoting ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
+function BalanceVoting ({ children, className = '', isReferenda, label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
 
@@ -25,7 +27,7 @@ function BalanceVoting ({ children, className = '', label, params }: Props): Rea
     <FormatBalance
       className={className}
       label={label}
-      value={allBalances?.votingBalance}
+      value={isReferenda ? allBalances?.votingBalance.add(allBalances ? allBalances.reservedBalance : new BN(0)) : allBalances?.votingBalance}
     >
       {children}
     </FormatBalance>


### PR DESCRIPTION
closes: https://github.com/polkadot-js/apps/issues/10837

TODO:

- [x] Ensure there is a check I can do that shows this is allowed on chain. Like some kind of call, or query that would only be available if this logic is available in the runtime. This is to avoid breaking all other chains in the UI. 