### PR TITLE
fix: broken balances page

### DIFF
--- a/packages/page-assets/src/Balances/index.tsx
+++ b/packages/page-assets/src/Balances/index.tsx
@@ -20,10 +20,9 @@ interface Props {
 
 function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [infoIndex, setInfoIndex] = useState(0);
+  const [selectedAssetValue, setSelectedAssetValue] = useState('0');
   const [info, setInfo] = useState<AssetInfoComplete | null>(null);
   const balances = useBalances(info?.id);
-  const maxNumLength = Number.MAX_SAFE_INTEGER.toString().length;
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t('accounts'), 'start'],
@@ -43,9 +42,9 @@ function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> 
   const assetOptions = useMemo(
     () => completeInfos.map(({ id, metadata }) => ({
       text: `${metadata.name.toUtf8()} (${formatNumber(id)})`,
-      value: id.toString().length < maxNumLength ? id.toNumber() : id.toString()
+      value: id.toString()
     })),
-    [completeInfos, maxNumLength]
+    [completeInfos]
   );
 
   const siFormat = useMemo(
@@ -66,18 +65,16 @@ function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> 
   );
 
   useEffect((): void => {
-    const info = infoIndex >= 0
-      ? completeInfos.find(({ id }) => id.toString() === infoIndex.toString()) ?? null
-      : null;
+    const info = completeInfos.find(({ id }) => id.toString() === selectedAssetValue);
 
     // if no info found (usually happens on first load), select the first one automatically
     if (!info) {
       setInfo(completeInfos.at(0) ?? null);
-      setInfoIndex(completeInfos.at(0)?.id?.toNumber() ?? 0);
+      setSelectedAssetValue(completeInfos.at(0)?.id?.toString() ?? '0');
     } else {
       setInfo(info);
     }
-  }, [completeInfos, infoIndex]);
+  }, [completeInfos, selectedAssetValue]);
 
   return (
     <StyledDiv className={className}>
@@ -88,10 +85,10 @@ function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> 
             <Dropdown
               isFull
               label={t('the asset to query for balances')}
-              onChange={setInfoIndex}
+              onChange={setSelectedAssetValue}
               onSearch={onSearch}
               options={assetOptions}
-              value={infoIndex}
+              value={selectedAssetValue}
             />
           )
           : undefined


### PR DESCRIPTION
## 📝 Description

This PR aims to fix a breaking edge case on `/assets/balances` page on top of https://github.com/polkadot-js/apps/pull/11222. 

This issue arises when the automatic selection of Asset ID (which happens on first visit) exceeds `2^53 - 1`, causing it to break. To address this, we will handle the selected Asset ID as a string instead of a number.

## 🤔 Previous Behavior

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/fa5016f0-b7b5-42c7-adf4-baec329df0a6" />

## ✅ Current Behaviour

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/544926e6-60a7-4e5d-aeac-b93ab2effa9d" />
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/94b6efc2-ea56-4c9b-a024-07337b071728" />

