### PR TITLE
Remove Permanence DAO Westend Asset Hub RPC endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -132,8 +132,8 @@ export const testParasWestendCommon: EndpointOption[] = [
       Dwellir: 'wss://asset-hub-westend-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
       // OnFinality: 'wss://westmint.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9955
-      Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
-      'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io'
+      Parity: 'wss://westend-asset-hub-rpc.polkadot.io'
+      // 'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io'
       // Stakeworld: 'wss://wnd-rpc.stakeworld.io/assethub'
     },
     relayName: 'westend',


### PR DESCRIPTION
Permanence DAO is removing Westend Asset Hub RPC nodes from its infrastructure. This PR removes the endpoint from Polkadot JS Apps.