### PR TITLE
Re-adding RadiumBlock as Shiden and Bifrost Polkadot Endpoint provider

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -108,8 +108,9 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     providers: {
       Dwellir: 'wss://bifrost-rpc.dwellir.com',
       Liebi: 'wss://bifrost-rpc.liebi.com/ws',
-      LiebiUS: 'wss://us.bifrost-rpc.liebi.com/ws'
+      LiebiUS: 'wss://us.bifrost-rpc.liebi.com/ws',
       // OnFinality: 'wss://bifrost-parachain.api.onfinality.io/public-ws'
+      RadiumBlock: 'wss://bifrost.public.curie.radiumblock.co/ws'
     },
     text: 'Bifrost',
     ui: {
@@ -717,7 +718,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
       Blast: 'wss://shiden.public.blastapi.io',
       Dwellir: 'wss://shiden-rpc.dwellir.com',
       OnFinality: 'wss://shiden.api.onfinality.io/public-ws',
-      // RadiumBlock: 'wss://shiden.public.curie.radiumblock.co/ws', // https://github.com/polkadot-js/apps/issues/11098
+      RadiumBlock: 'wss://shiden.public.curie.radiumblock.co/ws'
       'light client': 'light://substrate-connect/kusama/shiden'
     },
     text: 'Shiden',

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -718,7 +718,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
       Blast: 'wss://shiden.public.blastapi.io',
       Dwellir: 'wss://shiden-rpc.dwellir.com',
       OnFinality: 'wss://shiden.api.onfinality.io/public-ws',
-      RadiumBlock: 'wss://shiden.public.curie.radiumblock.co/ws'
+      RadiumBlock: 'wss://shiden.public.curie.radiumblock.co/ws',
       'light client': 'light://substrate-connect/kusama/shiden'
     },
     text: 'Shiden',


### PR DESCRIPTION
RadiumBlock would like to bring back our Shiden and Bifrost Polkadot endpoints. We have some observations that are causing issues. For various para chains, using external url for the relay chain seems to cause chains stalls. This issue has become much more prominent since the recent round of kusama/polkadot upgrades. We have a mitigation in place using extra capacity and eventually switching to using internal relay chain because the external relay seems to under perform.