### PR TITLE
Maximum transfer value while teleport

### DIFF
--- a/packages/react-components/src/InputBalance.tsx
+++ b/packages/react-components/src/InputBalance.tsx
@@ -95,7 +95,7 @@ function InputBalance ({ autoFocus, children, className = '', defaultValue: inDe
       labelExtra={
         <LabelledExtra>
           {labelExtra}
-          {!!si && (siSymbol || TokenUnit.abbr) &&
+          {!!si && (siSymbol || TokenUnit.abbr) && !isDisabled &&
           <p>
             {t('(enter value in standard units)')}
           </p>


### PR DESCRIPTION
## 📝 Description

Currently, users can input any value when teleporting assets, which can lead to unexpected errors if the amount exceeds the allowable limit or if it doesn't leave existential deposit behind. This PR addresses the issue by fetching the maximum transferable value for Teleport and enforcing this limit to ensure users cannot exceed it.

This update improves reliability and provides a smoother user experience by preventing invalid transfers and unexpected errors.

<img width="1083" alt="Image" src="https://github.com/user-attachments/assets/42b9e4fb-fe32-42a1-97fb-5bde58f7e0a2" />

<img width="1081" alt="Image" src="https://github.com/user-attachments/assets/c419e9ef-b98e-4c35-b10c-edb8e6dffd64" />