### PR TITLE
Accumulate proof size for block details page

### DIFF
--- a/packages/page-explorer/src/BlockInfo/Summary.tsx
+++ b/packages/page-explorer/src/BlockInfo/Summary.tsx
@@ -11,7 +11,7 @@ import { CardSummary, SummaryBox } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
 import { FormatBalance } from '@polkadot/react-query';
-import { BN, BN_ONE, BN_THREE, BN_TWO, BN_ZERO, formatNumber, isBn } from '@polkadot/util';
+import { BN, BN_ONE, BN_THREE, BN_TWO, formatNumber, isBn } from '@polkadot/util';
 
 import { useTranslation } from '../translate.js';
 
@@ -24,7 +24,7 @@ interface Props {
 
 function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?] {
   return events
-    ? events.reduce(([deposits, transfers, weight], { record: { event: { data, method, section } } }) => {
+    ? events.reduce(([deposits, transfers, weight, proofSize], { record: { event: { data, method, section } } }) => {
       const size = (convertWeight(
         ((method === 'ExtrinsicSuccess' ? data[0] : data[1]) as DispatchInfo)?.weight
       ).v2Weight as V2Weight).proofSize;
@@ -42,8 +42,8 @@ function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?
           ).v1Weight)
           : weight,
         section === 'system' && ['ExtrinsicFailed', 'ExtrinsicSuccess'].includes(method)
-          ? (isBn(size) ? size : size.toBn())
-          : BN_ZERO
+          ? proofSize.iadd(isBn(size) ? size : size.toBn())
+          : proofSize
       ];
     }, [new BN(0), new BN(0), new BN(0), new BN(0)])
     : [];

--- a/packages/page-explorer/src/BlockInfo/Summary.tsx
+++ b/packages/page-explorer/src/BlockInfo/Summary.tsx
@@ -4,6 +4,7 @@
 import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
 import type { V2Weight } from '@polkadot/react-hooks/useWeight';
 import type { Balance, DispatchInfo, SignedBlock } from '@polkadot/types/interfaces';
+import type { FrameSupportDispatchPerDispatchClassWeight } from '@polkadot/types/lookup';
 
 import React, { useMemo } from 'react';
 
@@ -17,9 +18,24 @@ import { useTranslation } from '../translate.js';
 
 interface Props {
   events?: KeyedEvent[] | null;
+  blockWeight?: FrameSupportDispatchPerDispatchClassWeight | null;
   maxBlockWeight?: BN;
   maxProofSize?: BN;
   signedBlock?: SignedBlock;
+}
+
+function accumulateWeights (
+  weight?: FrameSupportDispatchPerDispatchClassWeight | null
+): { totalRefTime: BN; totalProofSize: BN } {
+  const totalRefTime = new BN(0);
+  const totalProofSize = new BN(0);
+
+  (['normal', 'operational', 'mandatory'] as const).forEach((cls) => {
+    totalRefTime.iadd(weight?.[cls].refTime.toBn() ?? new BN(0));
+    totalProofSize.iadd(weight?.[cls].proofSize.toBn() ?? new BN(0));
+  });
+
+  return { totalProofSize, totalRefTime };
 }
 
 function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?] {
@@ -49,13 +65,24 @@ function extractEventDetails (events?: KeyedEvent[] | null): [BN?, BN?, BN?, BN?
     : [];
 }
 
-function Summary ({ events, maxBlockWeight, maxProofSize, signedBlock }: Props): React.ReactElement<Props> | null {
+function Summary ({ blockWeight, events, maxBlockWeight, maxProofSize, signedBlock }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
 
   const [deposits, transfers, weight, size] = useMemo(
-    () => extractEventDetails(events),
-    [events]
+    () => {
+      const eventDetails = extractEventDetails(events);
+      const { totalProofSize, totalRefTime } = accumulateWeights(blockWeight);
+
+      // Block weight is the source of truth; using events data as fallback only
+      if (blockWeight) {
+        eventDetails[2] = totalRefTime;
+        eventDetails[3] = totalProofSize;
+      }
+
+      return eventDetails;
+    },
+    [blockWeight, events]
   );
 
   return (


### PR DESCRIPTION
## 📝 Description

This PR fixes the calculation of `proofSize` on the block details page.

Previously, the implementation only captured the `proofSize` from the final `system` event in the block, which often led to inaccurate or underestimated values. This update changes the logic to fetch the actual block weight from storage, ensuring accurate reporting of `proofSize` and `refTime`.

<img width="1920" height="318" alt="image" src="https://github.com/user-attachments/assets/430c572b-123a-4083-9ba1-6dce0a6bbec4" />