### PR TITLE
Add Helikon public RPC endpoint for Mythos.

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -575,6 +575,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'mythos',
     paraId: 3369,
     providers: {
+      Helikon: 'wss://rpc.helikon.io/mythos',
       parity: 'wss://polkadot-mythos-rpc.polkadot.io'
     },
     text: 'Mythos',


### PR DESCRIPTION
This PR adds Helikon public RPC endpoint for Mythos.

Mythos RPC endpoint is load balanced with two archive nodes on NVMe drives on a 5Gbps symmetrical network. Our services run on owned hardware in multiple data centers in central Istanbul, and are monitored 24/7 at software (node), hardware (disk, CPU, memory) and network level.

Nodes can be viewed [here](https://telemetry.w3f.community/#list/0xf6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9) on the W3F Telemetry instance.

Helikon is a member of the IBP GeoDNS and provides public RPC endpoints for Kusama, Westend, Polkadot, all system parachains, and multiple Polkadot parachains. We also run boot nodes for all the chains we provide RPC services for.

Regards.