### PR TITLE
fix(bug): set current account nonce to be independent from user input

### DIFF
--- a/packages/react-signer/src/SignFields.tsx
+++ b/packages/react-signer/src/SignFields.tsx
@@ -22,12 +22,16 @@ function SignFields ({ address, onChange, signedTx }: Props): React.ReactElement
   const { api } = useApi();
   const [blocks, setBlocks] = useState(() => new BN(64));
   const [nonce, setNonce] = useState(BN_ZERO);
+  const [currentNonce, setCurrentNonce] = useState(BN_ZERO);
   const { t } = useTranslation();
 
   useEffect((): void => {
     address && api.derive.balances
       .account(address)
-      .then(({ accountNonce }) => setNonce(accountNonce))
+      .then(({ accountNonce }) => {
+        setNonce(accountNonce);
+        setCurrentNonce(accountNonce);
+      })
       .catch(console.error);
   }, [address, api]);
 
@@ -52,7 +56,7 @@ function SignFields ({ address, onChange, signedTx }: Props): React.ReactElement
           isDisabled={!!signedTx}
           isZeroable
           label={t('Nonce')}
-          labelExtra={t('Current account nonce: {{accountNonce}}', { replace: { accountNonce: nonce } })}
+          labelExtra={t('Current account nonce: {{accountNonce}}', { replace: { accountNonce: currentNonce } })}
           onChange={_setNonce}
           value={nonce}
         />


### PR DESCRIPTION
Closes #10861 

Changes `current account nonce` to be equal to the value of the accounts nonce, not the value input by the user.