### PR TITLE
fix: get next asset id issue

### DIFF
--- a/packages/apps-config/src/api/constants.ts
+++ b/packages/apps-config/src/api/constants.ts
@@ -6,7 +6,7 @@ import type { HexString } from '@polkadot/util/types';
 import { knownGenesis } from '@polkadot/networks/defaults';
 import { assert, BN } from '@polkadot/util';
 
-function getGenesis (name: string): HexString {
+export function getGenesis (name: string): HexString {
   const network = Object.entries(knownGenesis).find(([network]) => network === name);
 
   assert(network?.[1][0], `Unable to find genesisHash for ${name}`);

--- a/packages/page-assets/src/Overview/Create/Info.tsx
+++ b/packages/page-assets/src/Overview/Create/Info.tsx
@@ -1,6 +1,7 @@
 // Copyright 2017-2025 @polkadot/app-assets authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { BitLength } from '@polkadot/react-components/types';
 import type { BN } from '@polkadot/util';
 import type { InfoState } from './types.js';
 
@@ -20,7 +21,7 @@ interface Props {
   openId: BN;
 }
 
-const ASSET_ID_BIT_LENGTH = 128;
+const ASSET_ID_BIT_LENGTH: BitLength = 128;
 
 function Info ({ assetIds, className = '', defaultValue, onChange, openId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();

--- a/packages/page-assets/src/Overview/Create/Info.tsx
+++ b/packages/page-assets/src/Overview/Create/Info.tsx
@@ -20,6 +20,8 @@ interface Props {
   openId: BN;
 }
 
+const ASSET_ID_BIT_LENGTH = 128;
+
 function Info ({ assetIds, className = '', defaultValue, onChange, openId }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
@@ -114,6 +116,7 @@ function Info ({ assetIds, className = '', defaultValue, onChange, openId }: Pro
       </Modal.Columns>
       <Modal.Columns hint={t('The selected id for the asset. This should not match an already-existing asset id.')}>
         <InputNumber
+          bitLength={ASSET_ID_BIT_LENGTH}
           defaultValue={initial?.assetId || initialId}
           isError={!isValidId}
           isZeroable={false}

--- a/packages/page-assets/src/index.tsx
+++ b/packages/page-assets/src/index.tsx
@@ -36,7 +36,7 @@ function findOpenId (ids?: BN[]): BN {
   );
 
   return lastTaken
-    ? lastTaken.sub(BN_ONE)
+    ? lastTaken.add(BN_ONE)
     : ids[ids.length - 1].add(BN_ONE);
 }
 

--- a/packages/page-assets/src/index.tsx
+++ b/packages/page-assets/src/index.tsx
@@ -34,7 +34,7 @@ function findOpenId (genesisHash: HexString, ids?: BN[]): BN {
     return BN_ONE;
   }
 
-  if (GENESIS_HASHES.map((e) => e.toLowerCase()).includes(genesisHash)) {
+  if (GENESIS_HASHES.includes(genesisHash)) {
     return ids.sort((a, b) => a.cmp(b))[ids.length - 1].add(BN_ONE);
   }
 
@@ -76,7 +76,7 @@ function AssetApp ({ basePath, className }: Props): React.ReactElement<Props> {
   );
 
   const openId = useMemo(
-    () => findOpenId(api.genesisHash.toHex().toLowerCase() as HexString, ids),
+    () => findOpenId(api.genesisHash.toHex(), ids),
     [api.genesisHash, ids]
   );
 


### PR DESCRIPTION
## 📝 Description 

When creating a new asset, the Asset ID field should default to the next possible asset_id which is basically `last_created_asset_id + 1`

![Screenshot from 2024-10-04 12-46-08](https://github.com/user-attachments/assets/5df46e96-14d5-4a39-84b2-60869fc26101)

## 🤔 Previous behavior

The current UI makes it seem that any asset id would work, but after a runtime upgrade it is required that newly created asset id's follow a specific rule: the newly created asset's id should be the next possible id of the last created asset. 

In other terms, next_asset_id = previous_asset_id + 1

* **What is the motivation for changing the behavior?**

Without this change, users will face this error:

![Screenshot from 2024-10-04 12-48-33](https://github.com/user-attachments/assets/49b15823-0380-4551-a571-466b36ebcf87)

## 🚀 Current behavior

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/aa49c3e6-6c71-4ae7-8439-ff83e1b1f6a5" />


## ✅ Tasks

- [x] Fix `findOpenId` method to calculate default asset id
- [x] For Asset Hub, Next asset id is `prev asset id + 1`
