### PR TITLE
Remove Experimental from Coretime

### DIFF
--- a/packages/apps-routing/src/broker.ts
+++ b/packages/apps-routing/src/broker.ts
@@ -17,6 +17,6 @@ export default function create (t: TFunction): Route {
     group: 'network',
     icon: 'flask',
     name: 'broker',
-    text: t('nav.broker', 'Coretime Broker (Experimental)', { ns: 'app-broker' })
+    text: t('nav.broker', 'Coretime Broker', { ns: 'app-broker' })
   };
 }

--- a/packages/apps-routing/src/coretime.ts
+++ b/packages/apps-routing/src/coretime.ts
@@ -17,6 +17,6 @@ export default function create (t: TFunction): Route {
     group: 'network',
     icon: 'flask',
     name: 'coretime',
-    text: t('nav.coretime', 'Coretime (Experimental)', { ns: 'apps-routing' })
+    text: t('nav.coretime', 'Coretime', { ns: 'apps-routing' })
   };
 }

--- a/packages/apps/public/locales/en/app-broker.json
+++ b/packages/apps/public/locales/en/app-broker.json
@@ -19,7 +19,7 @@
   "cycle ts": "cycle ts",
   "estimated bulk price": "estimated bulk price",
   "mask": "mask",
-  "nav.broker": "Coretime Broker (Experimental)",
+  "nav.broker": "Coretime Broker",
   "next index": "next index",
   "parachain id": "parachain id",
   "pool size": "pool size",

--- a/packages/apps/public/locales/en/apps-routing.json
+++ b/packages/apps/public/locales/en/apps-routing.json
@@ -9,7 +9,7 @@
   "nav.claims": "Claim Tokens",
   "nav.collator": "Collators",
   "nav.contracts": "Contracts",
-  "nav.coretime": "Coretime (Experimental)",
+  "nav.coretime": "Coretime",
   "nav.council": "Council",
   "nav.democracy": "Democracy",
   "nav.explorer": "Explorer",


### PR DESCRIPTION
Removes the experimental tag from coretime.

closes: https://github.com/polkadot-js/apps/issues/11202