### PR TITLE
Suspended candidates query

### DIFF
--- a/packages/page-society/src/Suspended/index.tsx
+++ b/packages/page-society/src/Suspended/index.tsx
@@ -46,7 +46,7 @@ const OPT_ACC = {
 function Suspended ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const candidates = useCall<CandidateSuspend[]>(api.query.society.suspendedCandidates.entries, undefined, OPT_CAN);
+  const candidates = useCall<CandidateSuspend[]>(api.query.society.suspendedCandidates?.entries, undefined, OPT_CAN) ?? [];
   const members = useCall<AccountId[]>(api.query.society.suspendedMembers.keys, undefined, OPT_ACC);
 
   const headerRef = useRef({


### PR DESCRIPTION
## 📝 Description

This PR aims to prevent breaking `Suspended` Tab in Society Page for Kusama. 

## 🤔 Previous Behaviour

<img width="1920" alt="Screenshot 2025-04-09 at 11 13 44" src="https://github.com/user-attachments/assets/e4938210-fda3-4a82-9d5e-39336ebc85b9" />

## 🚀 Current Behaviour

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/9d998a22-fe08-4f98-80b2-8d9899b1e9f6" />

