### PR TITLE
Handle the case when pallet slots is not being used

### DIFF
--- a/packages/page-parachains/src/Overview/useParaInfo.ts
+++ b/packages/page-parachains/src/Overview/useParaInfo.ts
@@ -71,7 +71,7 @@ function useParaInfoImpl (id: ParaId): Result {
     [(api.query.parasHrmp || api.query.paraHrmp || api.query.hrmp)?.hrmpWatermarks, id],
     [(api.query.parasInclusion || api.query.paraInclusion || api.query.inclusion)?.pendingAvailability, id],
     [api.query.registrar.paras, id],
-    [api.query.slots.leases, id]
+    [api.query.slots?.leases, id]
   ], MULTI_OPTS);
 }
 

--- a/packages/page-parachains/src/Parathreads/useParaMap.ts
+++ b/packages/page-parachains/src/Parathreads/useParaMap.ts
@@ -63,7 +63,7 @@ function useParaMapImpl (ids?: ParaId[]): Result | undefined {
     [hasLinksMap]
   );
 
-  return useCall<Result>(ids && api.query.slots.leases.multi, [ids], {
+  return useCall<Result>(ids && api.query.slots?.leases.multi, [ids], {
     transform,
     withParamsTransform: true
   });

--- a/packages/page-parachains/src/useFunds.ts
+++ b/packages/page-parachains/src/useFunds.ts
@@ -160,7 +160,7 @@ function useFundsImpl (): Campaigns {
   const trigger = useEventTrigger([api.events.crowdloan?.Created]);
   const paraIds = useMapKeys(api.query.crowdloan?.funds, [], OPT_FUNDS, trigger.blockHash);
   const campaigns = useCall<Campaign[]>(api.query.crowdloan?.funds.multi, [paraIds], OPT_FUNDS_MULTI);
-  const leases = useCall<ParaId[]>(api.query.slots.leases.multi, [paraIds], OPT_LEASE);
+  const leases = useCall<ParaId[]>(api.query.slots?.leases.multi, [paraIds], OPT_LEASE);
   const [result, setResult] = useState<Campaigns>(EMPTY);
 
   // here we manually add the actual ending status and calculate the totals

--- a/packages/page-parachains/src/useLeasePeriod.ts
+++ b/packages/page-parachains/src/useLeasePeriod.ts
@@ -14,12 +14,12 @@ function useLeasePeriodImpl (): LeasePeriod | undefined {
   const bestNumber = useBestNumber();
 
   return useMemo((): LeasePeriod | undefined => {
-    if (!api.consts.slots.leasePeriod || !bestNumber) {
+    if (!api.consts.slots?.leasePeriod || !bestNumber) {
       return;
     }
 
-    const length = api.consts.slots.leasePeriod as BlockNumber;
-    const startNumber = bestNumber.sub((api.consts.slots.leaseOffset as BlockNumber) || BN_ZERO);
+    const length = api.consts.slots?.leasePeriod as BlockNumber;
+    const startNumber = bestNumber.sub((api.consts.slots?.leaseOffset as BlockNumber) || BN_ZERO);
     const progress = startNumber.mod(length);
 
     return {


### PR DESCRIPTION
The `slots` module does not have to be implemented by all relay chains. Currently, the frontend will crash if the implementation is not available, so making `slots` optional was required.