### PR TITLE
chore(passet-hub): add PAssetHub endpoint to Paseo

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -418,21 +418,6 @@ export const testParasPaseoCommon: EndpointOption[] = [
     }
   },
   {
-    info: 'PAssetHub - Contracts',
-    isPeopleForIdentity: true,
-    paraId: 1111,
-    providers: {
-      Parity: 'wss://testnet-passet-hub.polkadot.io'
-    },
-    relayName: 'paseo',
-    teleport: [-1],
-    text: 'PAssetHub - Contracts',
-    ui: {
-      color: '#77bb77',
-      logo: nodesAssetHubSVG
-    }
-  },
-  {
     info: 'PaseoBridgeHub',
     isPeopleForIdentity: true,
     paraId: 1002,
@@ -463,6 +448,21 @@ export const testParasPaseoCommon: EndpointOption[] = [
     ui: {
       color: '#113911',
       logo: chainsCoretimeKusamaSVG
+    }
+  },
+  {
+    info: 'PAssetHub - Contracts',
+    isPeopleForIdentity: true,
+    paraId: 1111,
+    providers: {
+      Parity: 'wss://testnet-passet-hub.polkadot.io'
+    },
+    relayName: 'paseo',
+    teleport: [-1],
+    text: 'PAssetHub - Contracts',
+    ui: {
+      color: '#77bb77',
+      logo: nodesAssetHubSVG
     }
   },
   {


### PR DESCRIPTION
Lists the interim solution for contracts in the app. Listed as a Paseo parachain.