### PR TITLE
Remove macos from electron CI build

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -55,7 +55,9 @@ jobs:
     if: "startsWith(github.event.head_commit.message, '[CI Skip] release/stable')"
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # Removed `macos-latest` since notarization errors.
+        # ref: https://github.com/polkadot-js/apps/issues/10486
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -64,12 +66,14 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
-    - name: Prepare for app notarization (macOS)
-      if: startsWith(matrix.os, 'macos')
-      # Import Apple API key for app notarization on macOS
-      run: |
-        mkdir -p ~/private_keys/
-        echo '${{ secrets.API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.API_KEY_ID }}.p8
+    # Removed `macos-latest` since notarization errors.
+    # ref: https://github.com/polkadot-js/apps/issues/10486
+    # - name: Prepare for app notarization (macOS)
+    #   if: startsWith(matrix.os, 'macos')
+    #   # Import Apple API key for app notarization on macOS
+    #   run: |
+    #     mkdir -p ~/private_keys/
+    #     echo '${{ secrets.API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.API_KEY_ID }}.p8
     - name: Build/release Electron app
       uses: samuelmeuli/action-electron-builder@v1
       with:


### PR DESCRIPTION
rel: https://github.com/polkadot-js/apps/issues/10486

Currently the macos certs are expired for the builds and need to be changed over to the new maintainers. This is out of bandwidth at the moment - therefore I am removing is as part of the CI build process, and will keep it tracked in the issue above.