### PR TITLE
Fixed Table Spacing in FireFox

### DIFF
--- a/packages/react-components/src/Table/index.tsx
+++ b/packages/react-components/src/Table/index.tsx
@@ -122,7 +122,7 @@ const StyledDiv = styled.div`
   }
 
   table {
-    border-collapse: collapse;
+    *border-collapse: collapse;
     border-spacing: 0;
     max-width: 100%;
     overflow: hidden;


### PR DESCRIPTION
## 📝 Description

This table seems to be shown differently in Firefox and Chrome. The spacing lines between the rows are missing in Firefox.

Menu: `Network` -> `Coretime`

## 🤔 Previous Behavior

Not just in Coretime page, it seems it's the issue with Table itself. In most of the pages, the same issue is there (in FireFox only, Chrome renders it fine). 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/9053d469-0faa-42f2-aab8-603c655b9768" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0089d21b-ea9c-4fc6-a338-5bda6416476c" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0b533c5b-d58a-4e2e-bc43-0e87d276c2d9" />

<img width="863" alt="image" src="https://github.com/user-attachments/assets/57640565-fa1f-478d-b50f-5b791c7e9384" />


## ✅ Current Behavior

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/8f17e117-bec3-4bdb-b7bf-eb278d46130d" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/817d6a3f-9652-4f60-b611-e3e579e1d386" />

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/0b0acf14-a94a-4987-9e71-7458c28767ad" />

<img width="865" alt="image" src="https://github.com/user-attachments/assets/307d6fa4-4103-4962-b241-b8e6428f571e" />


### NOTE: 

All images attached here, are for FireFox.