### PR TITLE
Display Basic Chain Info, Apps, API, and Metadata in Settings

### DIFF
--- a/packages/apps-config/src/index.ts
+++ b/packages/apps-config/src/index.ts
@@ -5,5 +5,6 @@ export * from './api/index.js';
 export * from './endpoints/index.js';
 export * from './extensions/index.js';
 export * from './links/index.js';
+export * from './packageInfo.js';
 export * from './settings/index.js';
 export * from './ui/index.js';

--- a/packages/apps-config/src/index.ts
+++ b/packages/apps-config/src/index.ts
@@ -5,6 +5,5 @@ export * from './api/index.js';
 export * from './endpoints/index.js';
 export * from './extensions/index.js';
 export * from './links/index.js';
-export * from './packageInfo.js';
 export * from './settings/index.js';
 export * from './ui/index.js';

--- a/packages/apps-config/src/ui/index.ts
+++ b/packages/apps-config/src/ui/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2025 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { packageInfo } from '../packageInfo.js';
 import { identityNodes, identitySpec } from './identityIcons/index.js';
 import { sanitize } from './util.js';
 
@@ -11,3 +12,5 @@ export function getSystemIcon (systemName: string, specName: string): 'beachball
     'substrate'
   ) as 'substrate';
 }
+
+export { packageInfo };

--- a/packages/apps-config/src/ui/index.ts
+++ b/packages/apps-config/src/ui/index.ts
@@ -13,4 +13,6 @@ export function getSystemIcon (systemName: string, specName: string): 'beachball
   ) as 'substrate';
 }
 
-export { packageInfo };
+export function getPackageVersion () {
+  return `apps v${packageInfo.version.replace('-x', '')}`;
+}

--- a/packages/apps/src/Menu/NodeInfo.tsx
+++ b/packages/apps/src/Menu/NodeInfo.tsx
@@ -5,13 +5,10 @@ import type { BareProps as Props } from '@polkadot/react-components/types';
 
 import React from 'react';
 
+import { getPackageVersion } from '@polkadot/apps-config';
 import { styled } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { NodeName, NodeVersion } from '@polkadot/react-query';
-
-import { packageInfo } from '../packageInfo.js';
-
-const uiInfo = `apps v${packageInfo.version.replace('-x', '')}`;
 
 function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
@@ -25,7 +22,7 @@ function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
         </div>
       )}
       <div>{api.libraryInfo.replace('@polkadot/', '')}</div>
-      <div>{uiInfo}</div>
+      <div>{getPackageVersion()}</div>
     </StyledDiv>
   );
 }

--- a/packages/apps/src/Menu/NodeInfo.tsx
+++ b/packages/apps/src/Menu/NodeInfo.tsx
@@ -10,6 +10,8 @@ import { styled } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { NodeName, NodeVersion } from '@polkadot/react-query';
 
+const appsVersion = getPackageVersion();
+
 function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
 
@@ -22,7 +24,7 @@ function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
         </div>
       )}
       <div>{api.libraryInfo.replace('@polkadot/', '')}</div>
-      <div>{getPackageVersion()}</div>
+      <div>{appsVersion}</div>
     </StyledDiv>
   );
 }

--- a/packages/page-settings/src/Metadata/NetworkSpecs.tsx
+++ b/packages/page-settings/src/Metadata/NetworkSpecs.tsx
@@ -242,6 +242,15 @@ const StyledTable = styled(Table)`
     }
   }
 
+  @media (max-width: 900px) {
+    tr {
+      &:first-child {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+
   .settings--networkSpecs-name {
     position: relative;
 

--- a/packages/page-settings/src/Metadata/SystemVersion.tsx
+++ b/packages/page-settings/src/Metadata/SystemVersion.tsx
@@ -11,6 +11,8 @@ import { useApi } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
 
+const appsVersion = getPackageVersion();
+
 function SystemVersion ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api, isApiReady, systemName, systemVersion } = useApi();
@@ -55,7 +57,7 @@ function SystemVersion ({ className }: Props): React.ReactElement<Props> {
             className='full'
             isDisabled
             label={t('Apps Version')}
-            value={`${getPackageVersion().replace('apps ', '')}`}
+            value={`${appsVersion.replace('apps ', '')}`}
           />
         </td>
       </tr>

--- a/packages/page-settings/src/Metadata/SystemVersion.tsx
+++ b/packages/page-settings/src/Metadata/SystemVersion.tsx
@@ -5,7 +5,7 @@ import type { BareProps as Props } from '@polkadot/react-components/types';
 
 import React, { useRef } from 'react';
 
-import { packageInfo } from '@polkadot/apps-config';
+import { getPackageVersion } from '@polkadot/apps-config';
 import { Input, Spinner, styled, Table } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 
@@ -55,7 +55,7 @@ function SystemVersion ({ className }: Props): React.ReactElement<Props> {
             className='full'
             isDisabled
             label={t('Apps Version')}
-            value={`v${packageInfo.version.replace('-x', '')}`}
+            value={`${getPackageVersion().replace('apps ', '')}`}
           />
         </td>
       </tr>

--- a/packages/page-settings/src/Metadata/SystemVersion.tsx
+++ b/packages/page-settings/src/Metadata/SystemVersion.tsx
@@ -1,0 +1,93 @@
+// Copyright 2017-2025 @polkadot/app-settings authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { BareProps as Props } from '@polkadot/react-components/types';
+
+import React, { useRef } from 'react';
+
+import { packageInfo } from '@polkadot/apps-config';
+import { Input, Spinner, styled, Table } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
+
+import { useTranslation } from '../translate.js';
+
+function SystemVersion ({ className }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const { api, isApiReady, systemName, systemVersion } = useApi();
+
+  const headerRef = useRef<[React.ReactNode?, string?, number?][]>([
+    [t('system version'), 'start', 2]
+  ]);
+
+  if (!isApiReady) {
+    return <Spinner />;
+  }
+
+  return (
+    <StyledTable
+      className={className}
+      empty={t('No version information available')}
+      header={headerRef.current}
+    >
+      <tr>
+        <td>
+          <Input
+            className='full'
+            isDisabled
+            label={t('Node version')}
+            value={systemName + ' v' + systemVersion}
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <Input
+            className='full'
+            isDisabled
+            label={t('API Version')}
+            value={`${api.libraryInfo.replace('@polkadot/api ', '')}`}
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <Input
+            className='full'
+            isDisabled
+            label={t('Apps Version')}
+            value={`v${packageInfo.version.replace('-x', '')}`}
+          />
+        </td>
+      </tr>
+    </StyledTable>
+  );
+}
+
+const StyledTable = styled(Table)`
+  td {
+    padding: 0;
+    text-align: left;
+
+    .input.ui--Input input {
+      border: none !important;
+      background: transparent;
+      padding: 0;
+      margin-left: 0;
+    }
+
+    .ui--Labelled-content .ui.input > input {
+      padding-left: 0 !important;
+    }
+
+    .ui--Labelled:not(.isSmall) {
+      padding-left: 0;
+    }
+
+    .ui--Labelled > label, .ui--Labelled > .ui--Labelled-content {
+      left: 0 !important;
+      padding-left: 0;
+    }
+  }
+`;
+
+export default React.memo(SystemVersion);

--- a/packages/page-settings/src/Metadata/index.tsx
+++ b/packages/page-settings/src/Metadata/index.tsx
@@ -9,6 +9,7 @@ import useChainInfo from '../useChainInfo.js';
 import useRawMetadata from '../useRawMetadata.js';
 import Extensions from './Extensions.js';
 import NetworkSpecs from './NetworkSpecs.js';
+import SystemVersion from './SystemVersion.js';
 
 export default function Metadata (): React.ReactElement {
   const { isDevelopment } = useApi();
@@ -24,6 +25,7 @@ export default function Metadata (): React.ReactElement {
         />
       )}
       <NetworkSpecs chainInfo={chainInfo} />
+      <SystemVersion />
     </>
   );
 }


### PR DESCRIPTION
Fixes #11580 

On mobile devices, key information from the menu bar—such as runtime version, block number, node version, API version, and apps version—was previously hidden due to limited screen space.

To resolve this, these details have now been added to the **Settings** page, under the existing **Metadata** tab.

### Previous Behavior (Mobile)

*info hidden in menu bar due to limited size*
<img width="393" alt="Screenshot 2025-05-27 at 6 14 41 PM" src="https://github.com/user-attachments/assets/77b08dac-681c-4f53-879b-617d39847c00" />

### Current Behavior (Mobile)

*info now visible under Settings > Metadata*
<img width="393" alt="Screenshot 2025-05-27 at 6 16 22 PM" src="https://github.com/user-attachments/assets/fdabc55f-2002-480a-b86a-14698ca5584a" />


