### PR TITLE
Update: Change XODE rpc on Kusama and Paseo

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -854,7 +854,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     info: 'xode',
     paraId: 3344,
     providers: {
-      XodeCommunity: 'wss://rpcnodea01.xode.net/n7yoxCmcIrCF6VziCcDmYTwL8R03a/rpc'
+      XodeCommunity: 'wss://kusama-rpcnode.xode.net'
     },
     text: 'Xode',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -387,7 +387,7 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'paseoXode',
     paraId: 4607,
     providers: {
-      XodeCommunity: 'wss://testrpcnodea01.xode.net/aRoyklGrhl9m2LlhX8NP/rpc'
+      XodeCommunity: 'wss://paseo-rpcnode.xode.net'
     },
     text: 'Xode',
     ui: {


### PR DESCRIPTION
Decomissioning the previous server.

1. Changing RPC of XODE on kusama from rpcnodea01.xode.net/n7yoxCmcIrCF6VziCcDmYTwL8R03a/rpc to  kusama-rpcnode.xode.net
2. Changing RPC of XODE on paseo from testrpcnodea01.xode.net/aRoyklGrhl9m2LlhX8NP/rpc to paseo-rpcnode.xode.net
