### PR TITLE
Enhance Preimage Page with Decodable Call Link

### DIFF
--- a/packages/page-preimages/src/Preimages/Call.tsx
+++ b/packages/page-preimages/src/Preimages/Call.tsx
@@ -3,9 +3,9 @@
 
 import type { Preimage } from '@polkadot/react-hooks/types';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { AddressMini, MarkError, MarkWarning } from '@polkadot/react-components';
+import { AddressMini, CopyButton, MarkError, MarkWarning, styled } from '@polkadot/react-components';
 import { ZERO_ACCOUNT } from '@polkadot/react-hooks/useWeight';
 import { CallExpander } from '@polkadot/react-params';
 import { Null } from '@polkadot/types-codec';
@@ -21,6 +21,14 @@ interface Props {
 function PreimageCall ({ className = '', value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
+  const link = useMemo(
+    () =>
+      value?.proposal
+        ? `#/extrinsics/decode/${value?.proposal?.toHex()}`
+        : null,
+    [value]
+  );
+
   return (
     <>
       <td className={`${className} all`}>
@@ -32,6 +40,16 @@ function PreimageCall ({ className = '', value }: Props): React.ReactElement<Pro
                   labelHash={t('call')}
                   value={value.proposal}
                 />
+              )}
+              {link && (
+                <StyledDiv>
+                  <a
+                    className='isDecoded'
+                    href={link}
+                    rel='noreferrer'
+                  >{link.slice(0, 30)}...</a>
+                  <CopyButton value={value.proposal?.toHex()} />
+                </StyledDiv>
               )}
               {value.proposalError
                 ? <MarkError content={value.proposalError} />
@@ -67,5 +85,11 @@ function PreimageCall ({ className = '', value }: Props): React.ReactElement<Pro
     </>
   );
 }
+
+const StyledDiv = styled.div`
+  display: flex;
+  align-items: center;
+  margin: -0.4rem 0rem -0.4rem 1rem;
+`;
 
 export default React.memo(PreimageCall);

--- a/packages/page-preimages/src/Preimages/Call.tsx
+++ b/packages/page-preimages/src/Preimages/Call.tsx
@@ -90,6 +90,7 @@ const StyledDiv = styled.div`
   display: flex;
   align-items: center;
   margin: -0.4rem 0rem -0.4rem 1rem;
+  white-space: nowrap;
 `;
 
 export default React.memo(PreimageCall);

--- a/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
+++ b/packages/page-preimages/src/Preimages/userPreimages/Preimage.tsx
@@ -121,6 +121,8 @@ const BORDER_TOP = `${BASE_BORDER * 3}rem solid var(--bg-page)`;
 const BORDER_RADIUS = `${BASE_BORDER * 4}rem`;
 
 const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
+  background: var(--bg-table);
+  
   .ui--Icon {
     border-width: 2px;
   }


### PR DESCRIPTION
## 📝 Description

This PR updates the preimage page to include a link that contains the encoded call. When clicked, the link gets decoded and displays the decoded call for the preimage, making it easier for users to view and access the raw data directly. This improves visibility into the preimage content without requiring manual decoding or use of external tools.

The hex value can also be easily copied for use in scripts or debugging workflows. This enhancement is particularly useful for developers who need quick access to the preimage hex for validation or integration purposes. By simplifying the process through a clickable, self-decoding link, this update streamlines developer experience and workflow efficiency.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a15dc63d-8ad3-440b-b1cd-ca821a9e42da" />
