### PR TITLE
Export Multisig as JSON

### DIFF
--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -235,6 +235,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
           filter={filterOn}
           isFavorite={isFavorite}
           key={address}
+          onStatusChange={onStatusChange}
           proxy={proxies?.[index]}
           setBalance={setBalance}
           toggleFavorite={toggleFavorite}
@@ -243,7 +244,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
 
       return all;
     }, {}),
-    [accountsMap, filterOn, proxies, setBalance, toggleFavorite]
+    [accountsMap, filterOn, proxies, setBalance, toggleFavorite, onStatusChange]
   );
 
   const groups = useMemo(


### PR DESCRIPTION
## 📝 Description

Currently, the UI lacks the ability to export Multisig accounts, making it challenging for users to transfer them when switching devices or browsers.  

This update introduces a feature that allows users to export all signatories as a JSON file, ensuring seamless portability. The exported JSON can be easily imported via the UI, enhancing user convenience and accessibility.  

## 🔥 Impact

This feature simplifies account management for users, allowing them to easily carry their Multisig accounts between different environments without manual reconfiguration.  

https://github.com/user-attachments/assets/b2855d6e-4f4e-4cfa-a385-610964383bca