### PR TITLE
Fix dark mode display hash display result in Fork 

### DIFF
--- a/packages/page-explorer/src/Forks.tsx
+++ b/packages/page-explorer/src/Forks.tsx
@@ -5,6 +5,7 @@ import type { Header } from '@polkadot/types/interfaces';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+
 import { CardSummary, IdentityIcon, styled, SummaryBox } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { formatNumber } from '@polkadot/util';
@@ -134,9 +135,11 @@ function isSingleRow (cols: Col[]): boolean {
 }
 
 function renderCol ({ author, hash, isEmpty, isFinalized, parent, width }: Col, index: number): React.ReactNode {
+ 
+  
   return (
     <td
-      className={`header ${isEmpty ? 'isEmpty' : ''} ${isFinalized ? 'isFinalized' : ''}`}
+      className={`header ${isEmpty ? 'isEmpty' : ''} ${isFinalized ? 'isFinalized' : 'isNotFinal'}`}
       colSpan={width}
       key={`${hash}:${index}:${width}`}
     >
@@ -442,6 +445,11 @@ const StyledDiv = styled.div`
         &.isFinalized {
           background: rgba(0, 255, 0, 0.1);
         }
+        
+        &.isNotFinal {
+        color: rgba(0,0,0);
+        }
+        
 
         &.isLink {
           background: transparent;

--- a/packages/page-explorer/src/Forks.tsx
+++ b/packages/page-explorer/src/Forks.tsx
@@ -5,7 +5,6 @@ import type { Header } from '@polkadot/types/interfaces';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-
 import { CardSummary, IdentityIcon, styled, SummaryBox } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { formatNumber } from '@polkadot/util';
@@ -135,8 +134,6 @@ function isSingleRow (cols: Col[]): boolean {
 }
 
 function renderCol ({ author, hash, isEmpty, isFinalized, parent, width }: Col, index: number): React.ReactNode {
- 
-  
   return (
     <td
       className={`header ${isEmpty ? 'isEmpty' : ''} ${isFinalized ? 'isFinalized' : 'isNotFinal'}`}
@@ -447,9 +444,8 @@ const StyledDiv = styled.div`
         }
         
         &.isNotFinal {
-        color: rgba(0,0,0);
+          color: rgba(0,0,0);
         }
-        
 
         &.isLink {
           background: transparent;


### PR DESCRIPTION
Users can read the fork hash display in Explorer/fork when the result is not finalized in darkmode. Fix from this 
This was the original dark mode followed by light mode 
<img width="1498" alt="Screenshot 2025-03-11 at 03 42 28" src="https://github.com/user-attachments/assets/a7693467-e554-48a0-a6b4-3a2f6af93bc2" />

<img width="824" alt="Screenshot 2025-03-11 at 03 42 57" src="https://github.com/user-attachments/assets/92b758a9-01cc-49eb-b7e1-262b98af6376" />

The images below are taken after I fixed the dark mode, which is also compatible with the light mode.
<img width="1457" alt="Screenshot 2025-03-11 at 03 47 31" src="https://github.com/user-attachments/assets/27dc9d03-0acd-4607-8190-826a03d9476f" />
<img width="1504" alt="Screenshot 2025-03-11 at 03 52 26" src="https://github.com/user-attachments/assets/c3f2faec-a817-46b8-8eb5-c6140dd4ac85" />


