### PR TITLE
Ensure safeguard against treasury spendLocal functions

### DIFF
--- a/packages/page-treasury/src/Overview/index.tsx
+++ b/packages/page-treasury/src/Overview/index.tsx
@@ -28,9 +28,13 @@ function Overview ({ className, isMember, members }: Props): React.ReactElement<
         approvalCount={info?.approvals.length}
         proposalCount={info?.proposals.length}
       />
-      <Button.Group>
-        <ProposalCreate />
-      </Button.Group>
+      {
+        api.tx.treasury.proposeSpend || !!api.tx.treasury.spendLocal
+          ? <Button.Group>
+            <ProposalCreate />
+          </Button.Group>
+          : <></>
+      }
       <Proposals
         isMember={isMember}
         members={members}


### PR DESCRIPTION
This ensures that for certain chains that don't have `proposeSend` and or `spendLocal` we can safeguard from the active send button