### PR TITLE
Refactor: Move Relay and Asset Hub API Connections to Context

### DIFF
--- a/packages/apps/src/Root.tsx
+++ b/packages/apps/src/Root.tsx
@@ -9,7 +9,7 @@ import { HashRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
 import { ApiCtxRoot } from '@polkadot/react-api';
-import { ApiStatsCtxRoot, BlockAuthorsCtxRoot, BlockEventsCtxRoot, KeyringCtxRoot, PayWithAssetCtxRoot, QueueCtxRoot, WindowSizeCtxRoot } from '@polkadot/react-hooks';
+import { ApiStatsCtxRoot, BlockAuthorsCtxRoot, BlockEventsCtxRoot, KeyringCtxRoot, PayWithAssetCtxRoot, QueueCtxRoot, StakingAsyncApisCtxRoot, WindowSizeCtxRoot } from '@polkadot/react-hooks';
 import { settings } from '@polkadot/ui-settings';
 
 import BeforeApiInit from './overlays/BeforeInit.js';
@@ -56,7 +56,9 @@ function Root ({ isElectron, store }: Props): React.ReactElement<Props> {
                     <HashRouter>
                       <WindowSizeCtxRoot>
                         <PayWithAssetCtxRoot>
-                          <Apps />
+                          <StakingAsyncApisCtxRoot>
+                            <Apps />
+                          </StakingAsyncApisCtxRoot>
                         </PayWithAssetCtxRoot>
                       </WindowSizeCtxRoot>
                     </HashRouter>

--- a/packages/page-staking-async/src/CommandCenter/index.tsx
+++ b/packages/page-staking-async/src/CommandCenter/index.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Dropdown, styled } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
-import { getApi } from '@polkadot/react-hooks/useStakingAsyncApis';
+import { getApi } from '@polkadot/react-hooks/ctx/StakingAsync';
 
 import AssetHubSection from './ah.js';
 import RelaySection from './relay.js';

--- a/packages/page-staking/src/Actions/partials/SessionKey.tsx
+++ b/packages/page-staking/src/Actions/partials/SessionKey.tsx
@@ -26,20 +26,20 @@ const EMPTY_PROOF = new Uint8Array();
 function SessionKey ({ className = '', controllerId, onChange, stashId, withFocus, withSenders }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const { isStakingAsyncPage, rcApi } = useStakingAsyncApis();
+  const { isStakingAsync, rcApi } = useStakingAsyncApis();
   const [keys, setKeys] = useState<string | null>(null);
 
   useEffect((): void => {
     try {
       onChange({
         sessionTx: isHex(keys)
-          ? (isStakingAsyncPage ? rcApi : api)?.tx.session.setKeys(keys, EMPTY_PROOF)
+          ? (isStakingAsync ? rcApi : api)?.tx.session.setKeys(keys, EMPTY_PROOF)
           : null
       });
     } catch {
       onChange({ sessionTx: null });
     }
-  }, [api, isStakingAsyncPage, keys, onChange, rcApi]);
+  }, [api, isStakingAsync, keys, onChange, rcApi]);
 
   return (
     <div className={className}>

--- a/packages/react-hooks/src/ctx/StakingAsync.tsx
+++ b/packages/react-hooks/src/ctx/StakingAsync.tsx
@@ -1,0 +1,96 @@
+// Copyright 2017-2025 @polkadot/react-hooks authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PropsWithChildren } from 'react';
+import type { StakingAsyncApis } from './types.js';
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { createWsEndpoints } from '@polkadot/apps-config';
+import { useApi } from '@polkadot/react-hooks';
+
+const allEndPoints = createWsEndpoints((k, v) => v?.toString() || k);
+
+export const getApi = async (url: string[]|string) => {
+  const api = await ApiPromise.create({
+    provider: new WsProvider(url)
+  });
+
+  await api.isReadyOrError;
+
+  return api;
+};
+
+const EMPTY_STATE: StakingAsyncApis = {
+  ahEndPoints: [],
+  isRelayChain: false,
+  isStakingAsyncPage: false,
+  rcEndPoints: []
+};
+
+export const StakingAsyncApisCtx = React.createContext<StakingAsyncApis>(EMPTY_STATE);
+
+export const StakingAsyncApisCtxRoot = ({ children }: PropsWithChildren) => {
+  const { api, isApiReady } = useApi();
+
+  return isApiReady &&
+    !!((api.tx.stakingAhClient) || (api.tx.staking && api.tx.stakingRcClient))
+    ? <StakingAsyncProvider>{children}</StakingAsyncProvider>
+    : <>{children}</>;
+};
+
+export const StakingAsyncProvider = ({ children }: PropsWithChildren) => {
+  const { api, apiEndpoint } = useApi();
+  const [ahApi, setAhApi] = useState<ApiPromise>();
+  const [rcApi, setRcApi] = useState<ApiPromise>();
+
+  const isRelayChain = useMemo(() => {
+    return !!api.tx.stakingAhClient;
+  }, [api]);
+
+  const isStakingAsyncPage = useMemo(() => {
+    return !!((api.tx.stakingAhClient) || (api.tx.staking && api.tx.stakingRcClient));
+  }, [api]);
+
+  const rcEndPoints = useMemo(() => {
+    return (isRelayChain
+      ? apiEndpoint?.providers
+      : apiEndpoint?.valueRelay) || [];
+  }, [apiEndpoint, isRelayChain]);
+
+  const ahEndPoints: string[] = useMemo(() => {
+    if (isRelayChain) {
+      return allEndPoints.find(({ genesisHashRelay, paraId }) =>
+        paraId === 1000 && genesisHashRelay === api.genesisHash.toHex()
+      )?.providers || [];
+    }
+
+    return apiEndpoint?.providers || [];
+  }, [api, apiEndpoint, isRelayChain]);
+
+  useEffect(() => {
+    if (isRelayChain) {
+      const ahUrl = ahEndPoints.at(Math.floor(Math.random() * ahEndPoints.length));
+
+      !!ahUrl && getApi(ahUrl).then(setAhApi).catch(console.error);
+    } else {
+      const rcUrl = rcEndPoints.at(Math.floor(Math.random() * rcEndPoints.length));
+
+      !!rcUrl && getApi(rcUrl).then(setRcApi).catch(console.error);
+    }
+  }, [ahEndPoints, isRelayChain, rcEndPoints]);
+
+  const state = useMemo(() => ({
+    ahApi,
+    ahEndPoints,
+    isRelayChain,
+    isStakingAsyncPage,
+    rcApi,
+    rcEndPoints
+  }), [ahApi, ahEndPoints, isRelayChain, isStakingAsyncPage, rcApi, rcEndPoints]);
+
+  return <StakingAsyncApisCtx.Provider value={state}>
+    {children}
+  </StakingAsyncApisCtx.Provider>;
+};

--- a/packages/react-hooks/src/ctx/StakingAsync.tsx
+++ b/packages/react-hooks/src/ctx/StakingAsync.tsx
@@ -25,7 +25,7 @@ export const getApi = async (url: string[]|string) => {
 const EMPTY_STATE: StakingAsyncApis = {
   ahEndPoints: [],
   isRelayChain: false,
-  isStakingAsyncPage: false,
+  isStakingAsync: false,
   rcEndPoints: []
 };
 
@@ -49,7 +49,7 @@ export const StakingAsyncProvider = ({ children }: PropsWithChildren) => {
     return !!api.tx.stakingAhClient;
   }, [api]);
 
-  const isStakingAsyncPage = useMemo(() => {
+  const isStakingAsync = useMemo(() => {
     return !!((api.tx.stakingAhClient) || (api.tx.staking && api.tx.stakingRcClient));
   }, [api]);
 
@@ -85,10 +85,10 @@ export const StakingAsyncProvider = ({ children }: PropsWithChildren) => {
     ahApi,
     ahEndPoints,
     isRelayChain,
-    isStakingAsyncPage,
+    isStakingAsync,
     rcApi,
     rcEndPoints
-  }), [ahApi, ahEndPoints, isRelayChain, isStakingAsyncPage, rcApi, rcEndPoints]);
+  }), [ahApi, ahEndPoints, isRelayChain, isStakingAsync, rcApi, rcEndPoints]);
 
   return <StakingAsyncApisCtx.Provider value={state}>
     {children}

--- a/packages/react-hooks/src/ctx/index.ts
+++ b/packages/react-hooks/src/ctx/index.ts
@@ -7,4 +7,5 @@ export { BlockEventsCtxRoot } from './BlockEvents.js';
 export { KeyringCtxRoot } from './Keyring.js';
 export { PayWithAssetCtxRoot } from './PayWithAsset.js';
 export { QueueCtxRoot } from './Queue.js';
+export { StakingAsyncApisCtxRoot } from './StakingAsync.js';
 export { WindowSizeCtxRoot } from './WindowSize.js';

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -120,6 +120,6 @@ export interface StakingAsyncApis {
   ahApi?: ApiPromise,
   ahEndPoints: string[],
   isRelayChain: boolean,
-  isStakingAsyncPage: boolean,
+  isStakingAsync: boolean,
   rcEndPoints: string[]
 }

--- a/packages/react-hooks/src/ctx/types.ts
+++ b/packages/react-hooks/src/ctx/types.ts
@@ -114,3 +114,12 @@ export interface WindowSize {
   height: number;
   width: number;
 }
+
+export interface StakingAsyncApis {
+  rcApi?: ApiPromise,
+  ahApi?: ApiPromise,
+  ahEndPoints: string[],
+  isRelayChain: boolean,
+  isStakingAsyncPage: boolean,
+  rcEndPoints: string[]
+}

--- a/packages/react-hooks/src/useStakingAsyncApis.ts
+++ b/packages/react-hooks/src/useStakingAsyncApis.ts
@@ -1,93 +1,15 @@
 // Copyright 2017-2025 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import type { StakingAsyncApis } from './ctx/types.js';
 
-import { ApiPromise, WsProvider } from '@polkadot/api';
-import { createWsEndpoints } from '@polkadot/apps-config';
-import { createNamedHook, useApi } from '@polkadot/react-hooks';
+import { useContext } from 'react';
 
-export const getApi = async (url: string[]|string) => {
-  const api = await ApiPromise.create({
-    provider: new WsProvider(url)
-  });
+import { StakingAsyncApisCtx } from './ctx/StakingAsync.js';
+import { createNamedHook } from './createNamedHook.js';
 
-  await api.isReadyOrError;
-
-  return api;
-};
-
-const allEndPoints = createWsEndpoints((k, v) => v?.toString() || k);
-
-function useStakingAsyncApisImpl () {
-  const { api, apiEndpoint, isApiReady } = useApi(); // <- check readiness
-  const [ahApi, setAhApi] = useState<ApiPromise>();
-  const [rcApi, setRcApi] = useState<ApiPromise>();
-
-  const isRelayChain = useMemo(() => {
-    if (!isApiReady) {
-      return false;
-    }
-
-    return !!api.tx.stakingAhClient;
-  }, [isApiReady, api]);
-
-  const isStakingAsyncPage = useMemo(() => {
-    if (!isApiReady) {
-      return false;
-    }
-
-    return !!((api.tx.stakingAhClient) || (api.tx.staking && api.tx.stakingRcClient));
-  }, [isApiReady, api]);
-
-  const rcEndPoints = useMemo(() => {
-    if (!isApiReady) {
-      return [];
-    }
-
-    return (isRelayChain
-      ? apiEndpoint?.providers
-      : apiEndpoint?.valueRelay) || [];
-  }, [isApiReady, apiEndpoint, isRelayChain]);
-
-  const ahEndPoints: string[] = useMemo(() => {
-    if (!isApiReady) {
-      return [];
-    }
-
-    if (isRelayChain) {
-      return allEndPoints.find(({ genesisHashRelay, paraId }) =>
-        paraId === 1000 && genesisHashRelay === api.genesisHash.toHex()
-      )?.providers || [];
-    }
-
-    return apiEndpoint?.providers || [];
-  }, [isApiReady, api, apiEndpoint, isRelayChain]);
-
-  useEffect(() => {
-    if (!isApiReady) {
-      return;
-    }
-
-    if (isRelayChain) {
-      const ahUrl = ahEndPoints.at(Math.floor(Math.random() * ahEndPoints.length));
-
-      !!ahUrl && getApi(ahUrl).then(setAhApi).catch(console.error);
-    } else {
-      const rcUrl = rcEndPoints.at(Math.floor(Math.random() * rcEndPoints.length));
-
-      !!rcUrl && getApi(rcUrl).then(setRcApi).catch(console.error);
-    }
-  }, [ahEndPoints, isApiReady, isRelayChain, rcEndPoints]);
-
-  return {
-    ahApi,
-    ahEndPoints,
-    isRelayChain,
-    isStakingAsyncPage,
-    rcApi,
-    rcEndPoints
-  };
+function useStakingAsyncApisImpl (): StakingAsyncApis {
+  return useContext(StakingAsyncApisCtx);
 }
 
 export const useStakingAsyncApis = createNamedHook('useStakingAsyncApis', useStakingAsyncApisImpl);

--- a/packages/react-signer/src/index.tsx
+++ b/packages/react-signer/src/index.tsx
@@ -94,7 +94,7 @@ function Signer ({ children, className = '' }: Props): React.ReactElement<Props>
   const { t } = useTranslation();
   const { queueSetTxStatus, txqueue } = useQueue();
   const [isQueueSubmit, setIsQueueSubmit] = useState(false);
-  const { isStakingAsyncPage, rcApi } = useStakingAsyncApis();
+  const { isStakingAsync, rcApi } = useStakingAsyncApis();
 
   const { currentItem, isRpc, isVisible, queueSize, requestAddress } = useMemo(
     () => extractCurrent(txqueue),
@@ -107,14 +107,14 @@ function Signer ({ children, className = '' }: Props): React.ReactElement<Props>
 
   useEffect((): void => {
     if (isRpc && currentItem) {
-      const apiForCall = isStakingAsyncPage
+      const apiForCall = isStakingAsync
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         ? STAKING_RELAY_CHAIN_RPC.includes(`${currentItem?.rpc.section}.${currentItem?.rpc.method}`) ? (rcApi!) : api
         : api;
 
       sendRpc(apiForCall, queueSetTxStatus, currentItem).catch(console.error);
     }
-  }, [api, currentItem, isRpc, isStakingAsyncPage, queueSetTxStatus, rcApi]);
+  }, [api, currentItem, isRpc, isStakingAsync, queueSetTxStatus, rcApi]);
 
   const _onCancel = useCallback(
     (): void => {


### PR DESCRIPTION
## 📝 Description

This PR refactors the logic for connecting to the **Relay Chain** and **Asset Hub** by moving it into a dedicated **React Context Provider**. The goal is to improve **scalability**, **maintainability**, and **performance**.

## Why?

Previously, every time the `useStakingAsyncApis` hook was invoked, it triggered a new connection to the chains due to remounting behavior. This caused unnecessary overhead and repeated API connections.

## What’s Changed?

- Chain connections are now established **once** when the app mounts.
- These connections are exposed via a context provider.
- Components across the app can access the APIs without triggering reconnections or extra re-renders.

## Example Use Case

Calculating the remaining time for a **Referendum** requires the current block number from the **Relay Chain**.  
Previously, this meant reconnecting to the Relay Chain API (via the Asset Hub explorer) every time this data was needed.

With the new context-based approach:
- The Relay Chain API is already connected.
- The block number can be accessed directly from the provider.
- No repeated connection logic is necessary.

---

This results in a more efficient and cleaner way to work with chain APIs throughout the app.


<img width="1303" height="643" alt="image" src="https://github.com/user-attachments/assets/e61c9f3a-7223-4114-a131-cba03ebe79d9" />
