### PR TITLE
fix: make use of `spendLocal` in treasury

### DIFF
--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -111,7 +111,7 @@ function Propose ({ className }: Props): React.ReactElement<Props> | null {
               label={t('Submit proposal')}
               onStart={toggleOpen}
               params={[value, beneficiary]}
-              tx={api.tx.treasury.spendLocal}
+              tx={api.tx.treasury.spendLocal ?? api.tx.treasury.proposeSpend}
             />
           </Modal.Actions>
         </Modal>

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -111,7 +111,7 @@ function Propose ({ className }: Props): React.ReactElement<Props> | null {
               label={t('Submit proposal')}
               onStart={toggleOpen}
               params={[value, beneficiary]}
-              tx={api.tx.treasury.proposeSpend}
+              tx={api.tx.treasury.spendLocal}
             />
           </Modal.Actions>
         </Modal>

--- a/packages/page-treasury/src/Overview/index.tsx
+++ b/packages/page-treasury/src/Overview/index.tsx
@@ -28,13 +28,9 @@ function Overview ({ className, isMember, members }: Props): React.ReactElement<
         approvalCount={info?.approvals.length}
         proposalCount={info?.proposals.length}
       />
-      {
-        api.tx.treasury.proposeSpend
-          ? <Button.Group>
-            <ProposalCreate />
-          </Button.Group>
-          : <></>
-      }
+      <Button.Group>
+        <ProposalCreate />
+      </Button.Group>
       <Proposals
         isMember={isMember}
         members={members}


### PR DESCRIPTION
## 📝 Description

This PR aims to make use of `spendLocal` instead of `proposeSpend` as this has been deprecated.