### PR TITLE
Deleted the OnFinality Bajun endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -76,8 +76,8 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     info: 'bajun',
     paraId: 2119,
     providers: {
-      AjunaNetwork: 'wss://rpc-para.bajun.network',
-      OnFinality: 'wss://bajun.api.onfinality.io/public-ws'
+      AjunaNetwork: 'wss://rpc-para.bajun.network'
+      // OnFinality: 'wss://bajun.api.onfinality.io/public-ws'
       // RadiumBlock: 'wss://bajun.public.curie.radiumblock.co/ws' https://github.com/polkadot-js/apps/issues/11157
     },
     text: 'Bajun Network',


### PR DESCRIPTION
Onfinality no longer supports this network.
- bajun: `wss://bajun.api.onfinality.io/public-ws`