### PR TITLE
Add Permanence DAO Europe public RPC endpoints for Polkadot and Westend Asset Hub

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -1006,6 +1006,7 @@ export const prodRelayPolkadot: EndpointOption = {
     IBP2: 'wss://polkadot.dotters.network',
     LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
+    'Permanence DAO EU': 'wss://polkadot.rpc.permanence.io',
     RadiumBlock: 'wss://polkadot.public.curie.radiumblock.co/ws',
     RockX: 'wss://rockx-dot.w3node.com/polka-public-dot/ws',
     Stakeworld: 'wss://dot-rpc.stakeworld.io',

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -134,7 +134,8 @@ export const testParasWestendCommon: EndpointOption[] = [
       IBP1: 'wss://sys.ibp.network/asset-hub-westend',
       IBP2: 'wss://asset-hub-westend.dotters.network',
       // OnFinality: 'wss://westmint.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9955
-      Parity: 'wss://westend-asset-hub-rpc.polkadot.io'
+      Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
+      'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io'
       // Stakeworld: 'wss://wnd-rpc.stakeworld.io/assethub'
     },
     relayName: 'westend',


### PR DESCRIPTION
This PR adds Permanence DAO ([X](https://x.com/PermanenceDAO), [web](https://permanence.io)) public RPC endpoints for Polkadot and Westend Asset Hub.

RPC endpoints are load balanced with two archive nodes, running on servers in Germany and Poland. Services are monitored 24/7 at software (node), hardware (disk, CPU, memory) and network level.

Polkadot nodes can be viewed [here](https://telemetry.polkadot.io/#/0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3), and Westend Asset Hub node [here](https://telemetry.polkadot.io/#list/0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9), on the Polkadot Telemetry instance. Please search by name `Permanence DAO`.

Best regards.