### PR TITLE
Update Mandala testnet config

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -232,8 +232,8 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'Mandala',
     paraId: 4818,
     providers: {
-      'Autobot': 'wss://rpc1.paseo.mandalachain.io',
-      'Bumblebee': 'wss://rpc2.paseo.mandalachain.io'
+      Autobot: 'wss://rpc1.paseo.mandalachain.io',
+      Bumblebee: 'wss://rpc2.paseo.mandalachain.io'
     },
     text: 'Mandala',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -228,6 +228,20 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
+    homepage: 'https://mandalachain.io',
+    info: 'Mandala',
+    paraId: 4818,
+    providers: {
+      'Autobot': 'wss://rpc1.paseo.mandalachain.io',
+      'Bumblebee': 'wss://rpc2.paseo.mandalachain.io'
+    },
+    text: 'Mandala',
+    ui: {
+      color: '#0036ac',
+      logo: nodesMandalaPNG
+    }
+  },
+  {
     info: 'muse',
     paraId: 3369,
     providers: {
@@ -263,20 +277,6 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     ui: {
       color: '#646566',
       logo: chainsNeurowebTestnetPNG
-    }
-  },
-  {
-    homepage: 'https://mandalachain.io',
-    info: 'Niskala',
-    paraId: 4022,
-    providers: {
-      'Baliola 1': 'wss://mlg1.mandalachain.io',
-      'Baliola 2': 'wss://mlg2.mandalachain.io'
-    },
-    text: 'Niskala',
-    ui: {
-      color: '#0036ac',
-      logo: nodesMandalaPNG
     }
   },
   {


### PR DESCRIPTION
## Update Niskala to Mandala Testnet Configuration

### Changes:
- Network name: `Niskala` → `Mandala`
- ParaID: Updated to `4818`
- RPC endpoints updated to new Mandala infrastructure:
  - Autobot: `wss://rpc1.paseo.mandalachain.io`
  - Bumblebee: `wss://rpc2.paseo.mandalachain.io`
  
### Details:
The Mandala testnet is now live on Paseo and ready for testing. This replaces the previous Niskala configuration with the new network infrastructure.

### Testing
- [x] Endpoint connectivity verified
- [x] Network loads successfully in Polkadot.js apps

### Type of Change
- [x] Configuration update
- [x] Network endpoint change