### PR TITLE
Allow anonymous proxy

### DIFF
--- a/packages/page-accounts/src/modals/ProxyOverview.tsx
+++ b/packages/page-accounts/src/modals/ProxyOverview.tsx
@@ -124,7 +124,7 @@ function NewProxy ({ index, onChangeAccount, onChangeType, onRemove, proxiedAcco
           isError={!accountId}
           label={t('proxy account')}
           onChange={_onChangeAccount}
-          type='account'
+          type='allPlus'
           value={accountId}
         />
         {accountId && accountId.eq(proxiedAccount) && (

--- a/packages/react-components/src/InputAddress/index.tsx
+++ b/packages/react-components/src/InputAddress/index.tsx
@@ -314,15 +314,25 @@ class InputAddress extends React.PureComponent<Props, State> {
       const accountId = transformToAccountId(query);
 
       if (accountId) {
-        const item = keyring.saveRecent(
-          accountId.toString()
-        ).option;
+        const account = keyring.getAccount(accountId);
 
-        matches.push({
-          key: item.key,
-          name: item.name,
-          value: item.value || undefined
-        });
+        if (account) {
+          matches.push({
+            key: account.address,
+            name: account.meta.name,
+            value: account.address
+          });
+        } else {
+          const item = keyring.saveRecent(
+            accountId.toString()
+          ).option;
+
+          matches.push({
+            key: item.key,
+            name: item.name,
+            value: item.value || undefined
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## 📝 Description

This PR aims to improve the behaviour for adding proxy for an account. Currently, an anonymous proxy is not allowed to be added for an account, however it should be possible technically. Additionally, It fixes account dropdown behaviour.

https://github.com/user-attachments/assets/51bb0f97-0d9a-485e-b2f5-f4982cd2d0a7