### PR TITLE
Reflecting changes to Identity pallet 

### DIFF
--- a/packages/react-components/src/AccountSidebar/Identity.tsx
+++ b/packages/react-components/src/AccountSidebar/Identity.tsx
@@ -1,11 +1,10 @@
 // Copyright 2017-2024 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AddressIdentity } from '@polkadot/react-hooks/types';
-
 import React, { useMemo } from 'react';
 
 import { useApi, useRegistrars, useSubidentities, useToggle } from '@polkadot/react-hooks';
+import { type AddressIdentity, AddressIdentityOtherDiscordKey } from '@polkadot/react-hooks/types';
 import { isHex } from '@polkadot/util';
 
 import AddressMini from '../AddressMini.js';
@@ -141,11 +140,11 @@ function Identity ({ address, identity }: Props): React.ReactElement<Props> | nu
                 </div>
               </div>
             )}
-            {identity.discord && (
+            {identity.other && AddressIdentityOtherDiscordKey in identity.other && (
               <div className='tr'>
                 <div className='th'>{t('discord')}</div>
                 <div className='td'>
-                  {identity.discord}
+                  {identity.other[AddressIdentityOtherDiscordKey]}
                 </div>
               </div>
             )}
@@ -162,6 +161,14 @@ function Identity ({ address, identity }: Props): React.ReactElement<Props> | nu
                 <div className='th'>{t('matrix')}</div>
                 <div className='td'>
                   {identity.matrix}
+                </div>
+              </div>
+            )}
+            {identity.discord && (
+              <div className='tr'>
+                <div className='th'>{t('discord')}</div>
+                <div className='td'>
+                  {identity.discord}
                 </div>
               </div>
             )}

--- a/packages/react-components/src/AccountSidebar/Identity.tsx
+++ b/packages/react-components/src/AccountSidebar/Identity.tsx
@@ -6,7 +6,6 @@ import type { AddressIdentity } from '@polkadot/react-hooks/types';
 import React, { useMemo } from 'react';
 
 import { useApi, useRegistrars, useSubidentities, useToggle } from '@polkadot/react-hooks';
-import { AddressIdentityOtherDiscordKey } from '@polkadot/react-hooks/types';
 import { isHex } from '@polkadot/util';
 
 import AddressMini from '../AddressMini.js';
@@ -142,11 +141,27 @@ function Identity ({ address, identity }: Props): React.ReactElement<Props> | nu
                 </div>
               </div>
             )}
-            {identity.other && AddressIdentityOtherDiscordKey in identity.other && (
+            {identity.discord && (
               <div className='tr'>
                 <div className='th'>{t('discord')}</div>
                 <div className='td'>
-                  {identity.other[AddressIdentityOtherDiscordKey]}
+                  {identity.discord}
+                </div>
+              </div>
+            )}
+            {identity.github && (
+              <div className='tr'>
+                <div className='th'>{t('github')}</div>
+                <div className='td'>
+                  {identity.github}
+                </div>
+              </div>
+            )}
+            {identity.matrix && (
+              <div className='tr'>
+                <div className='th'>{t('matrix')}</div>
+                <div className='td'>
+                  {identity.matrix}
                 </div>
               </div>
             )}


### PR DESCRIPTION
Identity object used to hold `discord` information under `others`, now it is part of the object on a higher level.



Reference for the changes after mirgration

https://github.com/paritytech/polkadot-sdk/pull/2931/files

`cumulus/scripts/migrate_storage_to_genesis/identityMigration.js`

```
// Migrate `IdentityInfo` data to the new format:
// - remove `additional` field
// - add `discord` field
// - add `github` field`
```