### PR TITLE
Alter code to make fellowship and ambassador pages to reappear

### DIFF
--- a/packages/apps-routing/src/ambassador.ts
+++ b/packages/apps-routing/src/ambassador.ts
@@ -9,7 +9,6 @@ export default function create (t: TFunction): Route {
   return {
     Component,
     display: {
-      needsAccounts: true,
       needsApi: [
         'tx.ambassadorCollective.vote',
         'tx.ambassadorReferenda.submit',

--- a/packages/apps-routing/src/fellowship.ts
+++ b/packages/apps-routing/src/fellowship.ts
@@ -9,7 +9,6 @@ export default function create (t: TFunction): Route {
   return {
     Component,
     display: {
-      needsAccounts: true,
       needsApi: [
         'tx.fellowshipCollective.vote',
         'tx.fellowshipReferenda.submit',


### PR DESCRIPTION
I am not sure how `needsAccounts` work. Based on my undersatnding it should allow for the page to appear if the collective has accounts. But while the collective has accounts it still dissappears.
By removing this boolean - the pages reappear but it would be nice to understand what that flag is doing

cc @TarikGul 