### PR TITLE
Improve block time handling for chains with elastic scaling

### DIFF
--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -10,7 +10,6 @@ import { AddressSmall, styled } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
-  isLast: boolean
   value: AugmentedBlockHeader;
 }
 
@@ -30,7 +29,7 @@ function getDisplayValue (elapsed: number): React.ReactNode {
       : formatValue(elapsed / 3600, 'hr');
 }
 
-function BlockHeader ({ isLast, value }: Props): React.ReactElement<Props> | null {
+function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
   if (!value) {
     return null;
   }
@@ -51,9 +50,7 @@ function BlockHeader ({ isLast, value }: Props): React.ReactElement<Props> | nul
         )}
       </td>
       <StyledTd className='ui--Elapsed --digits'>
-        {isLast
-          ? '-----'
-          : getDisplayValue(value.blockTime.toNumber() / 1000)}
+        {getDisplayValue(value.blockTime.toNumber() / 1000)}
       </StyledTd>
     </tr>
   );

--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -1,19 +1,36 @@
 // Copyright 2017-2025 @polkadot/app-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { HeaderExtended } from '@polkadot/api-derive/types';
+import type { AugmentedBlockHeader } from '@polkadot/react-hooks/ctx/types';
 
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { AddressSmall } from '@polkadot/react-components';
+import { AddressSmall, styled } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
-  value: HeaderExtended;
+  isLast: boolean
+  value: AugmentedBlockHeader;
 }
 
-function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
+function formatValue (value: number, type = 's', withDecimal = false): React.ReactNode {
+  const [pre, post] = value.toLocaleString('fullwide', { useGrouping: false }).split('.');
+
+  return withDecimal && post?.trim()?.length > 0
+    ? <>{pre}.{post}<span className='timeUnit'>{type}</span></>
+    : <>{pre}<span className='timeUnit'>{type}</span></>;
+}
+
+function getDisplayValue (elapsed: number): React.ReactNode {
+  return (elapsed < 60)
+    ? formatValue(elapsed, 's', elapsed < 15)
+    : (elapsed < 3600)
+      ? formatValue(elapsed / 60, 'min')
+      : formatValue(elapsed / 3600, 'hr');
+}
+
+function BlockHeader ({ isLast, value }: Props): React.ReactElement<Props> | null {
   if (!value) {
     return null;
   }
@@ -33,8 +50,19 @@ function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
           <AddressSmall value={value.author} />
         )}
       </td>
+      <StyledTd className='ui--Elapsed --digits'>
+        {isLast
+          ? '-----'
+          : getDisplayValue(value.blockTime.toNumber() / 1000)}
+      </StyledTd>
     </tr>
   );
 }
+
+const StyledTd = styled.td`
+  .timeUnit {
+    font-size: var(--font-percent-tiny);
+  }
+`;
 
 export default React.memo(BlockHeader);

--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -14,19 +14,19 @@ interface Props {
 }
 
 function formatValue (value: number, type = 's', withDecimal = false): React.ReactNode {
-  const [pre, post] = value.toLocaleString('fullwide', { useGrouping: false }).split('.');
+  const [pre, post] = value.toFixed().split('.');
 
   return withDecimal && post?.trim()?.length > 0
-    ? <>{pre}.{post}<span className='timeUnit'>{type}</span></>
-    : <>{pre}<span className='timeUnit'>{type}</span></>;
+    ? <>{pre}.{post} <span className='timeUnit'>{type} ago</span></>
+    : <>{pre} <span className='timeUnit'>{type} ago</span></>;
 }
 
 function getDisplayValue (elapsed: number): React.ReactNode {
   return (elapsed < 60)
-    ? formatValue(elapsed, 's', elapsed < 15)
+    ? formatValue(elapsed, 'secs', elapsed < 15)
     : (elapsed < 3600)
-      ? formatValue(elapsed / 60, 'min')
-      : formatValue(elapsed / 3600, 'hr');
+      ? formatValue(elapsed / 60, 'mins')
+      : formatValue(elapsed / 3600, 'hrs');
 }
 
 function BlockHeader ({ headers }: Props): React.ReactElement<Props> | null {
@@ -53,8 +53,11 @@ function BlockHeader ({ headers }: Props): React.ReactElement<Props> | null {
                 <AddressSmall value={value.author} />
               )}
             </td>
-            <td className='ui--Elapsed --digits'>
-              {getDisplayValue(value.blockTime.toNumber() / 1000)}
+            <td
+              className='all --digits blockTime'
+              key={Date.now()}
+            >
+              {getDisplayValue((Date.now() - value.timestamp.toNumber()) / 1000)}
             </td>
           </StyledTr>
         );
@@ -68,6 +71,11 @@ const BORDER_TOP = `${BASE_BORDER * 3}rem solid var(--bg-page)`;
 const BORDER_RADIUS = `${BASE_BORDER * 4}rem`;
 
 const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
+  .blockTime {
+    text-align: right;
+    font-style: italic;
+  }
+
   td {
     border-top: ${(props) => props.isFirstItem && BORDER_TOP};
     border-radius: 0rem !important;
@@ -83,7 +91,7 @@ const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
     }
 
     .timeUnit {
-      font-size: var(--font-percent-tiny);
+      font-size: var(--font-percent-small);
     }
   }
 `;

--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -10,7 +10,7 @@ import { AddressSmall, styled } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
-  value: AugmentedBlockHeader;
+  headers: AugmentedBlockHeader[];
 }
 
 function formatValue (value: number, type = 's', withDecimal = false): React.ReactNode {
@@ -29,36 +29,62 @@ function getDisplayValue (elapsed: number): React.ReactNode {
       : formatValue(elapsed / 3600, 'hr');
 }
 
-function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
-  if (!value) {
-    return null;
-  }
-
-  const hashHex = value.hash.toHex();
-
+function BlockHeader ({ headers }: Props): React.ReactElement<Props> | null {
   return (
-    <tr>
-      <td className='number'>
-        <h4 className='--digits'>
-          <Link to={`/explorer/query/${hashHex}`}>{formatNumber(value.number)}</Link>
-        </h4>
-      </td>
-      <td className='all hash overflow'>{hashHex}</td>
-      <td className='address'>
-        {value.author && (
-          <AddressSmall value={value.author} />
-        )}
-      </td>
-      <StyledTd className='ui--Elapsed --digits'>
-        {getDisplayValue(value.blockTime.toNumber() / 1000)}
-      </StyledTd>
-    </tr>
+    <>
+      {headers.map((value, index) => {
+        const hashHex = value.hash.toHex();
+
+        return (
+          <StyledTr
+            className='isExpanded'
+            isFirstItem={index === 0}
+            isLastItem={index === headers.length - 1}
+            key={value.number.toString()}
+          >
+            <td className='number'>
+              <h4 className='--digits'>
+                <Link to={`/explorer/query/${hashHex}`}>{formatNumber(value.number)}</Link>
+              </h4>
+            </td>
+            <td className='all hash overflow'>{hashHex}</td>
+            <td className='address'>
+              {value.author && (
+                <AddressSmall value={value.author} />
+              )}
+            </td>
+            <td className='ui--Elapsed --digits'>
+              {getDisplayValue(value.blockTime.toNumber() / 1000)}
+            </td>
+          </StyledTr>
+        );
+      })}
+    </>
   );
 }
 
-const StyledTd = styled.td`
-  .timeUnit {
-    font-size: var(--font-percent-tiny);
+const BASE_BORDER = 0.125;
+const BORDER_TOP = `${BASE_BORDER * 3}rem solid var(--bg-page)`;
+const BORDER_RADIUS = `${BASE_BORDER * 4}rem`;
+
+const StyledTr = styled.tr<{isFirstItem: boolean; isLastItem: boolean}>`
+  td {
+    border-top: ${(props) => props.isFirstItem && BORDER_TOP};
+    border-radius: 0rem !important;
+    
+    &:first-child {
+      border-top-left-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+      border-bottom-left-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+    }
+
+    &:last-child {
+      border-top-right-radius: ${(props) => props.isFirstItem ? BORDER_RADIUS : '0rem'}!important;
+      border-bottom-right-radius: ${(props) => props.isLastItem ? BORDER_RADIUS : '0rem'}!important;
+    }
+
+    .timeUnit {
+      font-size: var(--font-percent-tiny);
+    }
   }
 `;
 

--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -28,9 +28,8 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
     >
       {headers
         .filter((header) => !!header)
-        .map((header, index): React.ReactNode => (
+        .map((header): React.ReactNode => (
           <BlockHeader
-            isLast = {index === headers.length - 1}
             key={header.number.toString()}
             value={header}
           />

--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -3,7 +3,7 @@
 
 import type { AugmentedBlockHeader } from '@polkadot/react-hooks/ctx/types';
 
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
 
@@ -21,19 +21,35 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
     [t('recent blocks'), 'start', 4]
   ]);
 
+  const groupedByTimestamp = useMemo(() => {
+    return headers.reduce((acc, product) => {
+      const timestamp = product.timestamp.toString();
+
+      if (!acc[timestamp]) {
+        acc[timestamp] = [];
+      }
+
+      acc[timestamp].push(product);
+
+      return acc;
+    }, {} as Record<string, AugmentedBlockHeader[]>);
+  }, [headers]);
+
   return (
     <Table
       empty={t('No blocks available')}
       header={headerRef.current}
     >
-      {headers
-        .filter((header) => !!header)
-        .map((header): React.ReactNode => (
-          <BlockHeader
-            key={header.number.toString()}
-            value={header}
-          />
-        ))}
+      {Object
+        .entries(groupedByTimestamp)
+        .map(([timestamp, headers]): React.ReactNode => {
+          return (
+            <BlockHeader
+              headers={headers.filter((e) => !!e)}
+              key={timestamp}
+            />
+          );
+        })}
     </Table>
   );
 }

--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/app-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { HeaderExtended } from '@polkadot/api-derive/types';
+import type { AugmentedBlockHeader } from '@polkadot/react-hooks/ctx/types';
 
 import React, { useRef } from 'react';
 
@@ -11,14 +11,14 @@ import BlockHeader from './BlockHeader.js';
 import { useTranslation } from './translate.js';
 
 interface Props {
-  headers: HeaderExtended[];
+  headers: AugmentedBlockHeader[];
 }
 
 function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   const headerRef = useRef<([React.ReactNode?, string?, number?] | false)[]>([
-    [t('recent blocks'), 'start', 3]
+    [t('recent blocks'), 'start', 4]
   ]);
 
   return (
@@ -28,8 +28,9 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
     >
       {headers
         .filter((header) => !!header)
-        .map((header): React.ReactNode => (
+        .map((header, index): React.ReactNode => (
           <BlockHeader
+            isLast = {index === headers.length - 1}
             key={header.number.toString()}
             value={header}
           />

--- a/packages/page-explorer/src/Main.tsx
+++ b/packages/page-explorer/src/Main.tsx
@@ -1,8 +1,7 @@
 // Copyright 2017-2025 @polkadot/app-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { HeaderExtended } from '@polkadot/api-derive/types';
-import type { KeyedEvent } from '@polkadot/react-hooks/ctx/types';
+import type { AugmentedBlockHeader, KeyedEvent } from '@polkadot/react-hooks/ctx/types';
 
 import React from 'react';
 
@@ -16,14 +15,17 @@ import Summary from './Summary.js';
 interface Props {
   eventCount: number;
   events: KeyedEvent[];
-  headers: HeaderExtended[];
+  headers: AugmentedBlockHeader[];
 }
 
 function Main ({ eventCount, events, headers }: Props): React.ReactElement<Props> {
   return (
     <>
       <Query />
-      <Summary eventCount={eventCount} />
+      <Summary
+        eventCount={eventCount}
+        headers={headers}
+      />
       <Columar>
         <Columar.Column>
           <BlockHeaders headers={headers} />

--- a/packages/page-explorer/src/Summary.tsx
+++ b/packages/page-explorer/src/Summary.tsx
@@ -1,6 +1,8 @@
 // Copyright 2017-2025 @polkadot/app-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AugmentedBlockHeader } from '@polkadot/react-hooks/ctx/types';
+
 import React from 'react';
 
 import { CardSummary, SummaryBox } from '@polkadot/react-components';
@@ -13,9 +15,10 @@ import { useTranslation } from './translate.js';
 
 interface Props {
   eventCount: number;
+  headers: AugmentedBlockHeader[];
 }
 
-function Summary ({ eventCount }: Props): React.ReactElement {
+function Summary ({ eventCount, headers }: Props): React.ReactElement {
   const { t } = useTranslation();
   const { api } = useApi();
 
@@ -25,7 +28,8 @@ function Summary ({ eventCount }: Props): React.ReactElement {
         {api.query.timestamp && (
           <>
             <CardSummary label={t('last block')}>
-              <TimeNow />
+              {/* Restart timer on key change */}
+              <TimeNow key={headers.at(0)?.hash.toHex()} />
             </CardSummary>
             <CardSummary
               className='media--800'

--- a/packages/page-explorer/src/Summary.tsx
+++ b/packages/page-explorer/src/Summary.tsx
@@ -33,7 +33,7 @@ function Summary ({ eventCount, headers }: Props): React.ReactElement {
             </CardSummary>
             <CardSummary
               className='media--800'
-              label={t('target')}
+              label={t('slot')}
             >
               <BlockToTime value={BN_ONE} />
             </CardSummary>

--- a/packages/react-hooks/src/ctx/BlockAuthors.tsx
+++ b/packages/react-hooks/src/ctx/BlockAuthors.tsx
@@ -39,14 +39,8 @@ export function BlockAuthorsCtxRoot ({ children }: Props): React.ReactElement<Pr
       api.derive.chain.subscribeNewHeads(async (header: HeaderExtended): Promise<void> => {
         if (header?.number) {
           const timestamp = await ((await api.at(header.hash)).query.timestamp.now());
-          const parentTimestamp =
-           lastHeaders.find((last) => last.number.toBn().addn(1).eq(header.number.toBn()))?.timestamp ??
-           await ((await api.at(header.parentHash)).query.timestamp.now());
 
-          // Store the difference between the previous block time and the current one.
-          const blockTime = api.registry.createType('u64', timestamp.toBn().sub(parentTimestamp.toBn()));
-
-          const lastHeader = Object.assign(header, { blockTime, timestamp }) as AugmentedBlockHeader;
+          const lastHeader = Object.assign(header, { timestamp }) as AugmentedBlockHeader;
           const blockNumber = lastHeader.number.unwrap();
           let thisBlockAuthor = '';
 

--- a/packages/react-hooks/src/ctx/BlockAuthors.tsx
+++ b/packages/react-hooks/src/ctx/BlockAuthors.tsx
@@ -3,7 +3,7 @@
 
 import type { HeaderExtended } from '@polkadot/api-derive/types';
 import type { EraRewardPoints } from '@polkadot/types/interfaces';
-import type { BlockAuthors } from './types.js';
+import type { AugmentedBlockHeader, BlockAuthors } from './types.js';
 
 import React, { useEffect, useState } from 'react';
 
@@ -31,13 +31,16 @@ export function BlockAuthorsCtxRoot ({ children }: Props): React.ReactElement<Pr
   // No unsub, global context - destroyed on app close
   useEffect((): void => {
     api.isReady.then((): void => {
-      let lastHeaders: HeaderExtended[] = [];
+      let lastHeaders: AugmentedBlockHeader[] = [];
       let lastBlockAuthors: string[] = [];
       let lastBlockNumber = '';
 
       // subscribe to new headers
-      api.derive.chain.subscribeNewHeads((lastHeader: HeaderExtended): void => {
-        if (lastHeader?.number) {
+      api.derive.chain.subscribeNewHeads(async (header: HeaderExtended): Promise<void> => {
+        if (header?.number) {
+          const currentTimestamp = await ((await api.at(header.hash)).query.timestamp.now());
+
+          const lastHeader = Object.assign(header, { timestamp: currentTimestamp }) as AugmentedBlockHeader;
           const blockNumber = lastHeader.number.unwrap();
           let thisBlockAuthor = '';
 
@@ -60,7 +63,7 @@ export function BlockAuthorsCtxRoot ({ children }: Props): React.ReactElement<Pr
 
           lastHeaders = lastHeaders
             .filter((old, index) => index < MAX_HEADERS && old.number.unwrap().lt(blockNumber))
-            .reduce((next, header): HeaderExtended[] => {
+            .reduce((next, header): AugmentedBlockHeader[] => {
               next.push(header);
 
               return next;

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -8,7 +8,7 @@ import type { HeaderExtended } from '@polkadot/api-derive/types';
 import type { LinkOption } from '@polkadot/apps-config/endpoints/types';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';
 import type { ProviderStats } from '@polkadot/rpc-provider/types';
-import type { BlockNumber, EventRecord } from '@polkadot/types/interfaces';
+import type { BlockNumber, EventRecord, Moment } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 import type { AssetInfoComplete } from '../types.js';
 
@@ -75,13 +75,19 @@ export interface PayWithAsset {
   selectedFeeAsset: AssetInfoComplete | null;
 }
 
+interface BlockTime {
+  readonly timestamp: Moment;
+}
+
+export type AugmentedBlockHeader = HeaderExtended & BlockTime;
+
 export interface BlockAuthors {
   byAuthor: Record<string, string>;
   eraPoints: Record<string, string>;
   lastBlockAuthors: string[];
   lastBlockNumber?: string;
-  lastHeader?: HeaderExtended;
-  lastHeaders: HeaderExtended[];
+  lastHeader?: AugmentedBlockHeader;
+  lastHeaders: AugmentedBlockHeader[];
 }
 
 export interface BlockEvents {

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -77,6 +77,7 @@ export interface PayWithAsset {
 
 interface BlockTime {
   readonly timestamp: Moment;
+  readonly blockTime: Moment;
 }
 
 export type AugmentedBlockHeader = HeaderExtended & BlockTime;

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -77,7 +77,6 @@ export interface PayWithAsset {
 
 interface BlockTime {
   readonly timestamp: Moment;
-  readonly blockTime: Moment;
 }
 
 export type AugmentedBlockHeader = HeaderExtended & BlockTime;

--- a/packages/react-query/src/TimeNow.tsx
+++ b/packages/react-query/src/TimeNow.tsx
@@ -5,8 +5,6 @@ import type { Moment } from '@polkadot/types/interfaces';
 
 import React, { useMemo } from 'react';
 
-import { useApi, useCall } from '@polkadot/react-hooks';
-
 import Elapsed from './Elapsed.js';
 
 interface Props {
@@ -17,8 +15,7 @@ interface Props {
 }
 
 function TimeNow ({ children, className = '', label, value }: Props): React.ReactElement<Props> {
-  const { api } = useApi();
-  const timestamp = useCall<Moment>(!value && api.query.timestamp?.now);
+  const timestamp = Date.now();
 
   const [now, hasValue] = useMemo(
     () => [value || timestamp, !!(value || timestamp)],


### PR DESCRIPTION
## 📝 Description

This PR fixes the Explorer’s `recent blocks` column, related metrics, and latency chart for chains with **elastic scaling**.  
The changes are backward-compatible and do not affect chains without elastic scaling (i.e., the original UI behavior remains unchanged).

## 🚀 Changes

- **Group blocks per slot** in the `recent blocks` column.  
  Blocks produced in the same slot share the exact same on-chain timestamp, so grouping them visually makes them easier to distinguish.

- **Improve the `last block` timer and target display** for better accuracy.

- **Fix block time chart** to correctly represent blocks produced in the same slot.  
  Since multiple blocks in a slot have the same on-chain timestamp, the chart now:
  - Computes the average block time for a slot as 

$$
\text{AvgBlockTime} = \frac{\text{blockTime}(\text{previousSlot}) - \text{blockTime}(\text{currentSlot})}{\text{blocksInSlot}}
$$


  - Plots values based on this calculation.  

  This approach ensures consistency, as no alternative on-chain metrics exist for distinguishing blocks within the same slot.  
  While off-chain timestamps could be used, they risk introducing inconsistencies and incorrect values.

<hr></hr>

<img width="978" height="903" alt="image" src="https://github.com/user-attachments/assets/8acd527e-a182-4655-a9f2-fc878148b094" />

<img width="1920" height="497" alt="image" src="https://github.com/user-attachments/assets/8819c4a3-0048-476f-9d8e-63855fdae2cd" />
