### PR TITLE
Enables identity on Tanssi and Dancelight

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -634,6 +634,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   },
   {
     info: 'tanssi',
+    isPeople: true,
     providers: {
       'Tanssi Foundation': 'wss://services.tanssi-mainnet.network/tanssi'
     },

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -271,6 +271,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   },
   {
     info: 'Dancelight',
+    isPeople: true,
     providers: {
       'Tanssi Foundation': 'wss://services.tanssi-testnet.network/dancelight'
     },


### PR DESCRIPTION
This pull request adds the `isPeople: true` property to the endpoint configurations for both the Tanssi mainnet and Dancelight testnet chains.

Endpoint configuration updates:

* Added `isPeople: true` to the Tanssi mainnet entry in `prodChains` within `production.ts`
* Added `isPeople: true` to the Dancelight testnet entry in `testChains` within `testing.ts`