### PR TITLE
Fix typos in comment

### DIFF
--- a/packages/page-accounts/src/modals/IdentityMain.tsx
+++ b/packages/page-accounts/src/modals/IdentityMain.tsx
@@ -117,7 +117,7 @@ function IdentityMain ({ address, className = '', onClose }: Props): React.React
   const [valDiscord, setValDiscord] = useState('');
   const [valWeb, setValWeb] = useState('');
   const [gotPreviousIdentity, setGotPreviousIdentity] = useState(false);
-  // HACK This ensures we can deal with legacy indentity information for chains while
+  // HACK This ensures we can deal with legacy identity information for chains while
   // also giving support for the new identity logic inside of the Peoples chain.
   // The new logic is specific to people system parachains.
   const [isLegacyIdentity, setIsLegacyIdentity] = useState<boolean>(!specName.includes('people-'));

--- a/packages/page-staking2/src/index.tsx
+++ b/packages/page-staking2/src/index.tsx
@@ -23,7 +23,7 @@ function StakingApp ({ basePath }: Props): React.ReactElement<Props> {
 
   // on unmount anything else, ensure that for the next round we
   // are starting with a fresh cache (there could be large delays)
-  // between opening up staking (excuted inline, not via effect)
+  // between opening up staking (executed inline, not via effect)
   useEffect((): () => void => {
     return (): void => {
       clearCache();


### PR DESCRIPTION
This pull request corrects some typographical errors:

 - indentity -> identity 
 - excuted -> executed 