### PR TITLE
Displayed average block time for chains in explorer page

### DIFF
--- a/packages/page-explorer/src/Summary.tsx
+++ b/packages/page-explorer/src/Summary.tsx
@@ -5,7 +5,7 @@ import type { AugmentedBlockHeader } from '@polkadot/react-hooks/ctx/types';
 
 import React from 'react';
 
-import { CardSummary, styled, SummaryBox } from '@polkadot/react-components';
+import { CardSummary, Icon, styled, SummaryBox, Tooltip } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { BestFinalized, BestNumber, TimeNow, TotalInactive, TotalIssuance } from '@polkadot/react-query';
 import { formatNumber } from '@polkadot/util';
@@ -35,7 +35,21 @@ function Summary ({ eventCount, headers }: Props): React.ReactElement {
             </CardSummary>
             <CardSummary
               className='media--800 avgBlockTime'
-              label={t('average block time')}
+              label={
+                <p>
+                  {t('average block time')}
+                  <Icon
+                    icon='info-circle'
+                    isPadded
+                    tooltip='average-blocktime'
+                  />
+                  <Tooltip
+                    place='top'
+                    text={t('Average block time calculated over the last 50 blocks')}
+                    trigger='average-blocktime'
+                  />
+                </p>
+              }
             >
               <span className={`--digits ${isLoaded ? '' : '--tmp'}`}>{`${(timeAvg / 1000).toFixed(3)}`}<span className='postfix timeUnit'> s</span></span>
             </CardSummary>


### PR DESCRIPTION
## 📝 Description

Rather than showing the slot duration, we will aim to display the moving average of the last few blocks (maybe 50), and we’ll call it the average block time (This PR aims to do so), as 'slot time' might be confusing and unfamiliar to regular users.

Even though the slot time was initially decided to be kept there after this discussion: https://github.com/polkadot-js/apps/issues/11859 but the requirement has since changed.

---

<img width="1920" height="572" alt="image" src="https://github.com/user-attachments/assets/fc98b538-a4e8-4c20-8861-62ec21090ba3" />

<img width="1920" height="560" alt="image" src="https://github.com/user-attachments/assets/c91745ae-3d8b-43c9-8f19-85184cbc1634" />
