### PR TITLE
Fixed broken Block Details for blocks/chains with V1 Weight

### DIFF
--- a/packages/page-explorer/src/BlockInfo/ByHash.tsx
+++ b/packages/page-explorer/src/BlockInfo/ByHash.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { AddressSmall, Columar, LinkExternal, MarkError, Table } from '@polkadot/react-components';
 import { useApi, useIsMountedRef } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
-import { formatNumber } from '@polkadot/util';
+import { formatNumber, isBn } from '@polkadot/util';
 
 import Events from '../Events.js';
 import { useTranslation } from '../translate.js';
@@ -125,7 +125,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
       <Summary
         events={events}
         maxBlockWeight={(maxBlockWeight as V2Weight).refTime.toBn()}
-        maxProofSize={(maxBlockWeight as V2Weight).proofSize.toBn()}
+        maxProofSize={isBn(maxBlockWeight.proofSize) ? maxBlockWeight.proofSize : (maxBlockWeight as V2Weight).proofSize.toBn()}
         signedBlock={getBlock}
       />
       <Table header={header}>

--- a/packages/page-explorer/src/BlockInfo/Summary.tsx
+++ b/packages/page-explorer/src/BlockInfo/Summary.tsx
@@ -11,7 +11,7 @@ import { CardSummary, SummaryBox } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
 import { FormatBalance } from '@polkadot/react-query';
-import { BN, BN_ONE, BN_THREE, BN_TWO, BN_ZERO, formatNumber } from '@polkadot/util';
+import { BN, BN_ONE, BN_THREE, BN_TWO, BN_ZERO, formatNumber, isBn } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
 
@@ -25,6 +25,10 @@ interface Props {
 function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?] {
   return events
     ? events.reduce(([deposits, transfers, weight], { record: { event: { data, method, section } } }) => {
+      const size = (convertWeight(
+        ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo)?.weight
+      ).v2Weight as V2Weight).proofSize;
+
       return [
         section === 'balances' && method === 'Deposit'
           ? deposits.iadd(data[1] as Balance)
@@ -34,13 +38,11 @@ function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?
           : transfers,
         section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
           ? weight.iadd(convertWeight(
-            ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo).weight
+            ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo)?.weight
           ).v1Weight)
           : weight,
         section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
-          ? (convertWeight(
-            ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo).weight
-          ).v2Weight as V2Weight).proofSize.toBn()
+          ? (isBn(size) ? size : size.toBn())
           : BN_ZERO
       ];
     }, [new BN(0), new BN(0), new BN(0), new BN(0)])

--- a/packages/react-hooks/src/useWeight.ts
+++ b/packages/react-hooks/src/useWeight.ts
@@ -39,6 +39,14 @@ const EMPTY_STATE: Partial<Result> = {
 
 // return both v1 & v2 weight structures (would depend on actual use)
 export function convertWeight (weight: V1Weight | V2Weight): WeightResult {
+  // We need to handle it because sometimes input parameters are passed with type casting,
+  // which can result in them being undefined or null under certain conditions.
+  if (!weight) {
+    const refTime = BN_ZERO;
+
+    return { v1Weight: refTime, v2Weight: { proofSize: BN_ZERO, refTime } };
+  }
+
   if ((weight as V2Weight).proofSize) {
     // V2 weight
     const refTime = (weight as V2Weight).refTime.toBn();


### PR DESCRIPTION
## 📝 Description

The Block Details tab in the explorer throws an error for chains still using V1Weight, and all chains if looking up an old block that still used V1. 

The error thrown is-

```
Uncaught error. Something went wrong with the query and rendering of this component. Please supply all the details below when logging an issue, it may help in tracing the cause.

C.proofSize.toBn is not a function

TypeError: C.proofSize.toBn is not a function
at https://polkadot.js.org/apps/page.bb5be2985ccc3806.js:898:7854
at _i (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:77446)
at Ol (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:89067)
at _l (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:88275)
at El (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:87880)
at _u (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:137602)
at ws (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:123430)
at ys (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:123358)
at vs (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:123221)
at is (https://polkadot.js.org/apps/modu.bd8f3266470441f0.js:2:120028)
```

## 🤔 Previous behavior
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/07d43272-00fd-4f6b-beec-f1cb50d6324d" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f7c6cd02-7048-4fab-9e29-d9c13ec0f27c" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/fed1dc2b-1b9c-48ac-a570-b6517ed0f6f6" />

## ✅ Current behavior

https://github.com/user-attachments/assets/6ce70797-fecf-4391-9487-1dc0509ac12e

