### PR TITLE
Replace `isEmpty` checks with utility function

### DIFF
--- a/packages/react-hooks/src/useAccountInfo.ts
+++ b/packages/react-hooks/src/useAccountInfo.ts
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { keyring } from '@polkadot/ui-keyring';
 import { isFunction, isHex } from '@polkadot/util';
 
+import { isEmpty } from './utils/isEmpty.js';
 import { createNamedHook } from './createNamedHook.js';
 import { useApi } from './useApi.js';
 import { useCall } from './useCall.js';
@@ -59,14 +60,14 @@ function useAccountInfoImpl (value: string | null, isContract = false): UseAccou
   useEffect((): void => {
     validator && setFlags((flags) => ({
       ...flags,
-      isValidator: !validator.isEmpty
+      isValidator: !isEmpty(validator)
     }));
   }, [validator]);
 
   useEffect((): void => {
     nominator && setFlags((flags) => ({
       ...flags,
-      isNominator: !nominator.isEmpty
+      isNominator: !isEmpty(nominator)
     }));
   }, [nominator]);
 

--- a/packages/react-hooks/src/useOwnStashInfos.ts
+++ b/packages/react-hooks/src/useOwnStashInfos.ts
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { u8aConcat, u8aToHex } from '@polkadot/util';
 
+import { isEmpty } from './utils/isEmpty.js';
 import { createNamedHook } from './createNamedHook.js';
 import { useAccounts } from './useAccounts.js';
 import { useApi } from './useApi.js';
@@ -36,7 +37,7 @@ const QUERY_OPTS = {
 
 function getStakerState (stashId: string, allAccounts: string[], [isOwnStash, { claimedRewardsEras, controllerId: _controllerId, exposureMeta, exposurePaged, nextSessionIds: _nextSessionIds, nominators, rewardDestination, sessionIds: _sessionIds, stakingLedger, validatorPrefs }, validateInfo]: [boolean, DeriveStakingAccount, ValidatorInfo]): StakerState {
   const isStashNominating = !!(nominators?.length);
-  const isStashValidating = !(Array.isArray(validateInfo) ? validateInfo[1].isEmpty : validateInfo.isEmpty);
+  const isStashValidating = !(Array.isArray(validateInfo) ? isEmpty(validateInfo[1] as ValidatorPrefs) : isEmpty(validateInfo));
   const nextSessionIds = _nextSessionIds instanceof Map
     ? [..._nextSessionIds.values()]
     : _nextSessionIds;

--- a/packages/react-hooks/src/utils/isEmpty.ts
+++ b/packages/react-hooks/src/utils/isEmpty.ts
@@ -1,0 +1,14 @@
+// Copyright 2017-2025 @polkadot/react-hooks authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Struct } from '@polkadot/types-codec';
+
+export const isEmpty = (struct: Struct) => {
+  for (const v of struct.values()) {
+    if (!v.isEmpty) {
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
## 📝 Description

This PR aims to create a custom utility function for checking `isEmpty` state.  The reason is, For any address that is not a validator, the `staking.validators` method returns - 

```ts
{
    "commission": 0,
    "blocked": false
}
```

We have to check absolute emptyness for this Struct.

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/714594db-d35f-4f65-87e6-76c2a843bb74" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/58a99384-c6e0-4468-bc5c-6849f6ba4f73" />
