### PR TITLE
FIX: Fee Asset Selection

### DIFF
--- a/packages/react-hooks/src/ctx/PayWithAsset.tsx
+++ b/packages/react-hooks/src/ctx/PayWithAsset.tsx
@@ -5,7 +5,7 @@ import type { BN } from '@polkadot/util';
 import type { AssetInfoComplete } from '../types.js';
 import type { PayWithAsset } from './types.js';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { useApi, useAssetIds, useAssetInfos } from '@polkadot/react-hooks';
 
@@ -74,10 +74,6 @@ function PayWithAssetProvider ({ children }: Props): React.ReactElement<Props> {
     completeAssetInfos.length > 0,
   [api.call.assetConversionApi, api.registry.metadata.extrinsic.signedExtensions, api.tx.assetConversion, completeAssetInfos.length]
   );
-
-  useEffect(() => {
-    return () => setSelectedFeeAsset(null);
-  });
 
   const values: PayWithAsset = useMemo(() => {
     return {

--- a/packages/react-signer/src/PayWithAsset.tsx
+++ b/packages/react-signer/src/PayWithAsset.tsx
@@ -53,16 +53,19 @@ const PayWithAsset = ({ onChangeFeeAsset }: Props) => {
   }, [assetOptions, selectedAssetValue, nativeAsset]);
 
   useEffect(() => {
-    if (selectedFeeAsset) {
-      onChangeFeeAsset((e) =>
-        ({
-          ...e,
-          assetId: getFeeAssetLocation(api, selectedFeeAsset),
-          feeAsset: selectedFeeAsset
-        })
-      );
-    }
+    onChangeFeeAsset((e) =>
+      ({
+        ...e,
+        assetId: getFeeAssetLocation(api, selectedFeeAsset),
+        feeAsset: selectedFeeAsset
+      })
+    );
   }, [api, onChangeFeeAsset, selectedFeeAsset]);
+
+  useEffect(() => {
+    // Reselect native asset on component unmount
+    return () => onSelect(nativeAsset);
+  }, [nativeAsset, onSelect]);
 
   return (
     <Modal.Columns hint={t('By selecting this option, the transaction fee will be automatically deducted from the specified asset, ensuring a seamless and efficient payment process.')}>


### PR DESCRIPTION
## 📝 Description

Sometimes, a discrepancy occurs when selecting fee assets. Specifically, switching between native and non-native assets for fee payment can display an incorrect fee and prevent paying the fee in native tokens until the page is reloaded.
This PR resolves the issue by ensuring seamless switching between fee assets without requiring a page reload.

## 🤔 Current behaviour

https://github.com/user-attachments/assets/05dc2d05-a85a-4f83-9c93-370d0eaa7b67

## ✅ Expected behaviour

https://github.com/user-attachments/assets/fcd7183a-83ad-4a5b-abc4-2d98e27dc8d3