### PR TITLE
Add IBP endpoint to Mythos

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -576,6 +576,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 3369,
     providers: {
       Helikon: 'wss://rpc.helikon.io/mythos',
+      IBP1: 'wss://mythos.ibp.network',
       parity: 'wss://polkadot-mythos-rpc.polkadot.io'
     },
     text: 'Mythos',


### PR DESCRIPTION
Dear team, hello, 

Please consider this endpoint to the Polkadot's Mythos parachain.

This endpoint is provided by the Infrastructure Builders' Programme.

Many thanks and best wishes!

**_Milos_**