### PR TITLE
Improve amount error calculation by considering OpenGov-related locks

### DIFF
--- a/packages/page-staking2/src/Pools/useAmountError.ts
+++ b/packages/page-staking2/src/Pools/useAmountError.ts
@@ -7,16 +7,35 @@ import type { BN } from '@polkadot/util';
 import { useMemo } from 'react';
 
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
+import { BN_ZERO, hexToString } from '@polkadot/util';
+
+// Consider only OpenGov-related locks
+const openGovLockIds = ['referenda', 'convictionVoting', 'pyconvot'];
 
 function useAmountErrorImpl (accountId?: string | null, amount?: BN | null, minAmount?: BN | null): boolean {
   const { api } = useApi();
   const balances = useCall<DeriveBalancesAll>(!!accountId && api.derive.balances.all, [accountId]);
 
   return useMemo(
-    () => !amount || amount.isZero() || !minAmount || minAmount.gt(amount) || (
-      !!balances &&
-      amount.gt((balances.transferable || balances.availableBalance).sub(api.consts.balances.existentialDeposit))
-    ),
+    () => {
+      if (!amount || amount.isZero() || !minAmount || minAmount.gt(amount) || !balances) {
+        return true;
+      }
+
+      // Filter out OpenGov-related locks (those that don't prevent staking)
+      const openGovLocks = balances.lockedBreakdown.filter((lock) => {
+        return openGovLockIds.includes(hexToString(lock.id.toHex()));
+      });
+
+      // Total locked amount that affects staking
+      const openGovLockedBalance = openGovLocks.reduce((acc, lock) => acc.add(lock.amount), BN_ZERO);
+
+      const usableBalance = (balances.transferable || balances.availableBalance)
+        .add(openGovLockedBalance)
+        .sub(api.consts.balances.existentialDeposit);
+
+      return amount.gt(usableBalance);
+    },
     [api, amount, balances, minAmount]
   );
 }


### PR DESCRIPTION
## 📝 Description

This PR addresses an issue where users attempting to join a nomination pool via the UI were not able to contribute **tokens locked in OpenGov**. While the UI allowed joining the pool, it incorrectly excluded tokens locked for governance participation. The same action can be performed successfully through the **Extrinsics** page, which clearly indicates a bug in how the UI calculates eligible token amounts.

On Polkadot and its parachains, governance-locked tokens can be used in other staking-related operations. The issue was specific to how balances were computed or filtered on the client side when constructing the join pool extrinsic.

## ✅ Fixes
- Ensures that the total transferable balance **including governance-locked tokens** is correctly considered when joining a nomination pool.
- Aligns the UI behavior with the expected behavior of the extrinsic when submitted manually.

## 🤔 Previous behaviour

Here is the account details used for testing, which have 40 PAS [locked in OpenGov](https://paseo.subscan.io/extrinsic/0x104540881968ef3951abfb1445c3d0a66004cba4add53c318762f0679e6b51a8).

<img width="569" alt="Screenshot 2025-05-26 at 11 26 43" src="https://github.com/user-attachments/assets/427d8937-7b09-462c-a703-c334e13b2869" />

<hr />

Previously, the tokens locked in OpenGov are not allowed via UI.

<img width="1920" alt="Screenshot 2025-05-26 at 11 27 15" src="https://github.com/user-attachments/assets/21956da6-f7bc-4678-977a-6983d1152a0c" />

## 🤔 Current behaviour

https://paseo.subscan.io/extrinsic/6586467-2

https://github.com/user-attachments/assets/5caf91bf-156d-4ba6-8a12-4cc90c8225a5