### PR TITLE
Re-adding RadiumBlock as Westend Endpoint Provider 

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -225,7 +225,7 @@ export const testRelayWestend: EndpointOption = {
     // LuckyFriday: 'wss://rpc-westend.luckyfriday.io', // https://github.com/polkadot-js/apps/issues/10728
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',
-    // RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/11098
+    RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws',
     // Stakeworld: 'wss://wnd-rpc.stakeworld.io',
     'light client': 'light://substrate-connect/westend'
   },


### PR DESCRIPTION
 RadiumBlock would like to bring back our Westend Endpoint.  It's a best effort service and it running up against compute limit but have decided to increase capacity for community benefit.