### PR TITLE
fix: multisig data disappears while signing multiple multisig tx's from same account

### DIFF
--- a/packages/page-accounts/src/Accounts/useMultisigApprovals.ts
+++ b/packages/page-accounts/src/Accounts/useMultisigApprovals.ts
@@ -31,6 +31,7 @@ function useMultisigApprovalsImpl (address: string): [H256, Multisig][] | undefi
 
     if (multisigEvents.length) {
       const eventsHash = JSON.stringify(multisigEvents.map((e) => e.key));
+
       if (eventsHash !== prevEventsRef.current) {
         prevEventsRef.current = eventsHash;
         incTrigger();

--- a/packages/page-accounts/src/Accounts/useMultisigApprovals.ts
+++ b/packages/page-accounts/src/Accounts/useMultisigApprovals.ts
@@ -4,7 +4,7 @@
 import type { Option, StorageKey } from '@polkadot/types';
 import type { H256, Multisig } from '@polkadot/types/interfaces';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { createNamedHook, useApi, useBlockEvents, useIncrement, useIsMountedRef } from '@polkadot/react-hooks';
 
@@ -14,20 +14,28 @@ function useMultisigApprovalsImpl (address: string): [H256, Multisig][] | undefi
   const [multiInfos, setMultiInfos] = useState<[H256, Multisig][] | undefined>();
   const [trigger, incTrigger] = useIncrement(1);
   const mountedRef = useIsMountedRef();
+  const prevEventsRef = useRef<string>('');
 
   // increment the trigger by looking at all events
   //   - filter the by multisig module (old utility is not supported)
   //   - find anything data item where the type is AccountId
-  //   - increment the trigger when at least one matches our address
+  //   - increment the trigger when at least one matches our address and is different from previous multisig events
   useEffect((): void => {
-    events
-      .some(({ record: { event: { data, section } } }) =>
-        section === 'multisig' &&
-        data.some((item) =>
-          item.toRawType() === 'AccountId' &&
-          item.eq(address)
-        )
-      ) && incTrigger();
+    const multisigEvents = events.filter(({ record: { event: { data, section } } }) =>
+      section === 'multisig' &&
+      data.some((item) =>
+        item.toRawType() === 'AccountId' &&
+        item.eq(address)
+      )
+    );
+
+    if (multisigEvents.length) {
+      const eventsHash = JSON.stringify(multisigEvents.map((e) => e.key));
+      if (eventsHash !== prevEventsRef.current) {
+        prevEventsRef.current = eventsHash;
+        incTrigger();
+      }
+    }
   }, [address, events, incTrigger]);
 
   // query all the entries for the multisig, extracting approvals with their hash


### PR DESCRIPTION
fixes #11546

## Problem

The MultisigApprove modal was experiencing a UI glitch where the "call data for final approval" input field was constantly being reset during user interaction. This occurred because:

1. Any blockchain event (even those unrelated to multisig) would trigger the useMultisigApprovals hook
2. This caused unnecessary re-renders of the MultisigApprove component 
3. Each re-render would reset the input field value (`callHex`), making it impossible for users to input or edit call data

## Solution

The fix optimizes the useMultisigApprovals hook to prevent unnecessary triggers and re-renders:

1. Added a `useRef` to track previously processed multisig events
2. Implemented a filtering mechanism that only processes events that are:
   - From the multisig section
   - Related to the current address
   - Different from previously processed events
3. Created a comparison system using JSON.stringify to generate a hash of relevant events and only trigger updates when this hash changes

## Previous behaviour
https://github.com/user-attachments/assets/64e57944-bb25-4395-a4f8-7cf61595f3fe

## Current behaviour (after fix)
https://github.com/user-attachments/assets/a5e8dc42-9d53-49fb-b1de-0d0a22562f0d

