### PR TITLE
Require slots pallet for parachain page

### DIFF
--- a/packages/apps-routing/src/parachains.ts
+++ b/packages/apps-routing/src/parachains.ts
@@ -11,7 +11,8 @@ export default function create (t: TFunction): Route {
     display: {
       needsApi: [
         // children - parachainInfo.arachainId / parachainUpgrade.didSetValidationCode
-        ['query.paras.parachains']
+        ['query.paras.parachains'],
+        'query.slots'
       ]
     },
     group: 'network',


### PR DESCRIPTION
closes: https://github.com/polkadot-js/apps/pull/11381

Ensures slots pallet is also required for the parachain page.