### PR TITLE
Fix referenda list collapsing

### DIFF
--- a/packages/page-referenda/src/useReferenda.ts
+++ b/packages/page-referenda/src/useReferenda.ts
@@ -51,10 +51,10 @@ function sortGroups (a: ReferendaGroupKnown, b: ReferendaGroupKnown): number {
 }
 
 const OPT_MULTI = {
-  transform: ([[ids], all]: [[BN[]], Option<Referendum['info']>[]]) =>
-    ids.map((id, i) => {
+  transform: ([[ids], all]: [[BN[]], Option<Referendum['info']>[]]) => {
+    const res = ids.map((id, i) => {
       const infoOpt = all[i];
-      const info = infoOpt?.isSome ? infoOpt.unwrap() : undefined;
+      const info = infoOpt.unwrap();
 
       return {
         id,
@@ -62,7 +62,10 @@ const OPT_MULTI = {
         isConvictionVote: info ? isConvictionVote(info) : false,
         key: id.toString()
       };
-    }).filter((r) => r.info !== undefined),
+    });
+
+    return res.filter((r) => r.info !== undefined);
+  },
   withParamsTransform: true
 };
 

--- a/packages/page-referenda/src/useSummary.ts
+++ b/packages/page-referenda/src/useSummary.ts
@@ -11,7 +11,7 @@ import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 function calcActive (grouped: ReferendaGroup[] = []): number {
   return grouped.reduce((total, { referenda = [] }) =>
     total + referenda.filter((r) =>
-      r.info.isOngoing
+      r.info?.isOngoing
     ).length,
   0);
 }


### PR DESCRIPTION
## 📝 Description

This PR fixes a UI bug where, after interacting with a referendum (voting or placing a decision deposit) or performing a bounty-related action, the list refresh would only show the updated item and hide the rest until a manual page reload. The update ensures that a full list refresh occurs after transactions so all items remain visible without requiring a reload.

https://github.com/user-attachments/assets/17d14e08-b252-49c3-95d3-ec6fe906d5aa