### PR TITLE
fix: 🐛 Update `moonbeam-types-bundle` to latest

### DIFF
--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -33,7 +33,7 @@
     "@logion/node-api": "0.27.0-4",
     "@mangata-finance/type-definitions": "^2.1.2",
     "@metaverse-network-sdk/type-definitions": "0.0.1-16",
-    "@moonbeam-network/types-bundle": "1.0.0",
+    "@moonbeam-network/types-bundle": "1.0.1",
     "@parallel-finance/type-definitions": "2.0.1",
     "@peaqnetwork/type-definitions": "0.0.4",
     "@pendulum-chain/type-definitions": "0.3.8",

--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -33,6 +33,7 @@
     "@logion/node-api": "0.27.0-4",
     "@mangata-finance/type-definitions": "^2.1.2",
     "@metaverse-network-sdk/type-definitions": "0.0.1-16",
+    "@moonbeam-network/types-bundle": "1.0.0",
     "@parallel-finance/type-definitions": "2.0.1",
     "@peaqnetwork/type-definitions": "0.0.4",
     "@pendulum-chain/type-definitions": "0.3.8",
@@ -58,7 +59,6 @@
     "@unique-nft/unique-mainnet-types": "1001.63.0",
     "@zeitgeistpm/type-defs": "1.0.0",
     "@zeroio/type-definitions": "0.0.14",
-    "moonbeam-types-bundle": "2.0.10",
     "pontem-types-bundle": "1.0.15",
     "rxjs": "^7.8.1",
     "tslib": "^2.8.1"

--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -33,7 +33,7 @@
     "@logion/node-api": "0.27.0-4",
     "@mangata-finance/type-definitions": "^2.1.2",
     "@metaverse-network-sdk/type-definitions": "0.0.1-16",
-    "@moonbeam-network/types-bundle": "1.0.1",
+    "@moonbeam-network/types-bundle": "1.0.2",
     "@parallel-finance/type-definitions": "2.0.1",
     "@peaqnetwork/type-definitions": "0.0.4",
     "@pendulum-chain/type-definitions": "0.3.8",

--- a/packages/apps-config/src/api/spec/moonbeam.ts
+++ b/packages/apps-config/src/api/spec/moonbeam.ts
@@ -1,6 +1,6 @@
 // Copyright 2017-2025 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { moonbeamDefinitions } from 'moonbeam-types-bundle';
+import { moonbeamDefinitions } from '@moonbeam-network/types-bundle';
 
 export default moonbeamDefinitions;

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -49408,6 +49408,11 @@ export const typesBundle = {
               }
             ],
             "type": "bool"
+          },
+          "getLatestSyncedBlock": {
+            "description": "Returns the latest synced block from frontier's backend",
+            "params": [],
+            "type": "u32"
           }
         }
       },
@@ -51124,6 +51129,11 @@ export const typesBundle = {
               }
             ],
             "type": "bool"
+          },
+          "getLatestSyncedBlock": {
+            "description": "Returns the latest synced block from frontier's backend",
+            "params": [],
+            "type": "u32"
           }
         }
       },
@@ -52840,6 +52850,11 @@ export const typesBundle = {
               }
             ],
             "type": "bool"
+          },
+          "getLatestSyncedBlock": {
+            "description": "Returns the latest synced block from frontier's backend",
+            "params": [],
+            "type": "u32"
           }
         }
       },
@@ -54556,6 +54571,11 @@ export const typesBundle = {
               }
             ],
             "type": "bool"
+          },
+          "getLatestSyncedBlock": {
+            "description": "Returns the latest synced block from frontier's backend",
+            "params": [],
+            "type": "u32"
           }
         }
       },
@@ -56540,6 +56560,11 @@ export const typesBundle = {
               }
             ],
             "type": "bool"
+          },
+          "getLatestSyncedBlock": {
+            "description": "Returns the latest synced block from frontier's backend",
+            "params": [],
+            "type": "u32"
           }
         }
       },

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -49598,7 +49598,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -49707,7 +49706,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -49817,7 +49815,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -49944,7 +49941,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -50095,7 +50091,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -50251,7 +50246,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -50427,7 +50421,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -50604,7 +50597,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -50832,7 +50824,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -51073,7 +51064,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -51541,7 +51531,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -51650,7 +51639,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -51760,7 +51748,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -51887,7 +51874,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -52038,7 +52024,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -52194,7 +52179,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -52370,7 +52354,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -52547,7 +52530,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -52775,7 +52757,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53016,7 +52997,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53484,7 +53464,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53593,7 +53572,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53703,7 +53681,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53830,7 +53807,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -53981,7 +53957,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -54137,7 +54112,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -54313,7 +54287,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -54490,7 +54463,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -54718,7 +54690,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -54959,7 +54930,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -55427,7 +55397,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -55536,7 +55505,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -55646,7 +55614,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -55773,7 +55740,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -55924,7 +55890,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -56080,7 +56045,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -56256,7 +56220,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -56433,7 +56396,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -56661,7 +56623,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -56902,7 +56863,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -57638,7 +57598,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -57747,7 +57706,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -57857,7 +57815,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -57984,7 +57941,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -58135,7 +58091,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -58291,7 +58246,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -58467,7 +58421,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -58644,7 +58597,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -58872,7 +58824,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",
@@ -59113,7 +59064,6 @@ export const typesBundle = {
                 "Leaving": "RoundIndex"
               }
             },
-            "Range": "RangeBalance",
             "RangeBalance": {
               "min": "Balance",
               "ideal": "Balance",

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -49409,10 +49409,10 @@ export const typesBundle = {
             ],
             "type": "bool"
           },
-          "getLatestSyncedBlock": {
-            "description": "Returns the latest synced block from frontier's backend",
+          "getEthSyncBlockRange": {
+            "description": "Returns the range of blocks that are fully indexed in frontier's backend.",
             "params": [],
-            "type": "u32"
+            "type": "(H256, H256)"
           }
         }
       },
@@ -51012,6 +51012,109 @@ export const typesBundle = {
             null
           ],
           "types": {
+            "AccountId": "EthereumAccountId",
+            "Address": "AccountId",
+            "Balance": "u128",
+            "LookupSource": "AccountId",
+            "Account": {
+              "nonce": "U256",
+              "balance": "u128"
+            },
+            "EthTransaction": "LegacyTransaction",
+            "DispatchErrorModule": "DispatchErrorModuleU8",
+            "ExtrinsicSignature": "EthereumSignature",
+            "RoundIndex": "u32",
+            "Candidate": {
+              "id": "AccountId",
+              "fee": "Perbill",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "Nominator": {
+              "nominations": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "Bond": {
+              "owner": "AccountId",
+              "amount": "Balance"
+            },
+            "TxPoolResultContent": {
+              "pending": "HashMap<H160, HashMap<U256, PoolTransaction>>",
+              "queued": "HashMap<H160, HashMap<U256, PoolTransaction>>"
+            },
+            "TxPoolResultInspect": {
+              "pending": "HashMap<H160, HashMap<U256, Summary>>",
+              "queued": "HashMap<H160, HashMap<U256, Summary>>"
+            },
+            "TxPoolResultStatus": {
+              "pending": "U256",
+              "queued": "U256"
+            },
+            "Summary": "Bytes",
+            "PoolTransaction": {
+              "hash": "H256",
+              "nonce": "U256",
+              "blockHash": "Option<H256>",
+              "blockNumber": "Option<U256>",
+              "from": "H160",
+              "to": "Option<H160>",
+              "value": "U256",
+              "gasPrice": "U256",
+              "gas": "U256",
+              "input": "Bytes"
+            },
+            "AccountInfo": "AccountInfoWithTripleRefCount",
+            "CollatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Idle": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Range": "RangeBalance",
+            "RangeBalance": {
+              "min": "Balance",
+              "ideal": "Balance",
+              "max": "Balance"
+            },
+            "RangePerbill": {
+              "min": "Perbill",
+              "ideal": "Perbill",
+              "max": "Perbill"
+            },
+            "InflationInfo": {
+              "expect": "RangeBalance",
+              "annual": "RangePerbill",
+              "round": "RangePerbill"
+            },
+            "OrderedSet": "Vec<Bond>",
+            "Collator": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "CollatorSnapshot": {
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "SystemInherentData": {
+              "validationData": "PersistedValidationData",
+              "relayChain_state": "StorageProof",
+              "downwardMessages": "Vec<InboundDownwardMessage>",
+              "horizontalMessages": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>"
+            },
+            "RoundInfo": {
+              "current": "RoundIndex",
+              "first": "BlockNumber",
+              "length": "u32"
+            },
+            "AuthorId": "AccountId32",
+            "AccountId32": "H256",
             "ProxyType": {
               "_enum": [
                 "Any",
@@ -51022,6 +51125,125 @@ export const typesBundle = {
                 "Balances",
                 "AuthorMapping"
               ]
+            },
+            "RelayChainAccountId": "AccountId32",
+            "RewardInfo": {
+              "totalReward": "Balance",
+              "claimedReward": "Balance",
+              "contributedRelayAddresses": "Vec<RelayChainAccountId>"
+            },
+            "Collator2": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<AccountId>",
+              "topNominators": "Vec<Bond>",
+              "bottomNominators": "Vec<Bond>",
+              "totalCounted": "Balance",
+              "totalBacking": "Balance",
+              "state": "CollatorStatus"
+            },
+            "NominatorAdded": {
+              "_enum": {
+                "AddedToTop": "Balance",
+                "AddedToBottom": "Null"
+              }
+            },
+            "RegistrationInfo": {
+              "account": "AccountId",
+              "deposit": "Balance"
+            },
+            "ParachainBondConfig": {
+              "account": "AccountId",
+              "percent": "Percent"
+            },
+            "EthereumSignature": {
+              "r": "H256",
+              "s": "H256",
+              "v": "U8"
+            },
+            "NominatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Nominator2": {
+              "nominations": "Vec<Bond>",
+              "revocations": "Vec<AccountId>",
+              "total": "Balance",
+              "scheduledRevocationsCount": "u32",
+              "scheduledRevocationsTotal": "Balance",
+              "status": "NominatorStatus"
+            },
+            "ExitQ": {
+              "candidates": "Vec<AccountId>",
+              "nominatorsLeaving": "Vec<AccountId>",
+              "candidateSchedule": "Vec<(AccountId, RoundIndex)>",
+              "nominatorSchedule": "Vec<(AccountId, Option<AccountId>, RoundIndex)>"
+            },
+            "AssetType": {
+              "_enum": {
+                "Xcm": "MultiLocation"
+              }
+            },
+            "AssetId": "u128",
+            "TAssetBalance": "u128",
+            "ENUM_AccountId32": {
+              "network": "NetworkId",
+              "id": "[u8; 32]"
+            },
+            "ENUM_AccountKey20": {
+              "network": "NetworkId",
+              "key": "[u8; 20]"
+            },
+            "ENUM_AccountIndex64": {
+              "network": "NetworkId",
+              "index": "Compact<u64>"
+            },
+            "ENUM_Plurality": {
+              "id": "BodyId",
+              "part": "BodyPart"
+            },
+            "JunctionV0": {
+              "_enum": {
+                "Parent": "Null",
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
+            },
+            "CurrencyId": {
+              "_enum": {
+                "SelfReserve": "Null",
+                "OtherReserve": "u128"
+              }
+            },
+            "AssetRegistrarMetadata": {
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8",
+              "isFrozen": "bool"
+            },
+            "VestingBlockNumber": "u32",
+            "MultiLocation": "MultiLocationV1",
+            "JunctionV1": {
+              "_enum": {
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
             }
           }
         }
@@ -51130,10 +51352,10 @@ export const typesBundle = {
             ],
             "type": "bool"
           },
-          "getLatestSyncedBlock": {
-            "description": "Returns the latest synced block from frontier's backend",
+          "getEthSyncBlockRange": {
+            "description": "Returns the range of blocks that are fully indexed in frontier's backend.",
             "params": [],
-            "type": "u32"
+            "type": "(H256, H256)"
           }
         }
       },
@@ -52733,6 +52955,109 @@ export const typesBundle = {
             null
           ],
           "types": {
+            "AccountId": "EthereumAccountId",
+            "Address": "AccountId",
+            "Balance": "u128",
+            "LookupSource": "AccountId",
+            "Account": {
+              "nonce": "U256",
+              "balance": "u128"
+            },
+            "EthTransaction": "LegacyTransaction",
+            "DispatchErrorModule": "DispatchErrorModuleU8",
+            "ExtrinsicSignature": "EthereumSignature",
+            "RoundIndex": "u32",
+            "Candidate": {
+              "id": "AccountId",
+              "fee": "Perbill",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "Nominator": {
+              "nominations": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "Bond": {
+              "owner": "AccountId",
+              "amount": "Balance"
+            },
+            "TxPoolResultContent": {
+              "pending": "HashMap<H160, HashMap<U256, PoolTransaction>>",
+              "queued": "HashMap<H160, HashMap<U256, PoolTransaction>>"
+            },
+            "TxPoolResultInspect": {
+              "pending": "HashMap<H160, HashMap<U256, Summary>>",
+              "queued": "HashMap<H160, HashMap<U256, Summary>>"
+            },
+            "TxPoolResultStatus": {
+              "pending": "U256",
+              "queued": "U256"
+            },
+            "Summary": "Bytes",
+            "PoolTransaction": {
+              "hash": "H256",
+              "nonce": "U256",
+              "blockHash": "Option<H256>",
+              "blockNumber": "Option<U256>",
+              "from": "H160",
+              "to": "Option<H160>",
+              "value": "U256",
+              "gasPrice": "U256",
+              "gas": "U256",
+              "input": "Bytes"
+            },
+            "AccountInfo": "AccountInfoWithTripleRefCount",
+            "CollatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Idle": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Range": "RangeBalance",
+            "RangeBalance": {
+              "min": "Balance",
+              "ideal": "Balance",
+              "max": "Balance"
+            },
+            "RangePerbill": {
+              "min": "Perbill",
+              "ideal": "Perbill",
+              "max": "Perbill"
+            },
+            "InflationInfo": {
+              "expect": "RangeBalance",
+              "annual": "RangePerbill",
+              "round": "RangePerbill"
+            },
+            "OrderedSet": "Vec<Bond>",
+            "Collator": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "CollatorSnapshot": {
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "SystemInherentData": {
+              "validationData": "PersistedValidationData",
+              "relayChain_state": "StorageProof",
+              "downwardMessages": "Vec<InboundDownwardMessage>",
+              "horizontalMessages": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>"
+            },
+            "RoundInfo": {
+              "current": "RoundIndex",
+              "first": "BlockNumber",
+              "length": "u32"
+            },
+            "AuthorId": "AccountId32",
+            "AccountId32": "H256",
             "ProxyType": {
               "_enum": [
                 "Any",
@@ -52743,6 +53068,125 @@ export const typesBundle = {
                 "Balances",
                 "AuthorMapping"
               ]
+            },
+            "RelayChainAccountId": "AccountId32",
+            "RewardInfo": {
+              "totalReward": "Balance",
+              "claimedReward": "Balance",
+              "contributedRelayAddresses": "Vec<RelayChainAccountId>"
+            },
+            "Collator2": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<AccountId>",
+              "topNominators": "Vec<Bond>",
+              "bottomNominators": "Vec<Bond>",
+              "totalCounted": "Balance",
+              "totalBacking": "Balance",
+              "state": "CollatorStatus"
+            },
+            "NominatorAdded": {
+              "_enum": {
+                "AddedToTop": "Balance",
+                "AddedToBottom": "Null"
+              }
+            },
+            "RegistrationInfo": {
+              "account": "AccountId",
+              "deposit": "Balance"
+            },
+            "ParachainBondConfig": {
+              "account": "AccountId",
+              "percent": "Percent"
+            },
+            "EthereumSignature": {
+              "r": "H256",
+              "s": "H256",
+              "v": "U8"
+            },
+            "NominatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Nominator2": {
+              "nominations": "Vec<Bond>",
+              "revocations": "Vec<AccountId>",
+              "total": "Balance",
+              "scheduledRevocationsCount": "u32",
+              "scheduledRevocationsTotal": "Balance",
+              "status": "NominatorStatus"
+            },
+            "ExitQ": {
+              "candidates": "Vec<AccountId>",
+              "nominatorsLeaving": "Vec<AccountId>",
+              "candidateSchedule": "Vec<(AccountId, RoundIndex)>",
+              "nominatorSchedule": "Vec<(AccountId, Option<AccountId>, RoundIndex)>"
+            },
+            "AssetType": {
+              "_enum": {
+                "Xcm": "MultiLocation"
+              }
+            },
+            "AssetId": "u128",
+            "TAssetBalance": "u128",
+            "ENUM_AccountId32": {
+              "network": "NetworkId",
+              "id": "[u8; 32]"
+            },
+            "ENUM_AccountKey20": {
+              "network": "NetworkId",
+              "key": "[u8; 20]"
+            },
+            "ENUM_AccountIndex64": {
+              "network": "NetworkId",
+              "index": "Compact<u64>"
+            },
+            "ENUM_Plurality": {
+              "id": "BodyId",
+              "part": "BodyPart"
+            },
+            "JunctionV0": {
+              "_enum": {
+                "Parent": "Null",
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
+            },
+            "CurrencyId": {
+              "_enum": {
+                "SelfReserve": "Null",
+                "OtherReserve": "u128"
+              }
+            },
+            "AssetRegistrarMetadata": {
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8",
+              "isFrozen": "bool"
+            },
+            "VestingBlockNumber": "u32",
+            "MultiLocation": "MultiLocationV1",
+            "JunctionV1": {
+              "_enum": {
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
             }
           }
         }
@@ -52851,10 +53295,10 @@ export const typesBundle = {
             ],
             "type": "bool"
           },
-          "getLatestSyncedBlock": {
-            "description": "Returns the latest synced block from frontier's backend",
+          "getEthSyncBlockRange": {
+            "description": "Returns the range of blocks that are fully indexed in frontier's backend.",
             "params": [],
-            "type": "u32"
+            "type": "(H256, H256)"
           }
         }
       },
@@ -54454,6 +54898,109 @@ export const typesBundle = {
             null
           ],
           "types": {
+            "AccountId": "EthereumAccountId",
+            "Address": "AccountId",
+            "Balance": "u128",
+            "LookupSource": "AccountId",
+            "Account": {
+              "nonce": "U256",
+              "balance": "u128"
+            },
+            "EthTransaction": "LegacyTransaction",
+            "DispatchErrorModule": "DispatchErrorModuleU8",
+            "ExtrinsicSignature": "EthereumSignature",
+            "RoundIndex": "u32",
+            "Candidate": {
+              "id": "AccountId",
+              "fee": "Perbill",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "Nominator": {
+              "nominations": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "Bond": {
+              "owner": "AccountId",
+              "amount": "Balance"
+            },
+            "TxPoolResultContent": {
+              "pending": "HashMap<H160, HashMap<U256, PoolTransaction>>",
+              "queued": "HashMap<H160, HashMap<U256, PoolTransaction>>"
+            },
+            "TxPoolResultInspect": {
+              "pending": "HashMap<H160, HashMap<U256, Summary>>",
+              "queued": "HashMap<H160, HashMap<U256, Summary>>"
+            },
+            "TxPoolResultStatus": {
+              "pending": "U256",
+              "queued": "U256"
+            },
+            "Summary": "Bytes",
+            "PoolTransaction": {
+              "hash": "H256",
+              "nonce": "U256",
+              "blockHash": "Option<H256>",
+              "blockNumber": "Option<U256>",
+              "from": "H160",
+              "to": "Option<H160>",
+              "value": "U256",
+              "gasPrice": "U256",
+              "gas": "U256",
+              "input": "Bytes"
+            },
+            "AccountInfo": "AccountInfoWithTripleRefCount",
+            "CollatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Idle": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Range": "RangeBalance",
+            "RangeBalance": {
+              "min": "Balance",
+              "ideal": "Balance",
+              "max": "Balance"
+            },
+            "RangePerbill": {
+              "min": "Perbill",
+              "ideal": "Perbill",
+              "max": "Perbill"
+            },
+            "InflationInfo": {
+              "expect": "RangeBalance",
+              "annual": "RangePerbill",
+              "round": "RangePerbill"
+            },
+            "OrderedSet": "Vec<Bond>",
+            "Collator": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "CollatorSnapshot": {
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "SystemInherentData": {
+              "validationData": "PersistedValidationData",
+              "relayChain_state": "StorageProof",
+              "downwardMessages": "Vec<InboundDownwardMessage>",
+              "horizontalMessages": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>"
+            },
+            "RoundInfo": {
+              "current": "RoundIndex",
+              "first": "BlockNumber",
+              "length": "u32"
+            },
+            "AuthorId": "AccountId32",
+            "AccountId32": "H256",
             "ProxyType": {
               "_enum": [
                 "Any",
@@ -54464,6 +55011,125 @@ export const typesBundle = {
                 "Balances",
                 "AuthorMapping"
               ]
+            },
+            "RelayChainAccountId": "AccountId32",
+            "RewardInfo": {
+              "totalReward": "Balance",
+              "claimedReward": "Balance",
+              "contributedRelayAddresses": "Vec<RelayChainAccountId>"
+            },
+            "Collator2": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<AccountId>",
+              "topNominators": "Vec<Bond>",
+              "bottomNominators": "Vec<Bond>",
+              "totalCounted": "Balance",
+              "totalBacking": "Balance",
+              "state": "CollatorStatus"
+            },
+            "NominatorAdded": {
+              "_enum": {
+                "AddedToTop": "Balance",
+                "AddedToBottom": "Null"
+              }
+            },
+            "RegistrationInfo": {
+              "account": "AccountId",
+              "deposit": "Balance"
+            },
+            "ParachainBondConfig": {
+              "account": "AccountId",
+              "percent": "Percent"
+            },
+            "EthereumSignature": {
+              "r": "H256",
+              "s": "H256",
+              "v": "U8"
+            },
+            "NominatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Nominator2": {
+              "nominations": "Vec<Bond>",
+              "revocations": "Vec<AccountId>",
+              "total": "Balance",
+              "scheduledRevocationsCount": "u32",
+              "scheduledRevocationsTotal": "Balance",
+              "status": "NominatorStatus"
+            },
+            "ExitQ": {
+              "candidates": "Vec<AccountId>",
+              "nominatorsLeaving": "Vec<AccountId>",
+              "candidateSchedule": "Vec<(AccountId, RoundIndex)>",
+              "nominatorSchedule": "Vec<(AccountId, Option<AccountId>, RoundIndex)>"
+            },
+            "AssetType": {
+              "_enum": {
+                "Xcm": "MultiLocation"
+              }
+            },
+            "AssetId": "u128",
+            "TAssetBalance": "u128",
+            "ENUM_AccountId32": {
+              "network": "NetworkId",
+              "id": "[u8; 32]"
+            },
+            "ENUM_AccountKey20": {
+              "network": "NetworkId",
+              "key": "[u8; 20]"
+            },
+            "ENUM_AccountIndex64": {
+              "network": "NetworkId",
+              "index": "Compact<u64>"
+            },
+            "ENUM_Plurality": {
+              "id": "BodyId",
+              "part": "BodyPart"
+            },
+            "JunctionV0": {
+              "_enum": {
+                "Parent": "Null",
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
+            },
+            "CurrencyId": {
+              "_enum": {
+                "SelfReserve": "Null",
+                "OtherReserve": "u128"
+              }
+            },
+            "AssetRegistrarMetadata": {
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8",
+              "isFrozen": "bool"
+            },
+            "VestingBlockNumber": "u32",
+            "MultiLocation": "MultiLocationV1",
+            "JunctionV1": {
+              "_enum": {
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
             }
           }
         }
@@ -54572,10 +55238,10 @@ export const typesBundle = {
             ],
             "type": "bool"
           },
-          "getLatestSyncedBlock": {
-            "description": "Returns the latest synced block from frontier's backend",
+          "getEthSyncBlockRange": {
+            "description": "Returns the range of blocks that are fully indexed in frontier's backend.",
             "params": [],
-            "type": "u32"
+            "type": "(H256, H256)"
           }
         }
       },
@@ -56175,6 +56841,109 @@ export const typesBundle = {
             null
           ],
           "types": {
+            "AccountId": "EthereumAccountId",
+            "Address": "AccountId",
+            "Balance": "u128",
+            "LookupSource": "AccountId",
+            "Account": {
+              "nonce": "U256",
+              "balance": "u128"
+            },
+            "EthTransaction": "LegacyTransaction",
+            "DispatchErrorModule": "DispatchErrorModuleU8",
+            "ExtrinsicSignature": "EthereumSignature",
+            "RoundIndex": "u32",
+            "Candidate": {
+              "id": "AccountId",
+              "fee": "Perbill",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "Nominator": {
+              "nominations": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "Bond": {
+              "owner": "AccountId",
+              "amount": "Balance"
+            },
+            "TxPoolResultContent": {
+              "pending": "HashMap<H160, HashMap<U256, PoolTransaction>>",
+              "queued": "HashMap<H160, HashMap<U256, PoolTransaction>>"
+            },
+            "TxPoolResultInspect": {
+              "pending": "HashMap<H160, HashMap<U256, Summary>>",
+              "queued": "HashMap<H160, HashMap<U256, Summary>>"
+            },
+            "TxPoolResultStatus": {
+              "pending": "U256",
+              "queued": "U256"
+            },
+            "Summary": "Bytes",
+            "PoolTransaction": {
+              "hash": "H256",
+              "nonce": "U256",
+              "blockHash": "Option<H256>",
+              "blockNumber": "Option<U256>",
+              "from": "H160",
+              "to": "Option<H160>",
+              "value": "U256",
+              "gasPrice": "U256",
+              "gas": "U256",
+              "input": "Bytes"
+            },
+            "AccountInfo": "AccountInfoWithTripleRefCount",
+            "CollatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Idle": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Range": "RangeBalance",
+            "RangeBalance": {
+              "min": "Balance",
+              "ideal": "Balance",
+              "max": "Balance"
+            },
+            "RangePerbill": {
+              "min": "Perbill",
+              "ideal": "Perbill",
+              "max": "Perbill"
+            },
+            "InflationInfo": {
+              "expect": "RangeBalance",
+              "annual": "RangePerbill",
+              "round": "RangePerbill"
+            },
+            "OrderedSet": "Vec<Bond>",
+            "Collator": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "CollatorSnapshot": {
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "SystemInherentData": {
+              "validationData": "PersistedValidationData",
+              "relayChain_state": "StorageProof",
+              "downwardMessages": "Vec<InboundDownwardMessage>",
+              "horizontalMessages": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>"
+            },
+            "RoundInfo": {
+              "current": "RoundIndex",
+              "first": "BlockNumber",
+              "length": "u32"
+            },
+            "AuthorId": "AccountId32",
+            "AccountId32": "H256",
             "ProxyType": {
               "_enum": [
                 "Any",
@@ -56185,6 +56954,125 @@ export const typesBundle = {
                 "Balances",
                 "AuthorMapping"
               ]
+            },
+            "RelayChainAccountId": "AccountId32",
+            "RewardInfo": {
+              "totalReward": "Balance",
+              "claimedReward": "Balance",
+              "contributedRelayAddresses": "Vec<RelayChainAccountId>"
+            },
+            "Collator2": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<AccountId>",
+              "topNominators": "Vec<Bond>",
+              "bottomNominators": "Vec<Bond>",
+              "totalCounted": "Balance",
+              "totalBacking": "Balance",
+              "state": "CollatorStatus"
+            },
+            "NominatorAdded": {
+              "_enum": {
+                "AddedToTop": "Balance",
+                "AddedToBottom": "Null"
+              }
+            },
+            "RegistrationInfo": {
+              "account": "AccountId",
+              "deposit": "Balance"
+            },
+            "ParachainBondConfig": {
+              "account": "AccountId",
+              "percent": "Percent"
+            },
+            "EthereumSignature": {
+              "r": "H256",
+              "s": "H256",
+              "v": "U8"
+            },
+            "NominatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Nominator2": {
+              "nominations": "Vec<Bond>",
+              "revocations": "Vec<AccountId>",
+              "total": "Balance",
+              "scheduledRevocationsCount": "u32",
+              "scheduledRevocationsTotal": "Balance",
+              "status": "NominatorStatus"
+            },
+            "ExitQ": {
+              "candidates": "Vec<AccountId>",
+              "nominatorsLeaving": "Vec<AccountId>",
+              "candidateSchedule": "Vec<(AccountId, RoundIndex)>",
+              "nominatorSchedule": "Vec<(AccountId, Option<AccountId>, RoundIndex)>"
+            },
+            "AssetType": {
+              "_enum": {
+                "Xcm": "MultiLocation"
+              }
+            },
+            "AssetId": "u128",
+            "TAssetBalance": "u128",
+            "ENUM_AccountId32": {
+              "network": "NetworkId",
+              "id": "[u8; 32]"
+            },
+            "ENUM_AccountKey20": {
+              "network": "NetworkId",
+              "key": "[u8; 20]"
+            },
+            "ENUM_AccountIndex64": {
+              "network": "NetworkId",
+              "index": "Compact<u64>"
+            },
+            "ENUM_Plurality": {
+              "id": "BodyId",
+              "part": "BodyPart"
+            },
+            "JunctionV0": {
+              "_enum": {
+                "Parent": "Null",
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
+            },
+            "CurrencyId": {
+              "_enum": {
+                "SelfReserve": "Null",
+                "OtherReserve": "u128"
+              }
+            },
+            "AssetRegistrarMetadata": {
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8",
+              "isFrozen": "bool"
+            },
+            "VestingBlockNumber": "u32",
+            "MultiLocation": "MultiLocationV1",
+            "JunctionV1": {
+              "_enum": {
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
             }
           }
         }
@@ -56561,10 +57449,10 @@ export const typesBundle = {
             ],
             "type": "bool"
           },
-          "getLatestSyncedBlock": {
-            "description": "Returns the latest synced block from frontier's backend",
+          "getEthSyncBlockRange": {
+            "description": "Returns the range of blocks that are fully indexed in frontier's backend.",
             "params": [],
-            "type": "u32"
+            "type": "(H256, H256)"
           }
         }
       },
@@ -58164,6 +59052,109 @@ export const typesBundle = {
             null
           ],
           "types": {
+            "AccountId": "EthereumAccountId",
+            "Address": "AccountId",
+            "Balance": "u128",
+            "LookupSource": "AccountId",
+            "Account": {
+              "nonce": "U256",
+              "balance": "u128"
+            },
+            "EthTransaction": "LegacyTransaction",
+            "DispatchErrorModule": "DispatchErrorModuleU8",
+            "ExtrinsicSignature": "EthereumSignature",
+            "RoundIndex": "u32",
+            "Candidate": {
+              "id": "AccountId",
+              "fee": "Perbill",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "Nominator": {
+              "nominations": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "Bond": {
+              "owner": "AccountId",
+              "amount": "Balance"
+            },
+            "TxPoolResultContent": {
+              "pending": "HashMap<H160, HashMap<U256, PoolTransaction>>",
+              "queued": "HashMap<H160, HashMap<U256, PoolTransaction>>"
+            },
+            "TxPoolResultInspect": {
+              "pending": "HashMap<H160, HashMap<U256, Summary>>",
+              "queued": "HashMap<H160, HashMap<U256, Summary>>"
+            },
+            "TxPoolResultStatus": {
+              "pending": "U256",
+              "queued": "U256"
+            },
+            "Summary": "Bytes",
+            "PoolTransaction": {
+              "hash": "H256",
+              "nonce": "U256",
+              "blockHash": "Option<H256>",
+              "blockNumber": "Option<U256>",
+              "from": "H160",
+              "to": "Option<H160>",
+              "value": "U256",
+              "gasPrice": "U256",
+              "gas": "U256",
+              "input": "Bytes"
+            },
+            "AccountInfo": "AccountInfoWithTripleRefCount",
+            "CollatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Idle": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Range": "RangeBalance",
+            "RangeBalance": {
+              "min": "Balance",
+              "ideal": "Balance",
+              "max": "Balance"
+            },
+            "RangePerbill": {
+              "min": "Perbill",
+              "ideal": "Perbill",
+              "max": "Perbill"
+            },
+            "InflationInfo": {
+              "expect": "RangeBalance",
+              "annual": "RangePerbill",
+              "round": "RangePerbill"
+            },
+            "OrderedSet": "Vec<Bond>",
+            "Collator": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance",
+              "state": "CollatorStatus"
+            },
+            "CollatorSnapshot": {
+              "bond": "Balance",
+              "nominators": "Vec<Bond>",
+              "total": "Balance"
+            },
+            "SystemInherentData": {
+              "validationData": "PersistedValidationData",
+              "relayChain_state": "StorageProof",
+              "downwardMessages": "Vec<InboundDownwardMessage>",
+              "horizontalMessages": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>"
+            },
+            "RoundInfo": {
+              "current": "RoundIndex",
+              "first": "BlockNumber",
+              "length": "u32"
+            },
+            "AuthorId": "AccountId32",
+            "AccountId32": "H256",
             "ProxyType": {
               "_enum": [
                 "Any",
@@ -58174,6 +59165,125 @@ export const typesBundle = {
                 "Balances",
                 "AuthorMapping"
               ]
+            },
+            "RelayChainAccountId": "AccountId32",
+            "RewardInfo": {
+              "totalReward": "Balance",
+              "claimedReward": "Balance",
+              "contributedRelayAddresses": "Vec<RelayChainAccountId>"
+            },
+            "Collator2": {
+              "id": "AccountId",
+              "bond": "Balance",
+              "nominators": "Vec<AccountId>",
+              "topNominators": "Vec<Bond>",
+              "bottomNominators": "Vec<Bond>",
+              "totalCounted": "Balance",
+              "totalBacking": "Balance",
+              "state": "CollatorStatus"
+            },
+            "NominatorAdded": {
+              "_enum": {
+                "AddedToTop": "Balance",
+                "AddedToBottom": "Null"
+              }
+            },
+            "RegistrationInfo": {
+              "account": "AccountId",
+              "deposit": "Balance"
+            },
+            "ParachainBondConfig": {
+              "account": "AccountId",
+              "percent": "Percent"
+            },
+            "EthereumSignature": {
+              "r": "H256",
+              "s": "H256",
+              "v": "U8"
+            },
+            "NominatorStatus": {
+              "_enum": {
+                "Active": "Null",
+                "Leaving": "RoundIndex"
+              }
+            },
+            "Nominator2": {
+              "nominations": "Vec<Bond>",
+              "revocations": "Vec<AccountId>",
+              "total": "Balance",
+              "scheduledRevocationsCount": "u32",
+              "scheduledRevocationsTotal": "Balance",
+              "status": "NominatorStatus"
+            },
+            "ExitQ": {
+              "candidates": "Vec<AccountId>",
+              "nominatorsLeaving": "Vec<AccountId>",
+              "candidateSchedule": "Vec<(AccountId, RoundIndex)>",
+              "nominatorSchedule": "Vec<(AccountId, Option<AccountId>, RoundIndex)>"
+            },
+            "AssetType": {
+              "_enum": {
+                "Xcm": "MultiLocation"
+              }
+            },
+            "AssetId": "u128",
+            "TAssetBalance": "u128",
+            "ENUM_AccountId32": {
+              "network": "NetworkId",
+              "id": "[u8; 32]"
+            },
+            "ENUM_AccountKey20": {
+              "network": "NetworkId",
+              "key": "[u8; 20]"
+            },
+            "ENUM_AccountIndex64": {
+              "network": "NetworkId",
+              "index": "Compact<u64>"
+            },
+            "ENUM_Plurality": {
+              "id": "BodyId",
+              "part": "BodyPart"
+            },
+            "JunctionV0": {
+              "_enum": {
+                "Parent": "Null",
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
+            },
+            "CurrencyId": {
+              "_enum": {
+                "SelfReserve": "Null",
+                "OtherReserve": "u128"
+              }
+            },
+            "AssetRegistrarMetadata": {
+              "name": "Vec<u8>",
+              "symbol": "Vec<u8>",
+              "decimals": "u8",
+              "isFrozen": "bool"
+            },
+            "VestingBlockNumber": "u32",
+            "MultiLocation": "MultiLocationV1",
+            "JunctionV1": {
+              "_enum": {
+                "Parachain": "Compact<u32>",
+                "AccountId32": "ENUM_AccountId32",
+                "AccountIndex64": "ENUM_AccountIndex64",
+                "AccountKey20": "ENUM_AccountKey20",
+                "PalletInstance": "u8",
+                "GeneralIndex": "Compact<u128>",
+                "GeneralKey": "Vec<u8>",
+                "OnlyChild": "Null",
+                "Plurality": "ENUM_Plurality"
+              }
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,9 +1111,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@moonbeam-network/types-bundle@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@moonbeam-network/types-bundle@npm:1.0.1"
+"@moonbeam-network/types-bundle@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@moonbeam-network/types-bundle@npm:1.0.2"
   dependencies:
     "@biomejs/biome": "npm:*"
     "@polkadot/api": "npm:*"
@@ -1124,7 +1124,7 @@ __metadata:
     "@polkadot/types-codec": "npm:*"
     tsup: "npm:*"
     typescript: "npm:*"
-  checksum: 10/ef5a1877cd15ed4e43854ed16aeb297fe6ea05934c1c7c02d49fc677c5cf1e171dfda3b36567f1c8ffb4d1fe0451d8855c35d75919fa66f89940e96aace6116e
+  checksum: 10/994927e345515684ca067ab23b10b4d4a70a5ef1fa5e282dcc3b86d143eae103bbc4b19bc5526f3b850e92732b1b3e292527b868ecd095a40a5346a979d2b30c
   languageName: node
   linkType: hard
 
@@ -2185,7 +2185,7 @@ __metadata:
     "@logion/node-api": "npm:0.27.0-4"
     "@mangata-finance/type-definitions": "npm:^2.1.2"
     "@metaverse-network-sdk/type-definitions": "npm:0.0.1-16"
-    "@moonbeam-network/types-bundle": "npm:1.0.1"
+    "@moonbeam-network/types-bundle": "npm:1.0.2"
     "@parallel-finance/type-definitions": "npm:2.0.1"
     "@peaqnetwork/type-definitions": "npm:0.0.4"
     "@pendulum-chain/type-definitions": "npm:0.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,9 +1111,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@moonbeam-network/types-bundle@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@moonbeam-network/types-bundle@npm:1.0.0"
+"@moonbeam-network/types-bundle@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@moonbeam-network/types-bundle@npm:1.0.1"
   dependencies:
     "@biomejs/biome": "npm:*"
     "@polkadot/api": "npm:*"
@@ -1124,7 +1124,7 @@ __metadata:
     "@polkadot/types-codec": "npm:*"
     tsup: "npm:*"
     typescript: "npm:*"
-  checksum: 10/2c316d907778c93642d93056f6a30b2dfa678aac5632b7c551b2c14f28b62eebf9f3bf41ec7635d3364a59dd6b8e05c18d0d957b23ca0d34c13f8636d199f311
+  checksum: 10/ef5a1877cd15ed4e43854ed16aeb297fe6ea05934c1c7c02d49fc677c5cf1e171dfda3b36567f1c8ffb4d1fe0451d8855c35d75919fa66f89940e96aace6116e
   languageName: node
   linkType: hard
 
@@ -2185,7 +2185,7 @@ __metadata:
     "@logion/node-api": "npm:0.27.0-4"
     "@mangata-finance/type-definitions": "npm:^2.1.2"
     "@metaverse-network-sdk/type-definitions": "npm:0.0.1-16"
-    "@moonbeam-network/types-bundle": "npm:1.0.0"
+    "@moonbeam-network/types-bundle": "npm:1.0.1"
     "@parallel-finance/type-definitions": "npm:2.0.1"
     "@peaqnetwork/type-definitions": "npm:0.0.4"
     "@pendulum-chain/type-definitions": "npm:0.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,6 +155,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@biomejs/biome@npm:*":
+  version: 1.9.4
+  resolution: "@biomejs/biome@npm:1.9.4"
+  dependencies:
+    "@biomejs/cli-darwin-arm64": "npm:1.9.4"
+    "@biomejs/cli-darwin-x64": "npm:1.9.4"
+    "@biomejs/cli-linux-arm64": "npm:1.9.4"
+    "@biomejs/cli-linux-arm64-musl": "npm:1.9.4"
+    "@biomejs/cli-linux-x64": "npm:1.9.4"
+    "@biomejs/cli-linux-x64-musl": "npm:1.9.4"
+    "@biomejs/cli-win32-arm64": "npm:1.9.4"
+    "@biomejs/cli-win32-x64": "npm:1.9.4"
+  dependenciesMeta:
+    "@biomejs/cli-darwin-arm64":
+      optional: true
+    "@biomejs/cli-darwin-x64":
+      optional: true
+    "@biomejs/cli-linux-arm64":
+      optional: true
+    "@biomejs/cli-linux-arm64-musl":
+      optional: true
+    "@biomejs/cli-linux-x64":
+      optional: true
+    "@biomejs/cli-linux-x64-musl":
+      optional: true
+    "@biomejs/cli-win32-arm64":
+      optional: true
+    "@biomejs/cli-win32-x64":
+      optional: true
+  bin:
+    biome: bin/biome
+  checksum: 10/bd8ff8fb4dc0581bd60a9b9ac28d0cd03ba17c6a1de2ab6228b7fda582079594ceee774f47e41aac2fc6d35de1637def2e32ef2e58fa24e22d1b24ef9ee5cefa
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-darwin-arm64@npm:1.9.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-darwin-x64@npm:1.9.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64-musl@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.9.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-arm64@npm:1.9.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64-musl@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-x64-musl@npm:1.9.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-x64@npm:1.9.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-win32-arm64@npm:1.9.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-win32-x64@npm:1.9.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@chainsafe/is-ip@npm:^2.0.1":
   version: 2.0.1
   resolution: "@chainsafe/is-ip@npm:2.0.1"
@@ -341,6 +432,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/aix-ppc64@npm:0.24.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/android-arm64@npm:0.24.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/android-arm@npm:0.24.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/android-x64@npm:0.24.2"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/darwin-arm64@npm:0.24.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/darwin-x64@npm:0.24.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.24.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/freebsd-x64@npm:0.24.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-arm64@npm:0.24.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-arm@npm:0.24.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-ia32@npm:0.24.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-loong64@npm:0.24.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-mips64el@npm:0.24.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-ppc64@npm:0.24.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-riscv64@npm:0.24.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-s390x@npm:0.24.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/linux-x64@npm:0.24.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/netbsd-arm64@npm:0.24.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/netbsd-x64@npm:0.24.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/openbsd-arm64@npm:0.24.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/openbsd-x64@npm:0.24.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/sunos-x64@npm:0.24.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/win32-arm64@npm:0.24.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/win32-ia32@npm:0.24.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@esbuild/win32-x64@npm:0.24.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -492,6 +758,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 10/e9ed5fd27c3aec1095e3a16e0c0cf148d1fee55a38665c35f7b3f86a9b5d00d042ddaabc98e8a1cb7463b9378c15f22a94eb35e99469c201453eb8375191f243
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^29.6.2":
   version: 29.6.2
   resolution: "@jest/expect-utils@npm:29.6.2"
@@ -535,6 +815,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.2":
+  version: 0.3.8
+  resolution: "@jridgewell/gen-mapping@npm:0.3.8"
+  dependencies:
+    "@jridgewell/set-array": "npm:^1.2.1"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/9d3a56ab3612ab9b85d38b2a93b87f3324f11c5130859957f6500e4ac8ce35f299d5ccc3ecd1ae87597601ecf83cee29e9afd04c18777c24011073992ff946df
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:3.1.0":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
@@ -542,10 +833,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 10/97106439d750a409c22c8bff822d648f6a71f3aa9bc8e5129efdc36343cd3096ddc4eeb1c62d2fe48e9bdd4db37b05d4646a17114ecebd3bbcacfa2de51c3c1d
+  languageName: node
+  linkType: hard
+
 "@jridgewell/set-array@npm:^1.0.1":
   version: 1.1.2
   resolution: "@jridgewell/set-array@npm:1.1.2"
   checksum: 10/69a84d5980385f396ff60a175f7177af0b8da4ddb81824cb7016a9ef914eee9806c72b6b65942003c63f7983d4f39a5c6c27185bbca88eb4690b62075602e28e
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jridgewell/set-array@npm:1.2.1"
+  checksum: 10/832e513a85a588f8ed4f27d1279420d8547743cc37fcad5a5a76fc74bb895b013dfe614d0eed9cb860048e6546b798f8f2652020b4b2ba0561b05caa8c654b10
   languageName: node
   linkType: hard
 
@@ -573,6 +878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 10/4ed6123217569a1484419ac53f6ea0d9f3b57e5b57ab30d7c267bdb27792a27eb0e4b08e84a2680aa55cc2f2b411ffd6ec3db01c44fdc6dc43aca4b55f8374fd
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.17
   resolution: "@jridgewell/trace-mapping@npm:0.3.17"
@@ -580,6 +892,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:3.1.0"
     "@jridgewell/sourcemap-codec": "npm:1.4.14"
   checksum: 10/790d439c9b271d9fc381dc4a837393ab942920245efedd5db20f65a665c0f778637fa623573337d3241ff784ffdb6724bbadf7fa2b61666bcd4884064b02f113
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.24":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
   languageName: node
   linkType: hard
 
@@ -786,6 +1108,23 @@ __metadata:
   dependencies:
     lodash.merge: "npm:^4.6.2"
   checksum: 10/8e60e11381036594aad2c00d0caeb76f5d619abf789bdd67581fb12c245e2f128505c110d096e4a681f0165049883fa6a638aff0137d3174e1640ad1dacf597d
+  languageName: node
+  linkType: hard
+
+"@moonbeam-network/types-bundle@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@moonbeam-network/types-bundle@npm:1.0.0"
+  dependencies:
+    "@biomejs/biome": "npm:*"
+    "@polkadot/api": "npm:*"
+    "@polkadot/api-base": "npm:*"
+    "@polkadot/rpc-core": "npm:*"
+    "@polkadot/typegen": "npm:*"
+    "@polkadot/types": "npm:*"
+    "@polkadot/types-codec": "npm:*"
+    tsup: "npm:*"
+    typescript: "npm:*"
+  checksum: 10/2c316d907778c93642d93056f6a30b2dfa678aac5632b7c551b2c14f28b62eebf9f3bf41ec7635d3364a59dd6b8e05c18d0d957b23ca0d34c13f8636d199f311
   languageName: node
   linkType: hard
 
@@ -1088,6 +1427,13 @@ __metadata:
     is-ipfs: "npm:^0.6.0"
     recursive-fs: "npm:^1.1.2"
   checksum: 10/ebb39b4ad7352fc593147905eb4ead7bc729116c5d27aec5d2bb4a8e66c098aecdde1dc5f324e138a9edab108f90ecf8171d4dba279b737c6e331c69b71250b5
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
   languageName: node
   linkType: hard
 
@@ -1839,6 +2185,7 @@ __metadata:
     "@logion/node-api": "npm:0.27.0-4"
     "@mangata-finance/type-definitions": "npm:^2.1.2"
     "@metaverse-network-sdk/type-definitions": "npm:0.0.1-16"
+    "@moonbeam-network/types-bundle": "npm:1.0.0"
     "@parallel-finance/type-definitions": "npm:2.0.1"
     "@peaqnetwork/type-definitions": "npm:0.0.4"
     "@pendulum-chain/type-definitions": "npm:0.3.8"
@@ -1864,7 +2211,6 @@ __metadata:
     "@unique-nft/unique-mainnet-types": "npm:1001.63.0"
     "@zeitgeistpm/type-defs": "npm:1.0.0"
     "@zeroio/type-definitions": "npm:0.0.14"
-    moonbeam-types-bundle: "npm:2.0.10"
     pontem-types-bundle: "npm:1.0.15"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
@@ -2386,6 +2732,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@polkadot/typegen@npm:*":
+  version: 15.5.1
+  resolution: "@polkadot/typegen@npm:15.5.1"
+  dependencies:
+    "@polkadot/api": "npm:15.5.1"
+    "@polkadot/api-augment": "npm:15.5.1"
+    "@polkadot/rpc-augment": "npm:15.5.1"
+    "@polkadot/rpc-provider": "npm:15.5.1"
+    "@polkadot/types": "npm:15.5.1"
+    "@polkadot/types-augment": "npm:15.5.1"
+    "@polkadot/types-codec": "npm:15.5.1"
+    "@polkadot/types-create": "npm:15.5.1"
+    "@polkadot/types-support": "npm:15.5.1"
+    "@polkadot/util": "npm:^13.3.1"
+    "@polkadot/util-crypto": "npm:^13.3.1"
+    "@polkadot/x-ws": "npm:^13.3.1"
+    handlebars: "npm:^4.7.8"
+    tslib: "npm:^2.8.1"
+    yargs: "npm:^17.7.2"
+  bin:
+    polkadot-types-chain-info: scripts/polkadot-types-chain-info.mjs
+    polkadot-types-from-chain: scripts/polkadot-types-from-chain.mjs
+    polkadot-types-from-defs: scripts/polkadot-types-from-defs.mjs
+    polkadot-types-internal-interfaces: scripts/polkadot-types-internal-interfaces.mjs
+    polkadot-types-internal-metadata: scripts/polkadot-types-internal-metadata.mjs
+  checksum: 10/2e2a0384df792bb41cb507fb998487637aaa9b0a225cde3800e9bf3807fbb56ca88ef224245f45ec2bc67d3f58932bbba0d74d31bacbcc0bfb3f2f796d0ba463
+  languageName: node
+  linkType: hard
+
 "@polkadot/types-augment@npm:^15.2.1":
   version: 15.2.1
   resolution: "@polkadot/types-augment@npm:15.2.1"
@@ -2846,9 +3221,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.32.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm64@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-android-arm64@npm:4.21.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-android-arm64@npm:4.32.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2860,6 +3249,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-arm64@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.32.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-darwin-x64@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-darwin-x64@npm:4.21.0"
@@ -2867,9 +3263,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-x64@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-darwin-x64@npm:4.32.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.32.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.32.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm-gnueabihf@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.21.0"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.32.1"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
@@ -2881,9 +3305,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm-musleabihf@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.32.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm64-gnu@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.21.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.32.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2895,9 +3333,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm64-musl@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.32.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.32.1"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-powerpc64le-gnu@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.21.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.32.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2909,9 +3368,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-riscv64-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.32.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-s390x-gnu@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.21.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.32.1"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2923,9 +3396,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-x64-gnu@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.32.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-x64-musl@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-linux-x64-musl@npm:4.21.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.32.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -2937,6 +3424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-arm64-msvc@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.32.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-ia32-msvc@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.21.0"
@@ -2944,9 +3438,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-ia32-msvc@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.32.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-x64-msvc@npm:4.21.0":
   version: 4.21.0
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.21.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.32.1":
+  version: 4.32.1
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.32.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3354,6 +3862,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 10/7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.6":
+  version: 1.0.6
+  resolution: "@types/estree@npm:1.0.6"
+  checksum: 10/9d35d475095199c23e05b431bcdd1f6fec7380612aed068b14b2a08aa70494de8a9026765a5a91b1073f636fb0368f6d8973f518a31391d519e20c59388ed88d
   languageName: node
   linkType: hard
 
@@ -4694,6 +5209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "ansi-regex@npm:6.1.0"
+  checksum: 10/495834a53b0856c02acd40446f7130cb0f8284f4a39afdab20d5dc42b2e198b1196119fe887beed8f9055c4ff2055e3b2f6d4641d0be018cdfb64fedf6fc1aac
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -4719,7 +5241,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.1.0":
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+  languageName: node
+  linkType: hard
+
+"any-promise@npm:^1.0.0, any-promise@npm:^1.1.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
   checksum: 10/6737469ba353b5becf29e4dc3680736b9caa06d300bda6548812a8fee63ae7d336d756f88572fa6b5219aed36698d808fa55f62af3e7e6845c7a1dc77d240edb
@@ -5639,6 +6168,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-require@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "bundle-require@npm:5.1.0"
+  dependencies:
+    load-tsconfig: "npm:^0.2.3"
+  peerDependencies:
+    esbuild: ">=0.18"
+  checksum: 10/735e0220055b9bdac20bea48ec1e10dc3a205232c889ef54767900bebdc721959c4ccb221e4ea434d7ddcd693a8a4445c3d0598e4040ee313ce0ac3aae3e6178
+  languageName: node
+  linkType: hard
+
 "busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
@@ -5666,6 +6206,13 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10/a10abf2ba70c784471d6b4f58778c0beeb2b5d405148e66affa91f23a9f13d07603d0a0354667310ae1d6dc141474ffd44e2a074be0f6e2254edb8fc21445388
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10/002769a0fbfc51c062acd2a59df465a2a947916b02ac50b56c69ec6c018ee99ac3e7f4dd7366334ea847f1ecacf4defaa61bcd2ac283db50156ce1f1d8c8ad42
   languageName: node
   linkType: hard
 
@@ -5917,6 +6464,15 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10/863e3ff78ee7a4a24513d2a416856e84c8e4f5e60efbe03e8ab791af1a183f569b62fc6f6b8044e2804966cb81277ddbbc1dc374fba3265bd609ea8efd62f5b3
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^4.0.1":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: 10/bf2a575ea5596000e88f5db95461a9d59ad2047e939d5a4aac59dd472d126be8f1c1ff3c7654b477cf532d18f42a97279ef80ee847972fd2a25410bf00b80b59
   languageName: node
   linkType: hard
 
@@ -6253,6 +6809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: 10/3b2dc4125f387dab73b3294dbcb0ab2a862f9c0ad748ee2b27e3544d25325b7a8cdfbcc228d103a98a716960b14478114a5206b5415bd48cdafa38797891562c
+  languageName: node
+  linkType: hard
+
 "commander@npm:^5.0.0":
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
@@ -6405,6 +6968,13 @@ __metadata:
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
   checksum: 10/3b26bf4041fdb33deacdcb3af9ae11e9a0b413fb14c95844d74a460b55e407625b364955dcf965c654605cde9d24ad5dad423c489aa430825aab2035859aba0c
+  languageName: node
+  linkType: hard
+
+"consola@npm:^3.2.3":
+  version: 3.4.0
+  resolution: "consola@npm:3.4.0"
+  checksum: 10/99d4a8131f4cc42ff6bb8e4fd8c9dbd428d6b949f3ec25d9d24892a7b0603b0aabeee8213e13ad74439b5078fdb204f9377bcdd401949c33fff672d91f05c4ec
   languageName: node
   linkType: hard
 
@@ -6585,6 +7155,17 @@ __metadata:
   dependencies:
     node-fetch: "npm:^2.6.12"
   checksum: 10/e231a71926644ef122d334a3a4e73d9ba3ba4b480a8a277fb9badc434c1ba905b3d60c8034e18b348361a09afbec40ba9371036801ba2b675a7b84588f9f55d8
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
   languageName: node
   linkType: hard
 
@@ -6791,6 +7372,18 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10/d86fd7be2b85462297ea16f1934dc219335e802f629ca9a69b63ed8ed041dda492389bb2ee039217c02e5b54792b1c51aa96ae954cf28634d363a2360c7a1639
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.7":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/1847944c2e3c2c732514b93d11886575625686056cd765336212dc15de2d2b29612b6cd80e1afba767bb8e1803b778caf9973e98169ef1a24a7a7009e1820367
   languageName: node
   linkType: hard
 
@@ -7560,6 +8153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
+  languageName: node
+  linkType: hard
+
 "ecc-jsbn@npm:~0.1.1":
   version: 0.1.2
   resolution: "ecc-jsbn@npm:0.1.2"
@@ -7725,6 +8325,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 10/c72d67a6821be15ec11997877c437491c313d924306b8da5d87d2a2bcc2cec9903cb5b04ee1a088460501d8e5b44f10df82fdc93c444101a7610b80c8b6938e1
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
   languageName: node
   linkType: hard
 
@@ -7953,6 +8560,92 @@ __metadata:
   version: 4.1.1
   resolution: "es6-error@npm:4.1.1"
   checksum: 10/48483c25701dc5a6376f39bbe2eaf5da0b505607ec5a98cd3ade472c1939242156660636e2e508b33211e48e88b132d245341595c067bd4a95ac79fa7134da06
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.24.0":
+  version: 0.24.2
+  resolution: "esbuild@npm:0.24.2"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.24.2"
+    "@esbuild/android-arm": "npm:0.24.2"
+    "@esbuild/android-arm64": "npm:0.24.2"
+    "@esbuild/android-x64": "npm:0.24.2"
+    "@esbuild/darwin-arm64": "npm:0.24.2"
+    "@esbuild/darwin-x64": "npm:0.24.2"
+    "@esbuild/freebsd-arm64": "npm:0.24.2"
+    "@esbuild/freebsd-x64": "npm:0.24.2"
+    "@esbuild/linux-arm": "npm:0.24.2"
+    "@esbuild/linux-arm64": "npm:0.24.2"
+    "@esbuild/linux-ia32": "npm:0.24.2"
+    "@esbuild/linux-loong64": "npm:0.24.2"
+    "@esbuild/linux-mips64el": "npm:0.24.2"
+    "@esbuild/linux-ppc64": "npm:0.24.2"
+    "@esbuild/linux-riscv64": "npm:0.24.2"
+    "@esbuild/linux-s390x": "npm:0.24.2"
+    "@esbuild/linux-x64": "npm:0.24.2"
+    "@esbuild/netbsd-arm64": "npm:0.24.2"
+    "@esbuild/netbsd-x64": "npm:0.24.2"
+    "@esbuild/openbsd-arm64": "npm:0.24.2"
+    "@esbuild/openbsd-x64": "npm:0.24.2"
+    "@esbuild/sunos-x64": "npm:0.24.2"
+    "@esbuild/win32-arm64": "npm:0.24.2"
+    "@esbuild/win32-ia32": "npm:0.24.2"
+    "@esbuild/win32-x64": "npm:0.24.2"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/95425071c9f24ff88bf61e0710b636ec0eb24ddf8bd1f7e1edef3044e1221104bbfa7bbb31c18018c8c36fa7902c5c0b843f829b981ebc89160cf5eebdaa58f4
   languageName: node
   linkType: hard
 
@@ -8758,6 +9451,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.4.2":
+  version: 6.4.3
+  resolution: "fdir@npm:6.4.3"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10/8e6d20f4590dc168de1374a9cadaa37e20ca6e0b822aa247c230e7ea1d9e9674a68cd816146435e4ecc98f9285091462ab7e5e56eebc9510931a1794e4db68b2
+  languageName: node
+  linkType: hard
+
 "fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
   version: 3.2.0
   resolution: "fetch-blob@npm:3.2.0"
@@ -8977,6 +9682,16 @@ __metadata:
   dependencies:
     is-callable: "npm:^1.1.3"
   checksum: 10/fdac0cde1be35610bd635ae958422e8ce0cc1313e8d32ea6d34cfda7b60850940c1fd07c36456ad76bd9c24aef6ff5e03b02beb58c83af5ef6c968a64eada676
+  languageName: node
+  linkType: hard
+
+"foreground-child@npm:^3.1.0":
+  version: 3.3.0
+  resolution: "foreground-child@npm:3.3.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10/e3a60480f3a09b12273ce2c5fcb9514d98dd0e528f58656a1b04680225f918d60a2f81f6a368f2f3b937fcee9cfc0cbf16f1ad9a0bc6a3a6e103a84c9a90087e
   languageName: node
   linkType: hard
 
@@ -9433,6 +10148,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.3.10":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/698dfe11828b7efd0514cd11e573eaed26b2dff611f0400907281ce3eab0c1e56143ef9b35adc7c77ecc71fba74717b510c7c223d34ca8a98ec81777b293d4ac
+  languageName: node
+  linkType: hard
+
 "glob@npm:^5.0.15":
   version: 5.0.15
   resolution: "glob@npm:5.0.15"
@@ -9664,6 +10395,24 @@ __metadata:
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
   checksum: 10/441ec98b07f26819c70c702f6c874088eebeb551b242fe8fae4eab325746b82bf84ae7a1f6419547698accb3941fa26806c5f5f93c50e19f90e499065a711d61
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.8":
+  version: 4.7.8
+  resolution: "handlebars@npm:4.7.8"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
   languageName: node
   linkType: hard
 
@@ -11111,6 +11860,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^3.1.2":
+  version: 3.4.3
+  resolution: "jackspeak@npm:3.4.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.5
   resolution: "jake@npm:10.8.5"
@@ -11537,6 +12299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "lilconfig@npm:3.1.3"
+  checksum: 10/b932ce1af94985f0efbe8896e57b1f814a48c8dbd7fc0ef8469785c6303ed29d0090af3ccad7e36b626bfca3a4dc56cc262697e9a8dd867623cf09a39d54e4c3
+  languageName: node
+  linkType: hard
+
 "line-reader@npm:^0.2.4":
   version: 0.2.4
   resolution: "line-reader@npm:0.2.4"
@@ -11560,6 +12329,13 @@ __metadata:
     strip-bom: "npm:^4.0.0"
     type-fest: "npm:^0.6.0"
   checksum: 10/4429e430ebb99375fc7cd936348e4f7ba729486080ced4272091c1e386a7f5f738ea3337d8ffd4b01c2f5bc3ddde92f2c780045b66838fe98bdb79f901884643
+  languageName: node
+  linkType: hard
+
+"load-tsconfig@npm:^0.2.3":
+  version: 0.2.5
+  resolution: "load-tsconfig@npm:0.2.5"
+  checksum: 10/b3176f6f0c86dbdbbc7e337440a803b0b4407c55e2e1cfc53bd3db68e0211448f36428a6075ecf5e286db5d1bf791da756fc0ac4d2447717140fb6a5218ecfb4
   languageName: node
   linkType: hard
 
@@ -11644,6 +12420,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.sortby@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "lodash.sortby@npm:4.7.0"
+  checksum: 10/38df19ae28608af2c50ac342fc1f414508309d53e1d58ed9adfb2c3cd17c3af290058c0a0478028d932c5404df3d53349d19fa364ef6bed6145a6bc21320399e
+  languageName: node
+  linkType: hard
+
 "lodash.union@npm:^4.6.0":
   version: 4.6.0
   resolution: "lodash.union@npm:4.6.0"
@@ -11715,6 +12498,13 @@ __metadata:
   version: 2.0.0
   resolution: "lowercase-keys@npm:2.0.0"
   checksum: 10/1c233d2da35056e8c49fae8097ee061b8c799b2f02e33c2bf32f9913c7de8fb481ab04dab7df35e94156c800f5f34e99acbf32b21781d87c3aa43ef7b748b79e
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^10.2.0":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: 10/e6e90267360476720fa8e83cc168aa2bf0311f3f2eea20a6ba78b90a885ae72071d9db132f40fda4129c803e7dcec3a6b6a6fbb44ca90b081630b810b5d6a41a
   languageName: node
   linkType: hard
 
@@ -12412,6 +13202,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.4":
+  version: 9.0.5
+  resolution: "minimatch@npm:9.0.5"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
+  languageName: node
+  linkType: hard
+
 "minimist-options@npm:4.1.0":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -12443,6 +13242,13 @@ __metadata:
   version: 5.0.0
   resolution: "minipass@npm:5.0.0"
   checksum: 10/61682162d29f45d3152b78b08bab7fb32ca10899bc5991ffe98afc18c9e9543bd1e3be94f8b8373ba6262497db63607079dc242ea62e43e7b2270837b7347c93
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
   languageName: node
   linkType: hard
 
@@ -12545,16 +13351,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moonbeam-types-bundle@npm:2.0.10":
-  version: 2.0.10
-  resolution: "moonbeam-types-bundle@npm:2.0.10"
-  dependencies:
-    "@polkadot/api": "npm:^9.14.1"
-    typescript: "npm:^4.7.4"
-  checksum: 10/4b3eba43b6018a6360c494303a95b8bc99c4650366c6a95d75a363b5e4053297c4bbb96e73017bc029348c6f443b9e7c6f5889ead53f624491fa4935b5ba62d1
-  languageName: node
-  linkType: hard
-
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -12569,7 +13365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.1.1":
+"ms@npm:2.1.3, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -12682,6 +13478,17 @@ __metadata:
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: 10/a2d2e79dde87e3424ffc8c334472c7f3d17b072137734ca46e6f221131f1b014201cc593b69a38062e974fb2394d3d1cb4349f80f012bbf8b8ac1b28033e515f
+  languageName: node
+  linkType: hard
+
+"mz@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "mz@npm:2.7.0"
+  dependencies:
+    any-promise: "npm:^1.0.0"
+    object-assign: "npm:^4.0.1"
+    thenify-all: "npm:^1.0.0"
+  checksum: 10/8427de0ece99a07e9faed3c0c6778820d7543e3776f9a84d22cf0ec0a8eb65f6e9aee9c9d353ff9a105ff62d33a9463c6ca638974cc652ee8140cd1e35951c87
   languageName: node
   linkType: hard
 
@@ -13340,6 +14147,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10/58ee9538f2f762988433da00e26acc788036914d57c71c246bf0be1b60cdbd77dd60b6a3e1a30465f0b248aeb80079e0b34cb6050b1dfa18c06953bb1cbc7602
+  languageName: node
+  linkType: hard
+
 "package-json@npm:^6.3.0":
   version: 6.5.0
   resolution: "package-json@npm:6.5.0"
@@ -13487,6 +14301,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:0.1.7":
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
@@ -13542,10 +14366,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: 10/ce617b8da36797d09c0baacb96ca8a44460452c89362d7cb8f70ca46b4158ba8bc3606912de7c818eb4a939f7f9015cef3c766ec8a0c6bfc725fdc078e39c717
   languageName: node
   linkType: hard
 
@@ -13633,6 +14471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pirates@npm:^4.0.1":
+  version: 4.0.6
+  resolution: "pirates@npm:4.0.6"
+  checksum: 10/d02dda76f4fec1cbdf395c36c11cf26f76a644f9f9a1bfa84d3167d0d3154d5289aacc72677aa20d599bb4a6937a471de1b65c995e2aea2d8687cbcd7e43ea5f
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^4.1.0, pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
@@ -13711,6 +14556,29 @@ __metadata:
   version: 1.16.1
   resolution: "popper.js@npm:1.16.1"
   checksum: 10/71338c86faf9b66ce60c3cdd7fb2ed742944e5d2765a188f269239fee2980aa6223b77b41302d1b6eb7d724e611092f9a2576d0048ac2071b605291abc72c0cf
+  languageName: node
+  linkType: hard
+
+"postcss-load-config@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "postcss-load-config@npm:6.0.1"
+  dependencies:
+    lilconfig: "npm:^3.1.1"
+  peerDependencies:
+    jiti: ">=1.21.0"
+    postcss: ">=8.0.9"
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+    postcss:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  checksum: 10/1691cfc94948a9373d4f7b3b7a8500cfaf8cb2dcc2107c14f90f2a711a9892a362b0866894ac5bb723455fa685a15116d9ed3252188689c4502b137c19d6bdc4
   languageName: node
   linkType: hard
 
@@ -14570,6 +15438,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:^4.0.1":
+  version: 4.1.1
+  resolution: "readdirp@npm:4.1.1"
+  checksum: 10/e9a4a07b108b148e3646518c9e6fe097895b910148223361e8fd3983bc52435924f9b549aaa9ce7a471768312892cdd1cefcf467ef0fa58c6618c17266914bf8
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -15062,6 +15937,78 @@ __metadata:
   dependencies:
     estree-walker: "npm:^0.6.1"
   checksum: 10/f3dc20a8731523aff43e07fa50ed84857e9dd3ab81e2cfb0351d517c46820e585bfbd1530a5dddec3ac14d61d41eb9bf50b38ded987e558292790331cc5b0628
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.24.0":
+  version: 4.32.1
+  resolution: "rollup@npm:4.32.1"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.32.1"
+    "@rollup/rollup-android-arm64": "npm:4.32.1"
+    "@rollup/rollup-darwin-arm64": "npm:4.32.1"
+    "@rollup/rollup-darwin-x64": "npm:4.32.1"
+    "@rollup/rollup-freebsd-arm64": "npm:4.32.1"
+    "@rollup/rollup-freebsd-x64": "npm:4.32.1"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.32.1"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.32.1"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.32.1"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.32.1"
+    "@rollup/rollup-linux-x64-musl": "npm:4.32.1"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.32.1"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.32.1"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.32.1"
+    "@types/estree": "npm:1.0.6"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loongarch64-gnu":
+      optional: true
+    "@rollup/rollup-linux-powerpc64le-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10/5a64860df9d0c1b88d142b8502cb2e858e8314025ed35c605c70dc5c7c099fcecc9340cac269412c9a8b53705b911f1454b01164d23400c7d84cafb241be255f
   languageName: node
   linkType: hard
 
@@ -15622,6 +16569,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
+  languageName: node
+  linkType: hard
+
 "simple-concat@npm:^1.0.0":
   version: 1.0.1
   resolution: "simple-concat@npm:1.0.1"
@@ -15773,6 +16727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.8.0-beta.0":
+  version: 0.8.0-beta.0
+  resolution: "source-map@npm:0.8.0-beta.0"
+  dependencies:
+    whatwg-url: "npm:^7.0.0"
+  checksum: 10/c02e22ab9f8b8e38655ba1e9abae9fe1f8ba216cbbea922718d5e2ea45821606a74f10edec1db9055e7f7cfd1e6a62e5eade67ec30c017a02f4c8e990accbc1c
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.4.2":
   version: 0.4.4
   resolution: "source-map@npm:0.4.4"
@@ -15782,7 +16745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.0, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
@@ -16096,6 +17059,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10/e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^1.0.1":
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
@@ -16107,17 +17081,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "string-width@npm:4.2.3"
-  dependencies:
-    emoji-regex: "npm:^8.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10/e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^3.0.0":
   version: 3.1.0
   resolution: "string-width@npm:3.1.0"
@@ -16126,6 +17089,17 @@ __metadata:
     is-fullwidth-code-point: "npm:^2.0.0"
     strip-ansi: "npm:^5.1.0"
   checksum: 10/57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
@@ -16217,6 +17191,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+  checksum: 10/ae3b5436d34fadeb6096367626ce987057713c566e1e7768818797e00ac5d62023d0f198c4e681eae9e20701721980b26a64a8f5b91238869592a9c6800719a2
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
   version: 3.0.1
   resolution: "strip-ansi@npm:3.0.1"
@@ -16235,12 +17218,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
   dependencies:
-    ansi-regex: "npm:^5.0.1"
-  checksum: 10/ae3b5436d34fadeb6096367626ce987057713c566e1e7768818797e00ac5d62023d0f198c4e681eae9e20701721980b26a64a8f5b91238869592a9c6800719a2
+    ansi-regex: "npm:^6.0.1"
+  checksum: 10/475f53e9c44375d6e72807284024ac5d668ee1d06010740dec0b9744f2ddf47de8d7151f80e5f6190fc8f384e802fdf9504b76a7e9020c9faee7103623338be2
   languageName: node
   linkType: hard
 
@@ -16349,6 +17332,24 @@ __metadata:
   bin:
     stylus-lookup: bin/cli.js
   checksum: 10/94da8b81ef16f73eae0dc734b18165e6f84d41960bc85fb39d9b028f4b6d8c4c2983ce52492751a3eb2e8e65e3e1507adc6739cc3c7893754672546c6af22f62
+  languageName: node
+  linkType: hard
+
+"sucrase@npm:^3.35.0":
+  version: 3.35.0
+  resolution: "sucrase@npm:3.35.0"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.2"
+    commander: "npm:^4.0.0"
+    glob: "npm:^10.3.10"
+    lines-and-columns: "npm:^1.1.6"
+    mz: "npm:^2.7.0"
+    pirates: "npm:^4.0.1"
+    ts-interface-checker: "npm:^0.1.9"
+  bin:
+    sucrase: bin/sucrase
+    sucrase-node: bin/sucrase-node
+  checksum: 10/bc601558a62826f1c32287d4fdfa4f2c09fe0fec4c4d39d0e257fd9116d7d6227a18309721d4185ec84c9dc1af0d5ec0e05a42a337fbb74fc293e068549aacbe
   languageName: node
   linkType: hard
 
@@ -16584,6 +17585,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thenify-all@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "thenify-all@npm:1.6.0"
+  dependencies:
+    thenify: "npm:>= 3.1.0 < 4"
+  checksum: 10/dba7cc8a23a154cdcb6acb7f51d61511c37a6b077ec5ab5da6e8b874272015937788402fd271fdfc5f187f8cb0948e38d0a42dcc89d554d731652ab458f5343e
+  languageName: node
+  linkType: hard
+
+"thenify@npm:>= 3.1.0 < 4":
+  version: 3.3.1
+  resolution: "thenify@npm:3.3.1"
+  dependencies:
+    any-promise: "npm:^1.0.0"
+  checksum: 10/486e1283a867440a904e36741ff1a177faa827cf94d69506f7e3ae4187b9afdf9ec368b3d8da225c192bfe2eb943f3f0080594156bf39f21b57cd1411e2e7f6d
+  languageName: node
+  linkType: hard
+
 "thread-stream@npm:^3.0.0":
   version: 3.1.0
   resolution: "thread-stream@npm:3.1.0"
@@ -16644,6 +17663,23 @@ __metadata:
   version: 2.1.0
   resolution: "tiny-typed-emitter@npm:2.1.0"
   checksum: 10/709bca410054e08df4dc29d5ea0916328bb2900d60245c6a743068ea223887d9fd2c945b6070eb20336275a557a36c2808e5c87d2ed4b60633458632be4a3e10
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10/b9d5fed3166fb1acd1e7f9a89afcd97ccbe18b9c1af0278e429455f6976d69271ba2d21797e7c36d57d6b05025e525d2882d88c2ab435b60d1ddf2fea361de57
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.9":
+  version: 0.2.10
+  resolution: "tinyglobby@npm:0.2.10"
+  dependencies:
+    fdir: "npm:^6.4.2"
+    picomatch: "npm:^4.0.2"
+  checksum: 10/10c976866d849702edc47fc3fef27d63f074c40f75ef17171ecc1452967900699fa1e62373681dd58e673ddff2e3f6094bcd0a2101e3e4b30f4c2b9da41397f2
   languageName: node
   linkType: hard
 
@@ -16742,6 +17778,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tr46@npm:1.0.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10/6e80d75480cb6658f7f283c15f5f41c2d4dfa243ca99a0e1baf3de6cc823fc4c829f89782a7a11e029905781fccfea42d08d8a6674ba7948c7dbc595b6f27dd3
+  languageName: node
+  linkType: hard
+
 "tr46@npm:^5.0.0":
   version: 5.0.0
   resolution: "tr46@npm:5.0.0"
@@ -16829,6 +17874,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-interface-checker@npm:^0.1.9":
+  version: 0.1.13
+  resolution: "ts-interface-checker@npm:0.1.13"
+  checksum: 10/9f7346b9e25bade7a1050c001ec5a4f7023909c0e1644c5a96ae20703a131627f081479e6622a4ecee2177283d0069e651e507bedadd3904fc4010ab28ffce00
+  languageName: node
+  linkType: hard
+
 "ts-loader@npm:^9.5.1":
   version: 9.5.1
   resolution: "ts-loader@npm:9.5.1"
@@ -16879,6 +17931,47 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
+  languageName: node
+  linkType: hard
+
+"tsup@npm:*":
+  version: 8.3.6
+  resolution: "tsup@npm:8.3.6"
+  dependencies:
+    bundle-require: "npm:^5.0.0"
+    cac: "npm:^6.7.14"
+    chokidar: "npm:^4.0.1"
+    consola: "npm:^3.2.3"
+    debug: "npm:^4.3.7"
+    esbuild: "npm:^0.24.0"
+    joycon: "npm:^3.1.1"
+    picocolors: "npm:^1.1.1"
+    postcss-load-config: "npm:^6.0.1"
+    resolve-from: "npm:^5.0.0"
+    rollup: "npm:^4.24.0"
+    source-map: "npm:0.8.0-beta.0"
+    sucrase: "npm:^3.35.0"
+    tinyexec: "npm:^0.3.1"
+    tinyglobby: "npm:^0.2.9"
+    tree-kill: "npm:^1.2.2"
+  peerDependencies:
+    "@microsoft/api-extractor": ^7.36.0
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ">=4.5.0"
+  peerDependenciesMeta:
+    "@microsoft/api-extractor":
+      optional: true
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: 10/ee70995a5d155ea7d9d1e0491f46520fe250393ed7935d8776956fc3380d3c992b06e6a01223187712eb32f52ff06dbc66c60cbe5dc91c4bd1415ad6d238b517
   languageName: node
   linkType: hard
 
@@ -17052,6 +18145,15 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/00504c01ee42d470c23495426af07512e25e6546bce7e24572e72a9ca2e6b2e9bea63de4286c3cfea644874da1467dcfca23f4f98f7caf20f8b03c0213bb6837
+  languageName: node
+  linkType: hard
+
+"uglify-js@npm:^3.1.4":
+  version: 3.19.3
+  resolution: "uglify-js@npm:3.19.3"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 10/6b9639c1985d24580b01bb0ab68e78de310d38eeba7db45bec7850ab4093d8ee464d80ccfaceda9c68d1c366efbee28573b52f95e69ac792354c145acd380b11
   languageName: node
   linkType: hard
 
@@ -17849,6 +18951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "webidl-conversions@npm:4.0.2"
+  checksum: 10/594187c36f2d7898f89c0ed3b9248a095fa549ecc1befb10a97bc884b5680dc96677f58df5579334d8e0d1018e5ef075689cfa2a6c459f45a61a9deb512cb59e
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^7.0.0":
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
@@ -18072,6 +19181,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-url@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "whatwg-url@npm:7.1.0"
+  dependencies:
+    lodash.sortby: "npm:^4.7.0"
+    tr46: "npm:^1.0.1"
+    webidl-conversions: "npm:^4.0.2"
+  checksum: 10/769fd35838b4e50536ae08d836472e86adbedda1d5493ea34353c55468147e7868b91d2535b59e01a9e7331ab7e4cdfdf5490c279c045da23c327cf33e32f755
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-boxed-primitive@npm:1.0.2"
@@ -18173,7 +19293,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 10/497d40beb2bdb08e6d38754faa17ce20b0bf1306327f80cb777927edb23f461ee1f6bc659b3c3c93f26b08e1cf4b46acc5bae8fda1f0be3b5ab9a1a0211034cd
+  languageName: node
+  linkType: hard
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -18181,6 +19308,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the Moonbeam chains to use the latest types-bundle for custom RPCs and types. 

This will users to access the ethapis: `debug` `trace` `txpool` (and fixed `moon`) via the PJS app without having to rely on a raw JSON RPC call.