### PR TITLE
Enable Extrinsic Page Access Without Accounts

### DIFF
--- a/packages/apps-routing/src/extrinsics.ts
+++ b/packages/apps-routing/src/extrinsics.ts
@@ -9,7 +9,6 @@ export default function create (t: TFunction): Route {
   return {
     Component,
     display: {
-      needsAccounts: true,
       needsApi: []
     },
     group: 'developer',


### PR DESCRIPTION
## 📝 Description

This PR ensures that the extrinsic page is always accessible, even when no accounts are connected. This allows developers to explore deployed pallets, construct encoded calls, and interact with the UI for testing purposes without requiring an active account. While transaction submission remains restricted in this scenario, this enhancement provides valuable visibility into the available extrinsics and facilitates development workflows.

If the user/developer has an account, they will always be able to submit transactions, maintaining the existing flow. 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/1908b952-cc39-49cf-b2c8-4878616a22da" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/3b36b071-3d2c-4b3d-bbcd-d7f6abc3846e" />
