### PR TITLE
Displaying the commission set by a nomination pool on the staking pools page  

### DIFF
--- a/packages/page-staking2/src/Pools/Pool.tsx
+++ b/packages/page-staking2/src/Pools/Pool.tsx
@@ -72,6 +72,7 @@ function Pool ({ className = '', members, ownAccounts, params, poolId }: Props):
           withLoading
         />
         <td className='number media--1400'>{info && !info.rewardClaimable.isZero() && <FormatBalance value={info.rewardClaimable} />}</td>
+        <td className='number'>{info && info.bonded.commission.current.value && <div>{info.bonded.commission.current.value[0]?.toHuman()}</div>}</td>
         <td className='number'>
           {info && info.nominating.length !== 0 && (
             <ExpanderScroll

--- a/packages/page-staking2/src/Pools/Pools.tsx
+++ b/packages/page-staking2/src/Pools/Pools.tsx
@@ -51,6 +51,7 @@ function Pools ({ className, ids, ownPools, params }: Props): React.ReactElement
       [t('state'), 'media--1100'],
       [t('points')],
       [t('claimable'), 'media--1400'],
+      [t('commission')],
       [undefined, undefined, 3]
     ],
     [t]


### PR DESCRIPTION
## 📝 Description

This PR displays the **commission rate** for each **nomination pool** directly on the staking pools UI. Previously, users had no visibility into the commission values, which are crucial for making informed staking decisions.

<img width="1920" alt="Screenshot 2025-04-28 at 13 44 38" src="https://github.com/user-attachments/assets/4c4f7fda-e401-488f-a71f-7e48cbd1c8be" />
<img width="1920" alt="Screenshot 2025-04-28 at 13 46 35" src="https://github.com/user-attachments/assets/a70ac414-e974-4ad9-ab59-56f40343bf3e" />
