### PR TITLE
Fix typos in comment

### DIFF
--- a/packages/page-coretime/src/Sale/SaleDetailsView.tsx
+++ b/packages/page-coretime/src/Sale/SaleDetailsView.tsx
@@ -98,7 +98,7 @@ const SaleDetailsView = ({ chosenSaleNumber, relayName, saleParams }: { salePara
         <div style={{ display: 'grid', gap: '1rem', gridTemplateRows: '1fr 1fr 1fr', minWidth: '200px' }}>
           {!saleParams?.phaseConfig &&
             <div>
-              <p>{t(`This sale is of unsual length of ${saleParams.currentRegion.end.ts - saleParams.currentRegion.start.ts} timeslices, hence the regular phases are not applicable.`)}</p>
+              <p>{t(`This sale is of unusual length of ${saleParams.currentRegion.end.ts - saleParams.currentRegion.start.ts} timeslices, hence the regular phases are not applicable.`)}</p>
               <p>{t(`Sale start timeslice: ${saleParams.currentRegion.start.ts}`)}</p>
               <p>{t(`Sale end timeslice: ${saleParams.currentRegion.end.ts}`)}</p>
             </div>

--- a/packages/page-coretime/src/utils/index.ts
+++ b/packages/page-coretime/src/utils/index.ts
@@ -57,7 +57,7 @@ export function formatDate (date: Date, time = false) {
 }
 
 /**
- * Gives you a date for the traget timeslice
+ * Gives you a date for the target timeslice
  *
  * Relay chain info:
  * blockTime = 6000 ms


### PR DESCRIPTION
This pull request corrects some typographical errors:
 - `unsual` -> `unusual`
 - `traget` -> `target`