### PR TITLE
Update delegated account input type

### DIFF
--- a/packages/page-accounts/src/modals/Delegate.tsx
+++ b/packages/page-accounts/src/modals/Delegate.tsx
@@ -69,7 +69,7 @@ function Delegate ({ onClose, previousAmount, previousConviction, previousDelega
           <InputAddress
             label={t('delegated account')}
             onChange={setDelegatedAccount}
-            type='account'
+            type='allPlus'
             value={delegatedAccount}
           />
         </Modal.Columns>


### PR DESCRIPTION
## 📝 Description

This PR fixes the behavior of the **Delegated Account Input** component. Previously, the input only allowed selection from available (in-browser) accounts. However, this is incorrect — a delegated account does **not** need to be present in the browser extension or local keyring; it simply needs to be a valid address.

The fix aligns with the approach used for the **Proxy Input** component, as implemented in [this PR](https://github.com/polkadot-js/apps/pull/11450/files#diff-d35ac8929895659270ed7fb55bab94ba2f603624d8ea28a2a82f7dca8348f85a).

With this change, the Delegated Account Input now correctly accepts any valid address, regardless of its presence in the browser.