### PR TITLE
Update Labs WebSocket URL for Autonomys mainnet

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -85,7 +85,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'autonomys-mainnet',
     providers: {
       Foundation: 'wss://rpc.mainnet.subspace.foundation/ws',
-      Labs: 'wss://rpc-0.mainnet.autonomys.xyz/ws'
+      Labs: 'wss://rpc.mainnet.autonomys.xyz/ws'
     },
     text: 'Autonomys',
     ui: {


### PR DESCRIPTION
Updated Autonomys mainnet Labs endpoint to point to load balancer instead of direct rpc