### PR TITLE
fix: restore submit proposal button

### DIFF
--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -86,11 +86,13 @@ function Propose ({ className }: Props): React.ReactElement<Props> | null {
               >
                 {bondPercentage}
               </Static>
-              <InputBalance
-                defaultValue={bondMin}
-                isDisabled
-                label={t('minimum bond')}
-              />
+              {bondMin && (
+                <InputBalance
+                  defaultValue={bondMin}
+                  isDisabled
+                  label={t('minimum bond')}
+                />
+              )}
               {bondMax && (
                 <InputBalance
                   defaultValue={bondMax}

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -3,13 +3,12 @@
 
 import type { Option, u128 } from '@polkadot/types';
 import type { Permill } from '@polkadot/types/interfaces';
-import type { BN } from '@polkadot/util';
 
 import React, { useMemo, useState } from 'react';
 
 import { Button, InputAddress, InputBalance, MarkWarning, Modal, Static, TxButton } from '@polkadot/react-components';
 import { useApi, useToggle } from '@polkadot/react-hooks';
-import { BN_HUNDRED, BN_MILLION } from '@polkadot/util';
+import { BN, BN_HUNDRED, BN_MILLION } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
 
@@ -28,11 +27,15 @@ function Propose ({ className }: Props): React.ReactElement<Props> | null {
 
   const [bondMin, bondMax, bondPercentage] = useMemo(
     () => [
-      (api.consts.treasury.proposalBondMinimum as u128).toString(),
+      api.consts.treasury.proposalBondMinimum
+        ? (api.consts.treasury.proposalBondMinimum as u128).toString()
+        : null,
       (api.consts.treasury.proposalBondMaximum as Option<u128>)?.isSome
         ? (api.consts.treasury.proposalBondMaximum as Option<u128>).unwrap().toString()
         : null,
-      `${(api.consts.treasury.proposalBond as Permill).mul(BN_HUNDRED).div(BN_MILLION).toNumber().toFixed(2)}%`
+      api.consts.treasury.proposalBond
+        ? `${(api.consts.treasury.proposalBond as Permill).mul(BN_HUNDRED).div(BN_MILLION).toNumber().toFixed(2)}%`
+        : `${new BN(0).toNumber().toFixed(2)}%`
     ],
     [api]
   );

--- a/packages/page-treasury/src/Overview/index.tsx
+++ b/packages/page-treasury/src/Overview/index.tsx
@@ -28,13 +28,9 @@ function Overview ({ className, isMember, members }: Props): React.ReactElement<
         approvalCount={info?.approvals.length}
         proposalCount={info?.proposals.length}
       />
-      {
-        api.tx.treasury.proposeSpend
-          ? <Button.Group>
-            <ProposalCreate />
-          </Button.Group>
-          : <></>
-      }
+      <Button.Group>
+        <ProposalCreate />
+      </Button.Group>
       <Proposals
         isMember={isMember}
         members={members}


### PR DESCRIPTION
## 📝 Description

In this issue, `Submit Proposal` button has been disabled if `tx.treasury.proposeSend` is not available. Our focus is here to undo this change and fix the breaking changes. The Idea here is show same UX for all chains in Treasury Page.

Now, In this PR, All breaking changes have been fixed and `Submit Proposal` have been enabled. 