### PR TITLE
Handle External URL Navigation in Electron App

### DIFF
--- a/packages/apps-electron/src/electron/window.ts
+++ b/packages/apps-electron/src/electron/window.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/apps authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { BrowserWindow, screen } from 'electron';
+import { BrowserWindow, screen, shell } from 'electron';
 import path from 'path';
 
 export function createWindow (environment: string): Promise<unknown> {
@@ -23,6 +23,28 @@ export function createWindow (environment: string): Promise<unknown> {
 
     return win.loadURL('http://127.0.0.1:3000/');
   }
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    console.log('coming here');
+
+    // Open all http/https URLs externally
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url).catch(console.log);
+
+      return { action: 'deny' };
+    }
+
+    return { action: 'allow' };
+  });
+
+  win.webContents.on('will-navigate', (event, url) => {
+    console.log('coming here');
+
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      event.preventDefault();
+      shell.openExternal(url).catch(console.log);
+    }
+  });
 
   const mainFilePath = path.resolve(__dirname, 'index.html');
 

--- a/packages/apps-electron/src/electron/window.ts
+++ b/packages/apps-electron/src/electron/window.ts
@@ -25,8 +25,6 @@ export function createWindow (environment: string): Promise<unknown> {
   }
 
   win.webContents.setWindowOpenHandler(({ url }) => {
-    console.log('coming here');
-
     // Open all http/https URLs externally
     if (url.startsWith('http://') || url.startsWith('https://')) {
       shell.openExternal(url).catch(console.log);
@@ -38,8 +36,6 @@ export function createWindow (environment: string): Promise<unknown> {
   });
 
   win.webContents.on('will-navigate', (event, url) => {
-    console.log('coming here');
-
     if (url.startsWith('http://') || url.startsWith('https://')) {
       event.preventDefault();
       shell.openExternal(url).catch(console.log);

--- a/packages/apps-electron/src/electron/window.ts
+++ b/packages/apps-electron/src/electron/window.ts
@@ -24,6 +24,7 @@ export function createWindow (environment: string): Promise<unknown> {
     return win.loadURL('http://127.0.0.1:3000/');
   }
 
+  // Handle attempts to open a new window via window.open()
   win.webContents.setWindowOpenHandler(({ url }) => {
     // Open all http/https URLs externally
     if (url.startsWith('http://') || url.startsWith('https://')) {
@@ -35,6 +36,7 @@ export function createWindow (environment: string): Promise<unknown> {
     return { action: 'allow' };
   });
 
+  // Handle in-app navigation attempts, such as clicking on <a href="...">
   win.webContents.on('will-navigate', (event, url) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       event.preventDefault();


### PR DESCRIPTION
## 📝 Description

This PR manages how URLs are handled in Electron apps. For example, not all URLs need to open in the Electron window; some can be opened in an external browser window.