### PR TITLE
Restore `wss://kreivo.io` provider to the list of providers

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -427,8 +427,8 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     isPeopleForIdentity: true,
     paraId: 2281,
     providers: {
-      Kippu: 'wss://kreivo.kippu.rocks/'
-      // Virto: 'wss://kreivo.io/' // https://github.com/polkadot-js/apps/issues/11232
+      Kippu: 'wss://kreivo.kippu.rocks/',
+      Virto: 'wss://kreivo.io/'
     },
     relayName: 'kusama',
     text: 'Kreivo - By Virto',


### PR DESCRIPTION
This provider was temporarily out of service due to a misconfiguration in the DNS service, bus has since then be active for the last month ininterruptedly.