### PR TITLE
Import and export of addresses to the My Accounts Tab

### DIFF
--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -17,6 +17,7 @@ import { settings } from '@polkadot/ui-settings';
 import { BN_ZERO, isFunction } from '@polkadot/util';
 
 import CreateModal from '../modals/Create.js';
+import ExportAll from '../modals/ExportAll.js';
 import ImportModal from '../modals/Import.js';
 import Ledger from '../modals/Ledger.js';
 import Local from '../modals/LocalAdd.js';
@@ -104,6 +105,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
   const [isProxyOpen, toggleProxy] = useToggle();
   const [isLocalOpen, toggleLocal] = useToggle();
   const [isQrOpen, toggleQr] = useToggle();
+  const [isExportAll, toggleExportAll] = useToggle();
   const [favorites, toggleFavorite] = useFavorites(STORE_FAVS);
   const [balances, setBalances] = useState<Balances>({ accounts: {} });
   const [filterOn, setFilter] = useState<string>('');
@@ -318,6 +320,13 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
           onStatusChange={onStatusChange}
         />
       )}
+      {isExportAll && (
+        <ExportAll
+          accountsByGroup={groups}
+          onClose={toggleExportAll}
+          onStatusChange={onStatusChange}
+        />
+      )}
       <BannerExtension />
       <BannerClaims />
       <Summary balance={balances.summary} />
@@ -360,6 +369,11 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
               />
             </>
           )}
+          <Button
+            icon='file-export'
+            label={t('Export')}
+            onClick={toggleExportAll}
+          />
           <Button
             icon='qrcode'
             label={t('From Qr')}

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -324,7 +324,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
       )}
       {isExportAll && (
         <ExportAll
-          accountsByGroup={groups}
+          accountsByGroup={grouped}
           onClose={toggleExportAll}
           onStatusChange={onStatusChange}
         />

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -19,6 +19,7 @@ import { BN_ZERO, isFunction } from '@polkadot/util';
 import CreateModal from '../modals/Create.js';
 import ExportAll from '../modals/ExportAll.js';
 import ImportModal from '../modals/Import.js';
+import ImportAll from '../modals/ImportAll.js';
 import Ledger from '../modals/Ledger.js';
 import Local from '../modals/LocalAdd.js';
 import Multisig from '../modals/MultisigCreate.js';
@@ -106,6 +107,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
   const [isLocalOpen, toggleLocal] = useToggle();
   const [isQrOpen, toggleQr] = useToggle();
   const [isExportAll, toggleExportAll] = useToggle();
+  const [isImportAll, toggleImportAll] = useToggle();
   const [favorites, toggleFavorite] = useFavorites(STORE_FAVS);
   const [balances, setBalances] = useState<Balances>({ accounts: {} });
   const [filterOn, setFilter] = useState<string>('');
@@ -327,6 +329,12 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
           onStatusChange={onStatusChange}
         />
       )}
+      {isImportAll && (
+        <ImportAll
+          onClose={toggleImportAll}
+          onStatusChange={onStatusChange}
+        />
+      )}
       <BannerExtension />
       <BannerClaims />
       <Summary balance={balances.summary} />
@@ -369,6 +377,11 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
               />
             </>
           )}
+          <Button
+            icon='file-import'
+            label={t('Import')}
+            onClick={toggleImportAll}
+          />
           <Button
             icon='file-export'
             label={t('Export')}

--- a/packages/page-accounts/src/modals/ExportAll.tsx
+++ b/packages/page-accounts/src/modals/ExportAll.tsx
@@ -1,0 +1,95 @@
+// Copyright 2017-2025 @polkadot/app-accounts authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ActionStatus } from '@polkadot/react-components/Status/types';
+import type { ModalProps } from '../types.js';
+
+import FileSaver from 'file-saver';
+import React, { useCallback, useState } from 'react';
+
+import { Button, MarkWarning, Modal } from '@polkadot/react-components';
+import { useAccounts } from '@polkadot/react-hooks';
+import { keyring } from '@polkadot/ui-keyring';
+import { nextTick } from '@polkadot/util';
+
+import { useTranslation } from '../translate.js';
+
+interface Props extends ModalProps {
+  className?: string;
+  onClose: () => void;
+  accountsByGroup: Record<string, React.ReactNode[]>;
+  onStatusChange: (status: ActionStatus) => void;
+}
+
+function ExportAll ({ accountsByGroup, className, onClose, onStatusChange }: Props): React.ReactElement | null {
+  const { t } = useTranslation();
+  const { allAccounts } = useAccounts();
+  const [isBusy, setIsBusy] = useState(false);
+
+  const _onExportButtonClick = useCallback(() => {
+    setIsBusy(true);
+
+    nextTick((): void => {
+      const status: Partial<ActionStatus> = { action: 'export' };
+
+      try {
+        const accounts = allAccounts.map((account) => {
+          const keyringAccount = keyring.getPair(account);
+
+          return {
+            address: account,
+            meta: keyringAccount.meta
+          };
+        });
+
+        const blob = new Blob([JSON.stringify(accounts, null, 2)], { type: 'application/json; charset=utf-8' });
+
+        // eslint-disable-next-line deprecation/deprecation
+        FileSaver.saveAs(blob, `batch_exported_accounts_${new Date().getTime()}.json`);
+
+        status.status = 'success';
+        status.message = t('accounts exported');
+      } catch (error) {
+        status.status = 'error';
+        status.message = (error as Error).message;
+        console.error(error);
+      }
+
+      setIsBusy(false);
+      onStatusChange(status as ActionStatus);
+
+      if (status.status !== 'error') {
+        onClose();
+      }
+    });
+  }, [allAccounts, onClose, onStatusChange, t]);
+
+  return (
+    <Modal
+      className={className}
+      header={t('export all accounts')}
+      onClose={onClose}
+      size='large'
+    >
+      <Modal.Content>
+        <MarkWarning content={<>{t('Consider storing your account in a signer such as a browser extension, hardware device, QR-capable phone wallet (non-connected) or desktop application for optimal account security.')}&nbsp;{t('Future versions of the web-only interface will drop support for non-external accounts, much like the IPFS version.')}</>} />
+        <Modal.Columns hint={t('Choose type of accounts you want to export')}>
+          <div>
+            {Object.keys(accountsByGroup).map((group) => <p key={group}>{group}</p>)}
+          </div>
+        </Modal.Columns>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          icon='sync'
+          isBusy={isBusy}
+          label={t('Export')}
+          onClick={_onExportButtonClick}
+        />
+      </Modal.Actions>
+    </Modal>
+
+  );
+}
+
+export default React.memo(ExportAll);

--- a/packages/page-accounts/src/modals/ImportAll.tsx
+++ b/packages/page-accounts/src/modals/ImportAll.tsx
@@ -29,6 +29,7 @@ type File = FileAccount[]
 
 const acceptedFormats = ['application/json'];
 
+// Check if file is valid
 function isValidFile (fileContent: string, setError: Dispatch<SetStateAction<string | null>>): boolean {
   setError(null);
 

--- a/packages/page-accounts/src/modals/ImportAll.tsx
+++ b/packages/page-accounts/src/modals/ImportAll.tsx
@@ -1,0 +1,141 @@
+// Copyright 2017-2025 @polkadot/app-accounts authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Dispatch, SetStateAction } from 'react';
+import type { KeyringPair$Meta } from '@polkadot/keyring/types';
+import type { ActionStatus } from '@polkadot/react-components/Status/types';
+import type { ModalProps } from '../types.js';
+
+import React, { useCallback, useState } from 'react';
+
+import { Button, InputFile, MarkError, Modal } from '@polkadot/react-components';
+import keyring from '@polkadot/ui-keyring';
+import { nextTick, u8aToString } from '@polkadot/util';
+
+import { useTranslation } from '../translate.js';
+
+interface Props extends ModalProps {
+  className?: string;
+  onClose: () => void;
+  onStatusChange: (status: ActionStatus) => void;
+}
+
+interface FileAccount {
+  address: string;
+  meta: KeyringPair$Meta;
+}
+
+type File = FileAccount[]
+
+const acceptedFormats = ['application/json'];
+
+function isValidFile (fileContent: string, setError: Dispatch<SetStateAction<string | null>>): boolean {
+  setError(null);
+
+  try {
+    const content = JSON.parse(fileContent) as File;
+
+    if (!Array.isArray(content)) {
+      throw new Error('Invalid format: File content should be an array');
+    }
+
+    for (const item of content) {
+      if (
+        typeof item.address !== 'string' ||
+        typeof item.meta !== 'object' ||
+        item.meta === null
+      ) {
+        throw new Error('Invalid format: Each item must have a string "address" and an object "meta"');
+      }
+    }
+
+    return true;
+  } catch (error) {
+    console.error(error);
+    setError((error as Error).message ? (error as Error).message : (error as Error).toString());
+
+    return false;
+  }
+}
+
+function ImportAll ({ className, onClose, onStatusChange }: Props): React.ReactElement | null {
+  const { t } = useTranslation();
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const _onChangeFile = useCallback(
+    (file: Uint8Array) => {
+      const fileContent = u8aToString(file);
+
+      setFile(isValidFile(fileContent, setError) ? JSON.parse(fileContent) as File : null);
+    },
+    []
+  );
+
+  const _onImportButtonClick = useCallback(() => {
+    setIsBusy(true);
+    nextTick((): void => {
+      const status: Partial<ActionStatus> = { action: 'import' };
+
+      try {
+        file?.map((pair) =>
+          keyring.addExternal(pair.address, pair.meta)
+        );
+
+        status.status = 'success';
+        status.message = t('all accounts imported');
+      } catch (error) {
+        status.status = 'error';
+        status.message = (error as Error).message;
+        console.error(error);
+      }
+
+      setIsBusy(false);
+      onStatusChange(status as ActionStatus);
+
+      if (status.status !== 'error') {
+        onClose();
+      }
+    });
+  }, [file, onClose, onStatusChange, t]);
+
+  return (
+    <Modal
+      className={className}
+      header={t('import all accounts')}
+      onClose={onClose}
+      size='large'
+    >
+      <Modal.Content>
+        <Modal.Columns hint={t('Supply a backed-up JSON file')}>
+          <InputFile
+            accept={acceptedFormats}
+            className='full'
+            isError={!file}
+            label={t('backup file')}
+            onChange={_onChangeFile}
+            withLabel
+          />
+        </Modal.Columns>
+        <Modal.Columns>
+          {error && (
+            <MarkError content={error} />
+          )}
+        </Modal.Columns>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          icon='sync'
+          isBusy={isBusy}
+          isDisabled={!file || !!error}
+          label={t('Import')}
+          onClick={_onImportButtonClick}
+        />
+      </Modal.Actions>
+
+    </Modal>
+  );
+}
+
+export default React.memo(ImportAll);


### PR DESCRIPTION
## 📝 Description

This PR introduces import and export functionality to the **My Accounts** page, mirroring the existing features found on the Address Book page. This enhancement promotes consistency across the app and empowers users to manage their account data more efficiently.

## ✅ What's Included
- Added **Import** and **Export** buttons to the My Accounts page.
- Enabled support for uploading and downloading account data
- Implemented error handling and success notifications.

## 🤔 Why
Extending the import/export capabilities to the My Accounts page ensures a consistent user experience and provides valuable data portability for users who manage multiple accounts.

https://github.com/user-attachments/assets/44fbbb19-3053-41c0-8507-1e4afc2e2a39