### PR TITLE
Added l1.media RPC for Joystream

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -363,7 +363,8 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'joystream',
     providers: {
       Joyutils: 'wss://rpc.joyutils.org',
-      Jsgenesis: 'wss://rpc.joystream.org'
+      Jsgenesis: 'wss://rpc.joystream.org',
+      'l1.media': 'wss://rpc.l1.media'
     },
     text: 'Joystream',
     ui: {


### PR DESCRIPTION
By long-term DAO contributor, current Apps lead https://dao.l1.media/#/members/515
Deployed at https://blocks.l1.media/#/explorer