### PR TITLE
fix: default asset selection

### DIFF
--- a/packages/page-assets/src/Balances/index.tsx
+++ b/packages/page-assets/src/Balances/index.tsx
@@ -66,11 +66,17 @@ function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> 
   );
 
   useEffect((): void => {
-    setInfo(() =>
-      infoIndex >= 0
-        ? completeInfos.find(({ id }) => id.toString() === infoIndex.toString()) ?? null
-        : null
-    );
+    const info = infoIndex >= 0
+      ? completeInfos.find(({ id }) => id.toString() === infoIndex.toString()) ?? null
+      : null;
+
+    // if no info found (usually happens on first load), select the first one automatically
+    if (!info) {
+      setInfo(completeInfos.at(0) ?? null);
+      setInfoIndex(completeInfos.at(0)?.id?.toNumber() ?? 0);
+    } else {
+      setInfo(info);
+    }
   }, [completeInfos, infoIndex]);
 
   return (


### PR DESCRIPTION
## 📝 Description

On visiting the balances page for assets, a continuous loading screen is displayed. However, searching for assets manually from the dropdown works fine. But this can be confusing and difficult for some users to notice.

<img width="1728" alt="Image" src="https://github.com/user-attachments/assets/64bbbf4c-b6f3-49eb-bdd9-eda5d72202e1" />

## ✅ Current Behavior

https://github.com/user-attachments/assets/acbe85e8-e8f5-4cc0-add2-3592f082df49

