### PR TITLE
fix(ui): resolve apps version caching issue

### DIFF
--- a/packages/apps-config/src/index.ts
+++ b/packages/apps-config/src/index.ts
@@ -5,5 +5,6 @@ export * from './api/index.js';
 export * from './endpoints/index.js';
 export * from './extensions/index.js';
 export * from './links/index.js';
+export * from './packageInfo.js';
 export * from './settings/index.js';
 export * from './ui/index.js';

--- a/packages/apps-config/src/ui/index.ts
+++ b/packages/apps-config/src/ui/index.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2025 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { packageInfo } from '../packageInfo.js';
 import { identityNodes, identitySpec } from './identityIcons/index.js';
 import { sanitize } from './util.js';
 
@@ -11,8 +10,4 @@ export function getSystemIcon (systemName: string, specName: string): 'beachball
     identitySpec[sanitize(specName)] ||
     'substrate'
   ) as 'substrate';
-}
-
-export function getPackageVersion () {
-  return `apps v${packageInfo.version.replace('-x', '')}`;
 }

--- a/packages/apps/src/Menu/NodeInfo.tsx
+++ b/packages/apps/src/Menu/NodeInfo.tsx
@@ -5,14 +5,15 @@ import type { BareProps as Props } from '@polkadot/react-components/types';
 
 import React from 'react';
 
-import { getPackageVersion } from '@polkadot/apps-config';
+import { packageInfo } from '@polkadot/apps-config';
 import { styled } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { NodeName, NodeVersion } from '@polkadot/react-query';
 
+const appsVersion = `apps v${packageInfo.version.replace('-x', '')}`;
+
 function NodeInfo ({ className = '' }: Props): React.ReactElement<Props> {
   const { api, isApiReady } = useApi();
-  const appsVersion = getPackageVersion();
 
   return (
     <StyledDiv className={`${className} media--1400 highlight--color-contrast ui--NodeInfo`}>

--- a/packages/page-settings/src/Metadata/SystemVersion.tsx
+++ b/packages/page-settings/src/Metadata/SystemVersion.tsx
@@ -5,15 +5,16 @@ import type { BareProps as Props } from '@polkadot/react-components/types';
 
 import React, { useRef } from 'react';
 
-import { getPackageVersion } from '@polkadot/apps-config';
+import { packageInfo } from '@polkadot/apps-config';
 import { Input, Spinner, styled, Table } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
 
+const appsVersion = `apps v${packageInfo.version.replace('-x', '')}`;
+
 function SystemVersion ({ className }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const appsVersion = getPackageVersion();
   const { api, isApiReady, systemName, systemVersion } = useApi();
 
   const headerRef = useRef<[React.ReactNode?, string?, number?][]>([


### PR DESCRIPTION
## Description

In the current implementation, the build is created before the package version is bumped. As a result, `getPackageVersion` returns a cached version, causing the UI apps to display an outdated version even with a new build release.

To resolve this issue, the version should be read directly from the source file in `@polkadot/apps-config`, ensuring the displayed version is always accurate and up to date.