### PR TITLE
Fix TracksInfo values being undefined and causing a whitescreen

### DIFF
--- a/packages/page-referenda/src/useTracks.ts
+++ b/packages/page-referenda/src/useTracks.ts
@@ -7,13 +7,16 @@ import type { PalletReferenda, TrackDescription } from './types.js';
 
 import { useMemo } from 'react';
 
+import { BN_ZERO } from '@polkadot/util';
 import { createNamedHook, useApi } from '@polkadot/react-hooks';
 
 import { calcCurves } from './util.js';
 
+const zeroGraph = { approval: [BN_ZERO], support: [BN_ZERO], x: [BN_ZERO] }
+
 function expandTracks (tracks: [BN, PalletReferendaTrackInfo][]): TrackDescription[] {
   return tracks.map(([id, info]) => ({
-    graph: calcCurves(info),
+    graph: info.decisionDeposit && info.minApproval && info.minSupport ? calcCurves(info) : zeroGraph,
     id,
     info
   }));


### PR DESCRIPTION
Currently `PalletReferendaTracksInfo` is returning undefined values for `info.decisionPeriod`, `info.minApproval`, and `min.minSupport` which is causing `calcGraph` to fail. This PR just ensures the UI wont white screen. 

rel: https://github.com/paritytech/polkadot-sdk/pull/2072 