### PR TITLE
Enhance BlockByHash with next block navigation and copy functionality

### DIFF
--- a/packages/page-explorer/src/BlockInfo/ByHash.tsx
+++ b/packages/page-explorer/src/BlockInfo/ByHash.tsx
@@ -119,6 +119,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
             nextBlockHash: hash
           }));
         } else {
+          // Subscribe to new block headers until the next block is found, then unsubscribes.
           api.derive.chain.subscribeNewHeads((header: HeaderExtended): void => {
             if (mountedRef.current && header.number.unwrap().eq(nextBlockNumber)) {
               setState((prev) => ({


### PR DESCRIPTION
fixes #10122 #10510 


### Description

This PR improves the [BlockByHash](https://github.com/polkadot-js/apps/blob/master/packages/page-explorer/src/BlockInfo/ByHash.tsx) component by adding the following features:

* **Next Block Hash Display**
  When available, the hash of the next block is now shown, enabling smoother navigation between blocks.

* **Copy-to-Clipboard Functionality**
  Added copy buttons for both the **parent block hash** and the **next block hash**, allowing users to easily copy these values for use elsewhere.


### Screenshots

1. **When the next block is not available** <img width="1456" alt="Screenshot 2025-06-06 at 4 13 53 PM" src="https://github.com/user-attachments/assets/80f24e5d-8106-4b70-b1f3-db0d12ed57ac" />

2. **When the next block is available** <img width="1465" alt="Screenshot 2025-06-06 at 4 14 11 PM" src="https://github.com/user-attachments/assets/88a22887-0572-4dc1-9442-572e0f548301" />


