### PR TITLE
fix: update upload menu background color to use theme variable

### DIFF
--- a/packages/page-files/src/CrustFiles.tsx
+++ b/packages/page-files/src/CrustFiles.tsx
@@ -377,7 +377,7 @@ const StyledMain = styled.main`
   .uploadMenu {
     z-index: 200;
     display: none;
-    background-color: white;
+    background-color: var(--bg-table);
     position: absolute;
     top: 43px;
     left: 0;


### PR DESCRIPTION
fixes #9985 

## Previous behavior (Dark mode)
<img width="476" alt="Screenshot 2025-05-13 at 12 57 29 PM" src="https://github.com/user-attachments/assets/b37fb4a0-ded9-4a37-b062-20634fc40293" />

## Current behavior (After fix)
<img width="460" alt="Screenshot 2025-05-13 at 12 58 31 PM" src="https://github.com/user-attachments/assets/026067af-ed87-4171-855c-d9959d30ee26" />
