### PR TITLE
Small fix for non-showing tag for Reservation type on Coretime Broker - Coretime Chain

### DIFF
--- a/packages/page-broker/src/Overview/WorkInfoRow.tsx
+++ b/packages/page-broker/src/Overview/WorkInfoRow.tsx
@@ -85,14 +85,12 @@ function WorkInfoRow ({ data }: { data: InfoRow }): React.ReactElement {
       />
       <StyledTableCol hide={'mobile'}>
         <h5 style={{ opacity: '0.6' }}>type</h5>
-        {data.type &&
-          (
-            <Tag
-              color={colours[data.type] as FlagColor}
-              label={Object.values(CoreTimeTypes)[data.type]}
-            />
-          )
-        }
+        {typeof data.type === 'number' && data.type in CoreTimeTypes && (
+          <Tag
+            color={colours[data.type] as FlagColor}
+            label={Object.values(CoreTimeTypes)[data.type]}
+          />
+        )}
       </StyledTableCol>
       {data.owner
         ? <StyledTableCol hide='mobile'>


### PR DESCRIPTION
## Bug
<img width="1239" alt="Screenshot 2025-05-20 at 6 37 55 PM" src="https://github.com/user-attachments/assets/e43ccea2-68fb-4202-a76f-8a1400386143" />

## Pretty orange tag is back
<img width="1081" alt="Screenshot 2025-05-20 at 6 38 10 PM" src="https://github.com/user-attachments/assets/bdb5f2f4-882a-4cf6-a93b-350a06f42496" />
