### PR TITLE
Added polkassembly link for polkadot assethub

### DIFF
--- a/packages/apps-config/src/links/polkassembly.ts
+++ b/packages/apps-config/src/links/polkassembly.ts
@@ -34,6 +34,7 @@ export const PolkassemblyIo: ExternalDef = {
     'Pioneer Network': 'pioneer',
     'Polkadex Main Network': 'polkadex',
     Polkadot: 'polkadot',
+    'Polkadot Asset Hub': 'polkadot',
     Robonomics: 'robonomics',
     Rococo: 'rococo',
     Shibuya: 'shibuya',


### PR DESCRIPTION
Added polkassembly link for polkadot assethub

---

<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/2b3a7e22-e1f4-4fb2-8b57-c9bed928fb9d" />
