### PR TITLE
Improve input conversion logic in BaseBytes component

### DIFF
--- a/packages/react-params/src/Param/BaseBytes.tsx
+++ b/packages/react-params/src/Param/BaseBytes.tsx
@@ -48,7 +48,7 @@ function convertInput (value: string): [boolean, boolean, Uint8Array] {
     return [true, false, new Uint8Array([])];
   } else if (value.startsWith('0x')) {
     try {
-      return [true, false, hexToU8a(value)];
+      return [true, false, isHex(value) ? hexToU8a(value) : stringToU8a(value)];
     } catch {
       return [false, false, new Uint8Array([])];
     }


### PR DESCRIPTION
## 📝 Description

This PR addresses a regression where input for Bytes component starting with `0x` are incorrectly parsed as hex-encoded byte strings. This caused issues where display names like `0xTaylor` were misparsed as hex bytes (e.g., `0x0a0000`), leading to incorrect rendering.

This update improves the logic by only interpreting a string as hex if it is a *valid* hex sequence. Non-hex strings starting with `0x` are now correctly treated as plain text.

## 🤔 Previous behaviour

![260577349-db1f5933-e84f-427f-bb1d-b900289ab33b](https://github.com/user-attachments/assets/987d1ed9-10e2-4bf3-93bc-a8334d084a82)

## ✅ Current behaviour

https://github.com/user-attachments/assets/7765c0bb-ad70-4434-ae17-1dc723fe80a7