### PR TITLE
Fix Asset Id Parsing

### DIFF
--- a/packages/page-assets/src/Balances/index.tsx
+++ b/packages/page-assets/src/Balances/index.tsx
@@ -35,7 +35,7 @@ function Balances ({ className, infos = [] }: Props): React.ReactElement<Props> 
   const completeAssets = useMemo(
     () => infos
       .filter((i): i is AssetInfoComplete => !!(i.details && i.metadata) && !i.details.supply.isZero())
-      .sort((a, b) => a.id.cmp(b.id)),
+    ,
     [infos]
   );
 

--- a/packages/page-assets/src/Overview/Asset.tsx
+++ b/packages/page-assets/src/Overview/Asset.tsx
@@ -5,7 +5,7 @@ import type { AssetInfo } from '@polkadot/react-hooks/types';
 
 import React, { useMemo } from 'react';
 
-import { AddressSmall, Table } from '@polkadot/react-components';
+import { AddressSmall } from '@polkadot/react-components';
 import { FormatBalance } from '@polkadot/react-query';
 
 import Mint from './Mint/index.js';
@@ -25,8 +25,12 @@ function Asset ({ className, value: { details, id, isIssuerMe, metadata } }: Pro
 
   return (
     <tr className={className}>
-      <Table.Column.Id value={id} />
-      <td className='together'>{metadata?.name.toUtf8()}</td>
+      <td></td>
+      <td className='together'>
+        <span style={{ fontSize: 18, marginRight: 10 }}>
+          {id.toString()}
+        </span>
+        {metadata?.name.toUtf8()}</td>
       <td className='address media--1000'>{details && <AddressSmall value={details.owner} />}</td>
       <td className='address media--1300'>{details && <AddressSmall value={details.admin} />}</td>
       <td className='address media--1600'>{details && <AddressSmall value={details.issuer} />}</td>

--- a/packages/page-assets/src/index.tsx
+++ b/packages/page-assets/src/index.tsx
@@ -86,7 +86,10 @@ function AssetApp ({ basePath, className }: Props): React.ReactElement<Props> {
   );
 
   const openId = useMemo(
-    () => findOpenId(api.genesisHash.toHex(), ids),
+    () => findOpenId(
+      api.genesisHash.toHex(),
+      // Check if id is valid digit
+      ids?.filter((id) => /^\d{1,3}(,\d{3})*$/.test(id.toString()))),
     [api.genesisHash, ids]
   );
 

--- a/packages/react-hooks/src/ctx/PayWithAsset.tsx
+++ b/packages/react-hooks/src/ctx/PayWithAsset.tsx
@@ -44,8 +44,8 @@ function PayWithAssetProvider ({ children }: Props): React.ReactElement<Props> {
   const completeAssetInfos = useMemo(
     () => (assetInfos
       ?.filter((i): i is AssetInfoComplete =>
-        !!(i.details && i.metadata) && !i.details.supply.isZero() && !!i.details?.toJSON().isSufficient)
-      .sort((a, b) => a.id.cmp(b.id))) || [],
+        !!(i.details && i.metadata) && !i.details.supply.toHuman() && !!i.details?.toJSON().isSufficient)
+    ) || [],
     [assetInfos]
   );
 


### PR DESCRIPTION
## 📝 Description

This PR aims to fix the issue with parsing asset IDs. Asset IDs can be non-digits, such as objects like multilocations. For chains with these types of asset IDs, the UI explorer is breaking and displaying a white blank page. This issue will be addressed in this PR.

Additionally, the Assets page is also being fixed as this was also breaking.

There will be no effect for other chains. 

<img width="1920" alt="Screenshot 2025-02-25 at 23 16 19" src="https://github.com/user-attachments/assets/a21e5e3c-b1b1-487c-b98e-637cda2d9f29" />

#### Now there is no error in console 🚀.