### PR TITLE
Enhance Staking Rewards Payout

### DIFF
--- a/packages/react-hooks/src/useOwnEraRewards.ts
+++ b/packages/react-hooks/src/useOwnEraRewards.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2025 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Dispatch, SetStateAction } from 'react';
 import type { ApiPromise } from '@polkadot/api';
 import type { DeriveEraPoints, DeriveEraRewards, DeriveStakerReward } from '@polkadot/api-derive/types';
 import type { u32, Vec } from '@polkadot/types';
@@ -8,13 +9,14 @@ import type { EraIndex } from '@polkadot/types/interfaces';
 import type { PalletStakingStakingLedger } from '@polkadot/types/lookup';
 import type { StakerState } from './types.js';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { BN_ZERO } from '@polkadot/util';
 
 import { createNamedHook } from './createNamedHook.js';
 import { useApi } from './useApi.js';
 import { useCall } from './useCall.js';
+import { useEventTrigger } from './useEventTrigger.js';
 import { useIsMountedRef } from './useIsMountedRef.js';
 import { useOwnStashIds } from './useOwnStashes.js';
 
@@ -44,15 +46,13 @@ const EMPTY_STATE: State = {
   rewardCount: 0
 };
 
-const OPT_REWARDS = { withParams: true };
-
 function getLegacyRewards (ledger: PalletStakingStakingLedger, claimedRewardsEras?: Vec<u32>): u32[] {
   const legacyRewards = ledger.legacyClaimedRewards || (ledger as unknown as { claimedRewards: u32[] }).claimedRewards || [];
 
   return legacyRewards.concat(claimedRewardsEras?.toArray() || []);
 }
 
-function getRewards ([[stashIds], available]: [[string[]], DeriveStakerReward[][]]): State {
+function getRewards ([[stashIds], available]: [[string[], EraIndex[]], DeriveStakerReward[][]]): State {
   const allRewards: Record<string, DeriveStakerReward[]> = {};
 
   stashIds.forEach((stashId, index): void => {
@@ -110,14 +110,45 @@ function getValRewards (api: ApiPromise, validatorEras: ValidatorWithEras[], era
   };
 }
 
+function useStakerRewards (filteredEras: EraIndex[], setState: Dispatch<SetStateAction<State>>, ownValidators?: StakerState[], additional?: string[]) {
+  const { api } = useApi();
+
+  const stashIds = useOwnStashIds(additional);
+  const trigger = useEventTrigger([api.events.staking?.PayoutStarted, api.events.staking?.Rewarded]);
+  const [stakerRewards, setStakerRewards] = useState<[[string[], EraIndex[]], DeriveStakerReward[][]]>();
+
+  const onFetchStakeRewards = useCallback(async () => {
+    if (!ownValidators?.length && !!filteredEras.length && stashIds) {
+      setState((e) => ({ ...e, isLoadingRewards: true }));
+
+      const stakerRewards = await api.derive.staking?.stakerRewardsMultiEras(stashIds, filteredEras);
+
+      setStakerRewards([[stashIds, filteredEras], stakerRewards]);
+    }
+  }, [api.derive.staking, filteredEras, ownValidators?.length, setState, stashIds]);
+
+  useEffect(() => {
+    onFetchStakeRewards().catch(console.error);
+  }, [onFetchStakeRewards]);
+
+  useEffect(() => {
+    if (trigger.blockHash) {
+      onFetchStakeRewards().catch(console.error);
+    }
+  }, [onFetchStakeRewards, trigger.blockHash]);
+
+  return stakerRewards;
+}
+
 function useOwnEraRewardsImpl (maxEras?: number, ownValidators?: StakerState[], additional?: string[]): State {
   const { api } = useApi();
   const mountedRef = useIsMountedRef();
-  const stashIds = useOwnStashIds(additional);
+
   const allEras = useCall<EraIndex[]>(api.derive.staking?.erasHistoric);
   const [{ filteredEras, validatorEras }, setFiltered] = useState<Filtered>(EMPTY_FILTERED);
   const [state, setState] = useState<State>(EMPTY_STATE);
-  const stakerRewards = useCall<[[string[]], DeriveStakerReward[][]]>(!ownValidators?.length && !!filteredEras.length && stashIds && api.derive.staking?.stakerRewardsMultiEras, [stashIds, filteredEras], OPT_REWARDS);
+
+  const stakerRewards = useStakerRewards(filteredEras, setState, ownValidators, additional);
   const erasPoints = useCall<DeriveEraPoints[]>(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasPoints, [filteredEras, false]);
   const erasRewards = useCall<DeriveEraRewards[]>(!!validatorEras.length && !!filteredEras.length && api.derive.staking._erasRewards, [filteredEras, false]);
 


### PR DESCRIPTION
## 📝 Description

Previously, When a user claimed their staking rewards, the payout items remained visible in the UI, causing confusion. While the payouts were successfully processed on-chain, the UI did not reflect the updated state.

This PR ensures that claimed payout items are properly removed or updated in the UI, keeping it in sync with the on-chain state.

## 🚀 Impact
- Prevents stale payout items from being displayed.
- Improves user experience by providing accurate payout status.
