### PR TITLE
Move appsVersion initialization inside component

### DIFF
--- a/packages/apps/src/Menu/NodeInfo.tsx
+++ b/packages/apps/src/Menu/NodeInfo.tsx
@@ -10,10 +10,9 @@ import { styled } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { NodeName, NodeVersion } from '@polkadot/react-query';
 
-const appsVersion = getPackageVersion();
-
 function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
+  const appsVersion = getPackageVersion();
 
   return (
     <StyledDiv className={`${className} media--1400 highlight--color-contrast ui--NodeInfo`}>

--- a/packages/page-settings/src/Metadata/SystemVersion.tsx
+++ b/packages/page-settings/src/Metadata/SystemVersion.tsx
@@ -11,10 +11,9 @@ import { useApi } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
 
-const appsVersion = getPackageVersion();
-
 function SystemVersion ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const appsVersion = getPackageVersion();
   const { api, isApiReady, systemName, systemVersion } = useApi();
 
   const headerRef = useRef<[React.ReactNode?, string?, number?][]>([


### PR DESCRIPTION
The reason for this is that the `apps` UI is currently displaying the previous version. This might be happening because the CI commits occur after the build is completed. Additionally, since we were calling `getPackageVersion` outside the component, the result is likely being cached, which causes the UI to show the previous version instead of the current one.
