### PR TITLE
Filter events by user accounts

### DIFF
--- a/packages/apps/public/locales/en/app-explorer.json
+++ b/packages/apps/public/locales/en/app-explorer.json
@@ -10,6 +10,7 @@
   "No justifications available": "No justifications available",
   "No logs available": "No logs available",
   "Node info": "Node info",
+  "Show my events": "Show my events",
   "Unable to decode the block events. {{error}}": "Unable to decode the block events. {{error}}",
   "Unable to retrieve the specified block details. {{error}}": "Unable to retrieve the specified block details. {{error}}",
   "Waiting for next block...": "Waiting for next block...",

--- a/packages/apps/public/locales/en/translation.json
+++ b/packages/apps/public/locales/en/translation.json
@@ -701,6 +701,7 @@
   "Setup account as recoverable": "",
   "Share": "",
   "Show address on hardware device": "",
+  "Show my events": "",
   "Sign (no submission)": "",
   "Sign and Submit": "",
   "Sign and Upload": "",

--- a/packages/page-explorer/src/Events.tsx
+++ b/packages/page-explorer/src/Events.tsx
@@ -2,16 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
+import type { GenericExtrinsic, Vec } from '@polkadot/types';
+import type { AccountId } from '@polkadot/types/interfaces';
+import type { AnyTuple } from '@polkadot/types-codec/types';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { MarkError, styled, Table, Toggle } from '@polkadot/react-components';
-import { useToggle } from '@polkadot/react-hooks';
+import { useAccounts, useApi, useToggle } from '@polkadot/react-hooks';
+import { isEventFromMyAccounts } from '@polkadot/react-hooks/utils/isEventFromMyAccounts';
 import { formatNumber } from '@polkadot/util';
 
 import Event from './Event.js';
 import { useTranslation } from './translate.js';
+
+const MAX_CACHE = 100;
+const blockCache = new Map<string, { author: AccountId | undefined; extrinsics: Vec<GenericExtrinsic<AnyTuple>>}>();
 
 interface Props {
   className?: string;
@@ -44,6 +51,10 @@ function renederEvent (className: string | undefined, { blockHash, blockNumber, 
 
 function Events ({ className = '', emptyLabel, error, eventClassName, events, label, showToggle = false }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const { api } = useApi();
+  const { allAccounts } = useAccounts();
+  const [showOnlyUserEvents, onToggleUserEvents] = useToggle();
+  const [filteredEvents, setFilteredEvents] = useState<Props['events']>([]);
 
   const header = useMemo<[React.ReactNode?, string?, number?][]>(
     () => [
@@ -51,6 +62,59 @@ function Events ({ className = '', emptyLabel, error, eventClassName, events, la
     ],
     [label, t]
   );
+
+  useEffect(() => {
+    const filter = async () => {
+      if (!events || !showOnlyUserEvents) {
+        return;
+      }
+
+      for (const event of events) {
+        const { blockHash, record } = event;
+
+        if (!blockHash) {
+          continue;
+        }
+
+        // use cached block info if available
+        let blockData = blockCache.get(blockHash);
+
+        if (!blockData) {
+          const [{ author }, block] = await Promise.all([
+            await api.derive.chain.getHeader(blockHash),
+            await api.rpc.chain.getBlock(blockHash)
+          ]);
+          const extrinsics = block.block.extrinsics;
+
+          blockData = { author, extrinsics };
+          blockCache.set(blockHash, blockData);
+
+          // Evict oldest key
+          if (blockCache.size > MAX_CACHE) {
+            const oldest = blockCache.keys().next().value;
+
+            oldest && blockCache.delete(oldest);
+          }
+        }
+
+        const { author, extrinsics } = blockData;
+
+        if (isEventFromMyAccounts(record, extrinsics, author, allAccounts)) {
+          setFilteredEvents((prev) => {
+            const alreadyExists = (prev ?? []).some((e) => e.key === event.key);
+
+            if (alreadyExists) {
+              return prev;
+            }
+
+            return [event, ...(prev ?? [])];
+          });
+        }
+      }
+    };
+
+    filter().catch(console.error);
+  }, [allAccounts, api.derive.chain, api.rpc.chain, events, showOnlyUserEvents]);
 
   return (
     <StyledSection>
@@ -68,26 +132,19 @@ function Events ({ className = '', emptyLabel, error, eventClassName, events, la
               <td><MarkError content={t('Unable to decode the block events. {{error}}', { replace: { error: error.message } })} /></td>
             </tr>
           )
-          : events?.map((e) => renederEvent(eventClassName, e))
+          : (showOnlyUserEvents ? filteredEvents : events)?.map((e) => renederEvent(eventClassName, e))
         }
       </Table>
-      {showToggle && <ShowRelevantEventsToggle />}
+      {showToggle &&
+        <Toggle
+          label={t('Show my events')}
+          onChange={onToggleUserEvents}
+          value={showOnlyUserEvents}
+        />
+      }
     </StyledSection>
   );
 }
-
-const ShowRelevantEventsToggle = () => {
-  const { t } = useTranslation();
-  const [showRelevantEvents, setShowRelevantEvents] = useToggle();
-
-  return (
-    <Toggle
-      label={t('Show my events')}
-      onChange={setShowRelevantEvents}
-      value={showRelevantEvents}
-    />
-  );
-};
 
 const StyledSection = styled.section`
   position: relative;

--- a/packages/page-explorer/src/Events.tsx
+++ b/packages/page-explorer/src/Events.tsx
@@ -6,7 +6,8 @@ import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
-import { MarkError, Table } from '@polkadot/react-components';
+import { MarkError, styled, Table, Toggle } from '@polkadot/react-components';
+import { useToggle } from '@polkadot/react-hooks';
 import { formatNumber } from '@polkadot/util';
 
 import Event from './Event.js';
@@ -19,6 +20,7 @@ interface Props {
   events?: KeyedEvent[] | null;
   eventClassName?: string;
   label?: React.ReactNode;
+  showToggle?: boolean
 }
 
 function renederEvent (className: string | undefined, { blockHash, blockNumber, indexes, key, record }: KeyedEvent): React.ReactNode {
@@ -40,7 +42,7 @@ function renederEvent (className: string | undefined, { blockHash, blockNumber, 
   );
 }
 
-function Events ({ className = '', emptyLabel, error, eventClassName, events, label }: Props): React.ReactElement<Props> {
+function Events ({ className = '', emptyLabel, error, eventClassName, events, label, showToggle = false }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   const header = useMemo<[React.ReactNode?, string?, number?][]>(
@@ -51,24 +53,51 @@ function Events ({ className = '', emptyLabel, error, eventClassName, events, la
   );
 
   return (
-    <Table
-      className={className}
-      empty={emptyLabel || t('No events available')}
-      header={header}
-    >
-      {error
-        ? (
-          <tr
-            className={eventClassName}
-            key='error'
-          >
-            <td><MarkError content={t('Unable to decode the block events. {{error}}', { replace: { error: error.message } })} /></td>
-          </tr>
-        )
-        : events?.map((e) => renederEvent(eventClassName, e))
-      }
-    </Table>
+    <StyledSection>
+      <Table
+        className={className}
+        empty={emptyLabel || t('No events available')}
+        header={header}
+      >
+        {error
+          ? (
+            <tr
+              className={eventClassName}
+              key='error'
+            >
+              <td><MarkError content={t('Unable to decode the block events. {{error}}', { replace: { error: error.message } })} /></td>
+            </tr>
+          )
+          : events?.map((e) => renederEvent(eventClassName, e))
+        }
+      </Table>
+      {showToggle && <ShowRelevantEventsToggle />}
+    </StyledSection>
   );
 }
+
+const ShowRelevantEventsToggle = () => {
+  const { t } = useTranslation();
+  const [showRelevantEvents, setShowRelevantEvents] = useToggle();
+
+  return (
+    <Toggle
+      label={t('Show my events')}
+      onChange={setShowRelevantEvents}
+      value={showRelevantEvents}
+    />
+  );
+};
+
+const StyledSection = styled.section`
+  position: relative;
+
+  .ui--Toggle {
+    position: absolute;
+    top: 1.4rem;
+    right: 1rem;
+    z-index: 999;
+  }
+`;
 
 export default React.memo(Events);

--- a/packages/page-explorer/src/Events.tsx
+++ b/packages/page-explorer/src/Events.tsx
@@ -17,7 +17,7 @@ import { formatNumber } from '@polkadot/util';
 import Event from './Event.js';
 import { useTranslation } from './translate.js';
 
-const MAX_CACHE = 100;
+const MAX_CACHE = 200;
 const blockCache = new Map<string, { author: AccountId | undefined; extrinsics: Vec<GenericExtrinsic<AnyTuple>>}>();
 
 interface Props {

--- a/packages/page-explorer/src/Main.tsx
+++ b/packages/page-explorer/src/Main.tsx
@@ -29,7 +29,10 @@ function Main ({ eventCount, events, headers }: Props): React.ReactElement<Props
           <BlockHeaders headers={headers} />
         </Columar.Column>
         <Columar.Column>
-          <Events events={events} />
+          <Events
+            events={events}
+            showToggle
+          />
         </Columar.Column>
       </Columar>
     </>

--- a/packages/react-hooks/src/utils/isEventFromMyAccounts.ts
+++ b/packages/react-hooks/src/utils/isEventFromMyAccounts.ts
@@ -1,0 +1,34 @@
+// Copyright 2017-2025 @polkadot/react-hooks authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { GenericExtrinsic, Vec } from '@polkadot/types';
+import type { AccountId, EventRecord } from '@polkadot/types/interfaces';
+import type { AnyTuple } from '@polkadot/types-codec/types';
+
+import { stringToHex } from '@polkadot/util';
+
+export const isEventFromMyAccounts = (newEvent: EventRecord, extrinsics: Vec<GenericExtrinsic<AnyTuple>>, author: AccountId | undefined, allAccounts: string[]) => {
+  const { event, phase } = newEvent;
+
+  // 1. check if any event arg matches one of the accounts
+  const involvesInArgs = event.data.some((args) =>
+    allAccounts.some((account) => args.toString().includes(account) || args.toString().includes(stringToHex(account)))
+  );
+
+  // 2. check if extrinsic signer matches
+  let involvesInSigner = false;
+
+  if (phase.isApplyExtrinsic) {
+    const index = phase.asApplyExtrinsic.toNumber();
+    const ext = extrinsics[index];
+
+    if (ext?.signer) {
+      involvesInSigner = allAccounts.includes(ext.signer.toString());
+    }
+  }
+
+  // 3. check if block author is in user's accounts
+  const involvesInAuthor = author && allAccounts.includes(author.toString());
+
+  return involvesInArgs || involvesInSigner || involvesInAuthor;
+};


### PR DESCRIPTION
## 📝 Description

Currently, the explorer displays all chain events, which can make it difficult to identify events relevant to the user—especially on active networks with high event volume.

This PR introduces an **optional toggle** that allows users to filter and view **only the events involving their registered accounts** (as detected from the wallet extensions). This enhancement improves the developer experience by:

- Reducing visual noise in the event feed
- Making it easier to track specific extrinsics or state changes related to the user
- Improving usability for testers and developers on active networks

The toggle is off by default to preserve the existing behavior, and when enabled, it filters the events based on account involvement—either directly in the event data or as an block author/signer.

https://github.com/user-attachments/assets/eb49a638-e4f9-4336-a86d-a2cd4dc553f1