### PR TITLE
Fixed Assets loading screen

### DIFF
--- a/packages/react-hooks/src/useAssetInfos.ts
+++ b/packages/react-hooks/src/useAssetInfos.ts
@@ -59,12 +59,15 @@ function useAssetInfosImpl (ids?: BN[]): AssetInfo[] | undefined {
   const [state, setState] = useState<AssetInfo[] | undefined>();
 
   useEffect((): void => {
-    details && metadata && (details[0][0].length === metadata[0][0].length) &&
-      setState(
-        details[0][0].map((id, index) =>
-          extractInfo(allAccounts, id, details[1][index], metadata[1][index])
+    if (details && metadata) {
+      (details[0][0].length === metadata[0][0].length)
+        ? setState(
+          details[0][0].map((id, index) =>
+            extractInfo(allAccounts, id, details[1][index], metadata[1][index])
+          )
         )
-      );
+        : setState((prev) => prev || []);
+    }
   }, [allAccounts, details, ids, metadata]);
 
   return state;


### PR DESCRIPTION
## 📝 Description

Assets page shows a continuous loader on a chain with no (zero) assets. A continuous loader suggests the app is still fetching data or stuck, which creates confusion. The component cloud display blank content instead. This behaviour is now fixed.


https://github.com/user-attachments/assets/054096a9-6497-4c7d-997d-67f2b43b3263

