### PR TITLE
Improvement: Multisig Call Data Field

### DIFF
--- a/packages/page-accounts/src/modals/MultisigApprove.tsx
+++ b/packages/page-accounts/src/modals/MultisigApprove.tsx
@@ -79,6 +79,7 @@ function MultisigApprove ({ className = '', onClose, ongoing, threshold = 0, who
       isMultiCall: !!multisig && (multisig.approvals.length + 1) >= threshold,
       multisig
     });
+    setCallHex('');
     setCallData(EMPTY_CALL);
   }, [hash, ongoing, threshold]);
 
@@ -173,7 +174,7 @@ function MultisigApprove ({ className = '', onClose, ongoing, threshold = 0, who
         <Modal.Columns hint={t('The call hash from the list of available and unapproved calls.')}>
           <Dropdown
             label={t('pending hashes {{count}}', {
-              replace: { count: hashes.length }
+              replace: { count: `(${hashes.length})` }
             })}
             onChange={setHash}
             options={hashes}
@@ -231,27 +232,29 @@ function MultisigApprove ({ className = '', onClose, ongoing, threshold = 0, who
               <>
                 {isCallOverride && (
                   <Modal.Columns hint={t('The call data for this transaction matching the hash. Once sent, the multisig will be executed against this.')}>
-                    {callData && callInfo
-                      ? (
-                        <Expander
-                          isPadded
-                          summary={`${callInfo.section}.${callInfo.method}`}
-                          summaryMeta={callInfo.meta}
-                        >
-                          <CallDisplay
-                            className='details'
-                            value={callData}
-                          />
-                        </Expander>
-                      )
-                      : (
-                        <Input
-                          autoFocus
-                          isError={!callHex || !!callError}
-                          label={t('call data for final approval')}
-                          onChange={setCallHex}
-                        />
-                      )}
+                    <Input
+                      autoFocus
+                      isError={!callHex || !!callError}
+                      label={t('call data for final approval')}
+                      onChange={setCallHex}
+                      value={callHex}
+                    />
+                    {callData && callInfo &&
+                       (
+                         <div style={{ marginTop: 8 }}>
+                           <Expander
+                             isPadded
+                             summary={`${callInfo.section}.${callInfo.method}`}
+                             summaryMeta={callInfo.meta}
+                           >
+                             <CallDisplay
+                               className='details'
+                               value={callData}
+                             />
+                           </Expander>
+                         </div>
+                       )
+                    }
                     {callError && (
                       <MarkError content={callError} />
                     )}
@@ -290,7 +293,8 @@ function MultisigApprove ({ className = '', onClose, ongoing, threshold = 0, who
 
 const StyledModal = styled(Modal)`
   .tipToggle {
-    width: 100%;
+    width: fit-content;
+    float: right;
     text-align: right;
   }
 `;


### PR DESCRIPTION
## 📝 Description

This PR addresses layout inconsistencies in the **Multisig Pending Approvals Modal**, specifically when switching between multiple pending transaction hashes in the dropdown.  

## 🤔 Issue Details  

- When toggling between multiple pending hashes, the **call data input field** occasionally disappears.  
- If a user enters call data and then switches to another transaction, the previously entered call data becomes invisible.  
- Although this issue is **not consistently reproducible**, performing these actions **three to four times** typically triggers the bug.  

## 🚀 Fix & Improvements  

- Ensures that the call data input field remains visible when switching between transactions.
- Adjust the width of the **"Multisig message with call (for final approval)"** toggle to match its content. Currently, clicking on the empty space to the left also triggers the toggle action.
- Improves the layout to prevent unintended UI glitches.
