### PR TITLE
Update Xcavate para_id and rpc provider

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -343,7 +343,7 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
   {
     homepage: 'https://xcavate.io/',
     info: 'Xcavate',
-    paraId: 4605,
+    paraId: 4603,
     providers: {
       Xcavate: 'wss://rpc2-paseo.xcavate.io'
     },

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -343,9 +343,9 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
   {
     homepage: 'https://xcavate.io/',
     info: 'Xcavate',
-    paraId: 4603,
+    paraId: 4605,
     providers: {
-      // Xcavate: 'wss://rpc-paseo.xcavate.io:443' // https://github.com/polkadot-js/apps/issues/11299
+      Xcavate: 'wss://rpc2-paseo.xcavate.io'
     },
     text: 'Xcavate',
     ui: {


### PR DESCRIPTION
Hi, Xcavate chanin has been already listed in polkadot-js under paseo network. Our para_id `4603` isn't working atm because of that we are updaing our para_id as `4605` and rpc provider as `wss://rpc2-paseo.xcavate.io`

Thanks!