### PR TITLE
Re-adding RadiumBlock as Bridgehub Kusama and Polkadot AssetHub Endpoint provider

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -932,7 +932,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-bridge-hub-kusama.luckyfriday.io',
       // OnFinality: 'wss://bridgehub-kusama.api.onfinality.io/public-ws',
       Parity: 'wss://kusama-bridge-hub-rpc.polkadot.io',
-      // RadiumBlock: 'wss://bridgehub-kusama.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/11098
+      RadiumBlock: 'wss://bridgehub-kusama.public.curie.radiumblock.co/ws',
       Stakeworld: 'wss://ksm-rpc.stakeworld.io/bridgehub'
     },
     relayName: 'kusama',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -872,7 +872,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
-      // RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws', https://github.com/polkadot-js/apps/issues/11098
+      RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws',
       Stakeworld: 'wss://dot-rpc.stakeworld.io/assethub'
     },
     relayName: 'polkadot',


### PR DESCRIPTION
RadiumBlock would like to bring back our  Bridgehub Kusama and Polkadot AssetHub endpoints. We have some observations that are causing issues. For various para chains, using external url for the relay chain seems to cause chains stalls. This issue has become much more prominent since the recent round of kusama/polkadot upgrades. We have a mitigation in place using extra capacity and eventually switching to using internal relay chain because the external relay seems to under perform.