### PR TITLE
Enable Manual Address Input in Account Input When No Accounts Are Present

### DIFF
--- a/packages/react-components/src/InputAddress/index.tsx
+++ b/packages/react-components/src/InputAddress/index.tsx
@@ -154,7 +154,7 @@ class InputAddress extends React.PureComponent<Props, State> {
     const hasOptions = (options && options.length !== 0) || (optionsAll && Object.keys(optionsAll[type]).length !== 0);
 
     // the options could be delayed, don't render without
-    if (!hasOptions && !isDisabled) {
+    if (!hasOptions && !isDisabled && !['allPlus'].includes(type)) {
       // This is nasty, but since this things is non-functional, there is not much
       // we can do (well, wrap it, however that approach is deprecated here)
       return (

--- a/packages/react-params/src/Param/Account.tsx
+++ b/packages/react-params/src/Param/Account.tsx
@@ -56,7 +56,7 @@ function Account (props: Props): React.ReactElement<Props> {
         isInput
         label={label}
         onChange={_onChange}
-        placeholder='5...'
+        placeholder='5GLFK...'
         type='allPlus'
         withEllipsis
         withLabel={withLabel}


### PR DESCRIPTION
## 📝 Description

This PR addresses an issue where the Chain State tab UI blocks users from querying state using a custom address if no accounts are present in the Accounts list. Previously, the absence of accounts would disable the address input entirely, preventing valid queries for users who may not want to or cannot add an account.

With this change, the address input remains accessible regardless of the Accounts list state, enabling more flexible and exploratory use cases. Users can now directly input any valid address for state queries without needing to register it as an account first.

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/e5064a0a-cf8a-4cdb-a3de-f41bce72d7f9" />


## ✅ Current behaviour 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/6298a62b-93fe-44f0-a8d3-3e025b003bd5" />
