### PR TITLE
enable Helixstreet Endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -1024,7 +1024,7 @@ export const prodRelayKusama: EndpointOption = {
     Allnodes: 'wss://kusama-rpc.publicnode.com',
     Dwellir: 'wss://kusama-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
-    // Helixstreet: 'wss://rpc-kusama.helixstreet.io', // https://github.com/polkadot-js/apps/issues/11280
+    Helixstreet: 'wss://rpc-kusama.helixstreet.io',
     IBP1: 'wss://rpc.ibp.network/kusama',
     IBP2: 'wss://kusama.dotters.network',
     LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -1003,7 +1003,7 @@ export const prodRelayPolkadot: EndpointOption = {
     Blockops: 'wss://polkadot-public-rpc.blockops.network/ws',
     Dwellir: 'wss://polkadot-rpc.dwellir.com',
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
-    // Helixstreet: 'wss://rpc-polkadot.helixstreet.io', // https://github.com/polkadot-js/apps/issues/11280
+    Helixstreet: 'wss://rpc-polkadot.helixstreet.io',
     IBP1: 'wss://rpc.ibp.network/polkadot',
     IBP2: 'wss://polkadot.dotters.network',
     LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',


### PR DESCRIPTION
I'd like to kindly request that the Helixstreet endpoints be re-enabled.

For your information, Helixstreet has a total of 3 DNS entries - 2 IPv4 and one IPv6. Currently, most access is via IPv6. The endpoints are accessible via 2 ISPs.

We experienced issues with one endpoint at a provider, which has been temporarily removed. The endpoints are currently reachable via IPv4 & IPv6.

I apologize for any inconvenience caused.