### PR TITLE
docs: added missing types description

### DIFF
--- a/packages/apps-config/src/endpoints/types.ts
+++ b/packages/apps-config/src/endpoints/types.ts
@@ -8,14 +8,35 @@ import type { Option } from '../settings/types.js';
 
 interface BaseOption {
   dnslink?: string;
+  /**
+   * Genesis hash for chain
+   */
   genesisHash?: HexString;
+  /**
+   * Homepage Url
+   */
   homepage?: string;
+  /**
+   * Parachain Id of chain
+   */
   paraId?: number;
+  /**
+   * Summary about chain
+   */
   summary?: string;
   teleport?: number[];
   ui: {
+    /**
+     * Color for chain
+     */
     color?: string;
+    /**
+     * Identicon type i.e. polkadot, beachball, ethereum etc
+     */
     identityIcon?: IconTheme;
+    /**
+     * Logo component for chain
+     */
     logo?: string;
   }
 }
@@ -28,10 +49,22 @@ export interface EndpointOption extends BaseOption {
    * Declares whether the given endpoint is the People chain used to store identity information.
    */
   isPeople?: boolean;
+  /**
+   * Checks whether one of the given provider is reachable or not. If set to true, it hides the chain from explorer.
+   */
   isUnreachable?: boolean;
+  /**
+   * Declares list of all linked chains. However, It is applicable for relay chains only.
+   */
   linked?: EndpointOption[];
   info?: string;
+  /**
+   * Declares the list of all RPC providers
+   */
   providers: Record<string, `${'wss://' | 'light://substrate-connect/'}${string}`>;
+  /**
+   * Declares chain name
+   */
   text: string;
   /**
    * Declares whether or not the endpoint is a relay chain.


### PR DESCRIPTION
## Description

This PR aims to add some description for types used for `endpoints/types.ts` in `apps-config`. 