### PR TITLE
chore: re-enable rpc3 for Pop Network

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -310,8 +310,8 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 4001,
     providers: {
       'R0GUE-RPC1': 'wss://rpc1.paseo.popnetwork.xyz',
-      'R0GUE-RPC2': 'wss://rpc2.paseo.popnetwork.xyz'
-      // 'R0GUE-RPC3': 'wss://rpc3.paseo.popnetwork.xyz' // https://github.com/polkadot-js/apps/issues/11513
+      'R0GUE-RPC2': 'wss://rpc2.paseo.popnetwork.xyz',
+      'R0GUE-RPC3': 'wss://rpc3.paseo.popnetwork.xyz'
     },
     text: 'Pop Network',
     ui: {


### PR DESCRIPTION
This PR enables `R0GUE-RPC3` as it is reachable again.

It seems it was disabled after https://github.com/polkadot-js/apps/issues/11513