### PR TITLE
Add ZeitgeistPM OnFinality provider to production relay polkadot endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -895,7 +895,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'zeitgeist',
     paraId: 2092,
     providers: {
-      // OnFinality: 'wss://zeitgeist.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/11513
+      OnFinality: 'wss://zeitgeist.api.onfinality.io/public-ws'
       // ZeitgeistPM: 'wss://main.rpc.zeitgeist.pm/ws' // https://github.com/polkadot-js/apps/issues/11215
     },
     text: 'Zeitgeist',


### PR DESCRIPTION
Related to this issue: https://github.com/polkadot-js/apps/issues/11513

However, I can reach the endpoint using this link:

https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fzeitgeist.api.onfinality.io%2Fpublic-ws#/explorer