### PR TITLE
Naming issue for Paseo People chain

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -358,7 +358,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     }
   },
   {
-    info: 'PeopleChain',
+    info: 'PaseoPeopleChain',
     isPeople: true,
     isPeopleForIdentity: false,
     paraId: 1004,


### PR DESCRIPTION
There is a condition for filtering out people chain endpoints names, which requires the name of the relay chain to be part of the info property for the endpoint configuration. 


```
  {
    info: 'PaseoPeopleChain',
    isPeople: true,
    ...
  }
  ```
`endpoints.find(({ info, isPeople }) => isPeople && isString(info) && isString(curApiInfo) && info.toLowerCase().includes(curApiInfo.toLowerCase())) || null;`