### PR TITLE
Remove IBP endpoints on westend

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -131,8 +131,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://asset-hub-westend-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/asset-hub-westend',
-      IBP2: 'wss://asset-hub-westend.dotters.network',
       // OnFinality: 'wss://westmint.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9955
       Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
       'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io'
@@ -153,8 +151,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://bridge-hub-westend-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://westend-bridge-hub-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/bridgehub-westend',
-      IBP2: 'wss://bridge-hub-westend.dotters.network',
       // OnFinality: 'wss://bridgehub-westend.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9960
       Parity: 'wss://westend-bridge-hub-rpc.polkadot.io'
     },
@@ -171,8 +167,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://collectives-westend-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://westend-collectives-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/collectives-westend',
-      IBP2: 'wss://collectives-westend.dotters.network',
       Parity: 'wss://westend-collectives-rpc.polkadot.io'
     },
     relayName: 'westend',
@@ -189,8 +183,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1005,
     providers: {
       Dwellir: 'wss://coretime-westend-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/coretime-westend',
-      IBP2: 'wss://coretime-westend.dotters.network',
       Parity: 'wss://westend-coretime-rpc.polkadot.io'
     },
     relayName: 'westend',
@@ -207,8 +199,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1004,
     providers: {
       Dwellir: 'wss://people-westend-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/people-westend',
-      IBP2: 'wss://people-westend.dotters.network',
       Parity: 'wss://westend-people-rpc.polkadot.io'
     },
     relayName: 'westend',
@@ -234,8 +224,6 @@ export const testRelayWestend: EndpointOption = {
   providers: {
     Dwellir: 'wss://westend-rpc.n.dwellir.com',
     'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
-    IBP1: 'wss://rpc.ibp.network/westend',
-    IBP2: 'wss://westend.dotters.network',
     // LuckyFriday: 'wss://rpc-westend.luckyfriday.io', // https://github.com/polkadot-js/apps/issues/10728
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',


### PR DESCRIPTION

The IBP is discontinuing service of Westend and its associated chains. We would like to remove the endpoints from PJS, thank you.

