### PR TITLE
Enhance Preimages Page with Improved Usability

### DIFF
--- a/packages/page-preimages/src/Preimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/Preimage.tsx
@@ -1,9 +1,10 @@
 // Copyright 2017-2025 @polkadot/app-preimages authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
 import type { HexString } from '@polkadot/util/types';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { usePreimage } from '@polkadot/react-hooks';
 import { formatNumber } from '@polkadot/util';
@@ -15,10 +16,15 @@ import Hash from './Hash.js';
 interface Props {
   className?: string;
   value: HexString;
+  cb?: (info: TPreimage) => void;
 }
 
-function Preimage ({ className, value }: Props): React.ReactElement<Props> {
+function Preimage ({ cb, className, value }: Props): React.ReactElement<Props> {
   const info = usePreimage(value);
+
+  useEffect(() => {
+    info && cb?.(info);
+  }, [cb, info]);
 
   return (
     <tr className={className}>

--- a/packages/page-preimages/src/Preimages/index.tsx
+++ b/packages/page-preimages/src/Preimages/index.tsx
@@ -7,11 +7,12 @@ import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Button, styled, Table } from '@polkadot/react-components';
+import { useAccounts } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
 import usePreimages from '../usePreimages.js';
 import Add from './Add/index.js';
-import { UserPreimages } from './userPreimages/index.js';
+import UserPreimages from './userPreimages/index.js';
 import Preimage from './Preimage.js';
 import Summary from './Summary.js';
 
@@ -23,6 +24,7 @@ interface Props {
 
 function Hashes ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const { allAccounts } = useAccounts();
   const [allPreImagesInfo, setAllPreImagesInfo] = useState<TPreimage[]>([]);
   const hashes = usePreimages();
 
@@ -34,9 +36,9 @@ function Hashes ({ className }: Props): React.ReactElement<Props> {
     ]));
   }, []);
 
-  const groupedByDepositor = useMemo(() => {
+  const groupedUserPreimages = useMemo(() => {
     return allPreImagesInfo.reduce((result: Record<string, TPreimage[]>, current) => {
-      if (current.deposit?.who) {
+      if (current.deposit?.who && allAccounts.includes(current.deposit?.who)) {
         const newItems = [...(result[current.deposit?.who] || []), current];
 
         result[current.deposit?.who] = newItems;
@@ -44,7 +46,7 @@ function Hashes ({ className }: Props): React.ReactElement<Props> {
 
       return result;
     }, {} as Record<string, TPreimage[]>);
-  }, [allPreImagesInfo]);
+  }, [allAccounts, allPreImagesInfo]);
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t('preimages'), 'start', 2],
@@ -59,7 +61,7 @@ function Hashes ({ className }: Props): React.ReactElement<Props> {
       <Button.Group>
         <Add />
       </Button.Group>
-      <UserPreimages userPreimages={groupedByDepositor} />
+      <UserPreimages userPreimages={groupedUserPreimages} />
       <Table
         className={className}
         empty={hashes && t('No hashes found')}

--- a/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
@@ -3,11 +3,13 @@
 
 import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
 
-import React from 'react';
+import React, { useState } from 'react';
 
-import { AddressMini, styled } from '@polkadot/react-components';
+import { AddressMini, Checkbox, styled, TxButton } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
 import { formatNumber } from '@polkadot/util';
 
+import { useTranslation } from '../../translate.js';
 import Call from '../Call.js';
 import Hash from '../Hash.js';
 
@@ -17,7 +19,36 @@ interface Props {
   preimageInfos: TPreimage[];
 }
 
+interface SelectPreimageProps {
+  proposalHash: TPreimage['proposalHash'],
+  onSelectPreimage: React.Dispatch<React.SetStateAction<TPreimage['proposalHash'][]>>
+}
+
+const SelectPreimage = ({ onSelectPreimage, proposalHash }: SelectPreimageProps) => {
+  const [checked, setChecked] = useState(false);
+
+  const onChange = React.useCallback((value: boolean) => {
+    setChecked(value);
+    onSelectPreimage((prevHashes) =>
+      // Add preimage hash if checked else filter it out
+      value ? [...prevHashes, proposalHash] : prevHashes.filter((i) => i !== proposalHash)
+    );
+  }, [onSelectPreimage, proposalHash]);
+
+  return (
+    <Checkbox
+      onChange={onChange}
+      value={checked}
+    />
+  );
+};
+
 const Preimage = ({ className, depositor, preimageInfos }: Props) => {
+  const { t } = useTranslation();
+  const { api } = useApi();
+
+  const [selectedPreimages, onSelectPreimage] = useState<TPreimage['proposalHash'][]>([]);
+
   return (
     <>
       {preimageInfos.map((info, index) => {
@@ -25,7 +56,7 @@ const Preimage = ({ className, depositor, preimageInfos }: Props) => {
           <StyledTr
             className={`isExpanded ${className}`}
             isFirstItem={index === 0}
-            isLastItem={index === preimageInfos.length - 1}
+            isLastItem={false}
             key={info.proposalHash}
           >
             <td
@@ -35,7 +66,13 @@ const Preimage = ({ className, depositor, preimageInfos }: Props) => {
               {index === 0 && <AddressMini value={depositor} />}
             </td>
             <Call value={info} />
-            <Hash value={info.proposalHash} />
+            <td style={{ alignItems: 'center', display: 'flex' }}>
+              <SelectPreimage
+                onSelectPreimage={onSelectPreimage}
+                proposalHash={info.proposalHash}
+              />
+              <Hash value={info.proposalHash} />
+            </td>
             <td className='number media--1000'>
               {info?.proposalLength
                 ? formatNumber(info.proposalLength)
@@ -53,6 +90,28 @@ const Preimage = ({ className, depositor, preimageInfos }: Props) => {
           </StyledTr>
         );
       })}
+      <StyledTr
+        className={`isExpanded ${className}`}
+        isFirstItem={false}
+        isLastItem
+      >
+        <td className='all' />
+        <td className='all' />
+        <td className='media--1300' />
+        <td>
+          <TxButton
+            accountId={depositor}
+            className={className}
+            icon='minus'
+            isToplevel
+            label={t('Unnote')}
+            params={[selectedPreimages.map((i) => api.tx.preimage.unnotePreimage(i))]}
+            tx={api.tx.utility.batchAll}
+          />
+        </td>
+        <td className='media--1000' />
+        <td className='media--1100' />
+      </StyledTr>
     </>
   );
 };
@@ -62,20 +121,28 @@ const BORDER_TOP = `${BASE_BORDER * 3}rem solid var(--bg-page)`;
 const BORDER_RADIUS = `${BASE_BORDER * 4}rem`;
 
 const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
+  .ui--Icon {
+    border-width: 2px;
+  }
+  
   td {
     border-top: ${(props) => props.isFirstItem && BORDER_TOP};
     border-radius: 0rem !important;
     
-      &:first-child {
-        padding-block: 1rem !important;
-        border-top-left-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
-        border-bottom-left-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
-      }
+    &:first-child {
+      padding-block: 1rem !important;
+      border-top-left-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+      border-bottom-left-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+    }
 
-      &:last-child {
-        border-top-right-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
-        border-bottom-right-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
-      }
+    &:last-child {
+      border-top-right-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+      border-bottom-right-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+    }
+
+    td {
+      border: none !important;
+    }
   }
 `;
 

--- a/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
@@ -5,7 +5,7 @@ import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
 
 import React from 'react';
 
-import { AddressMini } from '@polkadot/react-components';
+import { AddressMini, styled } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 import Call from '../Call.js';
@@ -22,8 +22,10 @@ const Preimage = ({ className, depositor, preimageInfos }: Props) => {
     <>
       {preimageInfos.map((info, index) => {
         return (
-          <tr
-            className={className}
+          <StyledTr
+            className={`isExpanded ${className}`}
+            isFirstItem={index === 0}
+            isLastItem={index === preimageInfos.length - 1}
             key={info.proposalHash}
           >
             <td
@@ -48,11 +50,33 @@ const Preimage = ({ className, depositor, preimageInfos }: Props) => {
                 )
                 : <span className='--tmp'>Unrequested</span>}
             </td>
-          </tr>
+          </StyledTr>
         );
       })}
     </>
   );
 };
+
+const BASE_BORDER = 0.125;
+const BORDER_TOP = `${BASE_BORDER * 3}rem solid var(--bg-page)`;
+const BORDER_RADIUS = `${BASE_BORDER * 4}rem`;
+
+const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
+  td {
+    border-top: ${(props) => props.isFirstItem && BORDER_TOP};
+    border-radius: 0rem !important;
+    
+      &:first-child {
+        padding-block: 1rem !important;
+        border-top-left-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+        border-bottom-left-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+      }
+
+      &:last-child {
+        border-top-right-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+        border-bottom-right-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+      }
+  }
+`;
 
 export default React.memo(Preimage);

--- a/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
@@ -1,0 +1,58 @@
+// Copyright 2017-2025 @polkadot/app-preimages authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
+
+import React from 'react';
+
+import { AddressMini } from '@polkadot/react-components';
+import { formatNumber } from '@polkadot/util';
+
+import Call from '../Call.js';
+import Hash from '../Hash.js';
+
+interface Props {
+  className?: string;
+  depositor: string,
+  preimageInfos: TPreimage[];
+}
+
+const Preimage = ({ className, depositor, preimageInfos }: Props) => {
+  return (
+    <>
+      {preimageInfos.map((info, index) => {
+        return (
+          <tr
+            className={className}
+            key={info.proposalHash}
+          >
+            <td
+              className='address all'
+              style={{ paddingTop: 15, verticalAlign: 'top' }}
+            >
+              {index === 0 && <AddressMini value={depositor} />}
+            </td>
+            <Call value={info} />
+            <Hash value={info.proposalHash} />
+            <td className='number media--1000'>
+              {info?.proposalLength
+                ? formatNumber(info.proposalLength)
+                : <span className='--tmp'>999,999</span>}
+            </td>
+            <td className='preimageStatus start media--1100 together'>
+              {info
+                ? (
+                  <>
+                    {info.status && (<div>{info.status?.type}{info.count !== 0 && <>&nbsp;/&nbsp;{formatNumber(info.count)}</>}</div>)}
+                  </>
+                )
+                : <span className='--tmp'>Unrequested</span>}
+            </td>
+          </tr>
+        );
+      })}
+    </>
+  );
+};
+
+export default React.memo(Preimage);

--- a/packages/page-preimages/src/Preimages/userPreimages/index.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/index.tsx
@@ -8,21 +8,22 @@ import React, { useRef } from 'react';
 import { Table } from '@polkadot/react-components';
 
 import { useTranslation } from '../../translate.js';
+import Preimage from './Preimage.js';
 
 interface Props {
   className?: string;
   userPreimages: Record<string, TPreimage[]>
 }
 
-export const UserPreimages = ({ className, userPreimages }: Props) => {
+const UserPreimages = ({ className, userPreimages }: Props) => {
   const { t } = useTranslation();
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
     [t('my preimages'), 'start', 2],
-    [t('hash'), 'media--1000'],
-    [undefined, 'media--1000'],
+    [undefined, 'media--1300'],
+    [t('hash'), 'start'],
     [t('length'), 'media--1000'],
-    [t('status'), 'start media--1200']
+    [t('status'), 'start media--1100']
   ]);
 
   return (
@@ -31,13 +32,15 @@ export const UserPreimages = ({ className, userPreimages }: Props) => {
       empty={Object.values(userPreimages) && t('No hashes found')}
       header={headerRef.current}
     >
-      {/* {hashes?.map((h) => (
+      {Object.keys(userPreimages)?.map((depositor) => (
         <Preimage
-          cb={onSetAllPreImagesInfo}
-          key={h}
-          value={h}
+          depositor={depositor}
+          key={depositor}
+          preimageInfos={userPreimages[depositor]}
         />
-      ))} */}
+      ))}
     </Table>
   );
 };
+
+export default React.memo(UserPreimages);

--- a/packages/page-preimages/src/Preimages/userPreimages/index.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/index.tsx
@@ -1,0 +1,43 @@
+// Copyright 2017-2025 @polkadot/app-preimages authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Preimage as TPreimage } from '@polkadot/react-hooks/types';
+
+import React, { useRef } from 'react';
+
+import { Table } from '@polkadot/react-components';
+
+import { useTranslation } from '../../translate.js';
+
+interface Props {
+  className?: string;
+  userPreimages: Record<string, TPreimage[]>
+}
+
+export const UserPreimages = ({ className, userPreimages }: Props) => {
+  const { t } = useTranslation();
+
+  const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
+    [t('my preimages'), 'start', 2],
+    [t('hash'), 'media--1000'],
+    [undefined, 'media--1000'],
+    [t('length'), 'media--1000'],
+    [t('status'), 'start media--1200']
+  ]);
+
+  return (
+    <Table
+      className={className}
+      empty={Object.values(userPreimages) && t('No hashes found')}
+      header={headerRef.current}
+    >
+      {/* {hashes?.map((h) => (
+        <Preimage
+          cb={onSetAllPreImagesInfo}
+          key={h}
+          value={h}
+        />
+      ))} */}
+    </Table>
+  );
+};

--- a/packages/react-hooks/src/useAssetIds.ts
+++ b/packages/react-hooks/src/useAssetIds.ts
@@ -11,7 +11,7 @@ const EMPTY_PARAMS: unknown[] = [];
 
 const OPT_KEY = {
   transform: (keys: StorageKey<[u32]>[]): u32[] =>
-    keys.map(({ args: [id] }) => id)
+    keys.map(({ args: [id] }) => id).filter((id) => id !== undefined)
 };
 
 function filter (records: EventRecord[]): Changes<u32> {


### PR DESCRIPTION
## 📝 Description

This PR enhances the **Preimages** page by improving its user-experience and adding new features to streamline interactions.  

## 🚀 Features Added  
- **Batch Unnote**:  
  - Users can now **select multiple preimages** and unnote them in a single action.  
- **Account-Based Filtering**:  
  - Display preimages associated only with the user’s accounts.  

## 🔥 Impact  

These improvements will significantly enhance the user experience by:  

✅ Making it easier to manage multiple preimages at once.  
✅ Providing better visibility of preimages relevant to the user.  

https://github.com/user-attachments/assets/85637ee2-7ac4-4690-9860-cfd93c7f3af8

