### PR TITLE
fix: filter-out non eth accounts from eth chains

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -174,8 +174,18 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, fork: 
     isDevelopment,
     ss58Format,
     store,
-    type: isEthereum ? 'ethereum' : 'ed25519'
-  }, injectedAccounts);
+    type: 'ed25519'
+  },
+  isEthereum
+    ? injectedAccounts.map((account) => {
+      const copy = { ...account };
+
+      copy.type = 'ethereum';
+
+      return copy;
+    })
+    : injectedAccounts
+  );
 
   const defaultSection = Object.keys(api.tx)[0];
   const defaultMethod = Object.keys(api.tx[defaultSection])[0];

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -174,7 +174,7 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, fork: 
     isDevelopment,
     ss58Format,
     store,
-    type: 'ed25519'
+    type: isEthereum ? 'ethereum' : 'ed25519'
   },
   isEthereum
     ? injectedAccounts.map((account) => {


### PR DESCRIPTION
Closes #11875 . I already provided an explanation of the cause in the issue.