### PR TITLE
Update zkVerify testnet endpoint and name

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -1123,9 +1123,9 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'zkVerify-testnet',
     providers: {
-      zkVerify: 'wss://testnet-rpc.zkverify.io'
+      zkVerify: 'wss://volta-rpc.zkverify.io'
     },
-    text: 'zkVerify Testnet',
+    text: 'zkVerify Volta Testnet',
     ui: {
       color: '#15AA6A',
       logo: nodesZkVerifyPNG


### PR DESCRIPTION
This PR modifies the endpoint and the display name for the zkVerify testnet, which have been updated recently.