### PR TITLE
Refactor: Vote component

### DIFF
--- a/packages/react-params/src/Param/Vote.tsx
+++ b/packages/react-params/src/Param/Vote.tsx
@@ -20,6 +20,7 @@ function Vote ({ className = '', defaultValue: { value }, isDisabled, isError, o
 
   // Derive aye and conviction from the value prop
   const { aye, conviction } = useMemo(() => {
+    // Logic sucks here, but to be honest, can not find other way to do it
     const resolvedAye = value instanceof GenericVote
       ? value.isAye
       : isBn(value)

--- a/packages/react-params/src/Param/Vote.tsx
+++ b/packages/react-params/src/Param/Vote.tsx
@@ -3,7 +3,7 @@
 
 import type { Props } from '../types.js';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 
 import { Dropdown } from '@polkadot/react-components';
 import { GenericVote } from '@polkadot/types';
@@ -12,30 +12,48 @@ import { isBn, isNumber } from '@polkadot/util';
 import { useTranslation } from '../translate.js';
 import Bare from './Bare.js';
 
-interface VoteParts {
-  aye: boolean;
-  conviction: number;
-}
-
 const AYE_MASK = 0b10000000;
-const EMPTY_VOTE: VoteParts = { aye: true, conviction: 0 };
 
+// In this approach, it will avoid using additional local states and instead rely directly on the parent-provided values and methods.
 function Vote ({ className = '', defaultValue: { value }, isDisabled, isError, onChange, withLabel }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [vote, setVote] = useState(EMPTY_VOTE);
 
-  useEffect((): void => {
-    onChange && onChange({ isValid: true, value: vote });
-  }, [onChange, vote]);
+  // Derive aye and conviction from the value prop
+  const { aye, conviction } = useMemo(() => {
+    const resolvedAye = value instanceof GenericVote
+      ? value.isAye
+      : isBn(value)
+        ? !!(value.toNumber() & AYE_MASK)
+        : isNumber(value)
+          ? !!(value & AYE_MASK)
+          : typeof value === 'object' && value !== null && 'aye' in value
+            ? !!value.aye
+            : true;
+
+    const resolvedConviction = value instanceof GenericVote
+      ? value.conviction.index
+      : typeof value === 'object' && value !== null && 'conviction' in value
+        ? Number(value.conviction)
+        : 0;
+
+    return {
+      aye: resolvedAye,
+      conviction: resolvedConviction
+    };
+  }, [value]);
 
   const onChangeVote = useCallback(
-    (aye: boolean) => setVote(({ conviction }) => ({ aye, conviction })),
-    []
+    (newAye: boolean) => {
+      onChange?.({ isValid: true, value: { aye: newAye, conviction } });
+    },
+    [conviction, onChange]
   );
 
   const onChangeConviction = useCallback(
-    (conviction: number) => setVote(({ aye }) => ({ aye, conviction })),
-    []
+    (newConviction: number) => {
+      onChange?.({ isValid: true, value: { aye, conviction: newConviction } });
+    },
+    [aye, onChange]
   );
 
   const optAyeRef = useRef([
@@ -53,22 +71,11 @@ function Vote ({ className = '', defaultValue: { value }, isDisabled, isError, o
     { text: t('Locked6x'), value: 6 }
   ]);
 
-  const defaultVote = isBn(value)
-    ? !!(value.toNumber() & AYE_MASK)
-    : isNumber(value)
-      ? !!(value & AYE_MASK)
-      : value instanceof GenericVote
-        ? value.isAye
-        : !!value;
-  const defaultConv = value instanceof GenericVote
-    ? value.conviction.index
-    : 0;
-
   return (
     <Bare className={className}>
       <Dropdown
         className='full'
-        defaultValue={defaultVote}
+        defaultValue={aye}
         isDisabled={isDisabled}
         isError={isError}
         label={t('aye: bool')}
@@ -78,7 +85,7 @@ function Vote ({ className = '', defaultValue: { value }, isDisabled, isError, o
       />
       <Dropdown
         className='full'
-        defaultValue={defaultConv}
+        defaultValue={conviction}
         isDisabled={isDisabled}
         isError={isError}
         label={t('conviction: Conviction')}


### PR DESCRIPTION
## 📝 Description

This PR addresses a bug where transactions with a `Nay` vote are incorrectly displayed as `Aye` in the **Submission** tab of the UI. The bug occurs during the decoding process after switching tabs, even though the underlying transaction data remains correct. 
The issue is with the `Vote` type itself, not just the `aye`. Even if we change `Conviction` value and switch back to submission tab, it resets to `None`.

Encoded call - 0x1400c8000400e87648170000000000000000000000

## 🤔 Previous Behavior

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/019d0cd0-d3b4-4238-b30e-3a709f96b0b0" />

<img width="1728" alt="Screenshot 2025-05-09 at 12 40 17" src="https://github.com/user-attachments/assets/483bcff8-43f2-4601-a36d-0f5226daafdd" />

## ✅ Current Behaviour

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/019d0cd0-d3b4-4238-b30e-3a709f96b0b0" />

<img width="1728" alt="Screenshot 2025-05-09 at 12 42 55" src="https://github.com/user-attachments/assets/c188dcbb-f4ed-4711-bf47-a68c50492e9d" />

## 🖋️ Note

Here is one successful transaction with current flow (on Paseo) - https://paseo.subscan.io/extrinsic/0x543a94bbf3d5d9637b1baa7adfa6909df65466709ca2a6aee80347536ab55530