### PR TITLE
fix: Preserve chain colors when WS_URL matches existing endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TFunction } from '../types.js';
-import type { LinkOption } from './types.js';
+import type { EndpointOption, LinkOption } from './types.js';
 
 export const CUSTOM_ENDPOINT_KEY = 'polkadot-app-custom-endpoints';
 
@@ -13,30 +13,59 @@ interface EnvWindow {
   }
 }
 
-export function createCustom (t: TFunction): LinkOption[] {
+function findUiForUrl (url: string, endpoints: EndpointOption[]): LinkOption['ui'] {
+  // Search through all endpoints to find a matching provider URL
+  for (const endpoint of endpoints) {
+    if (endpoint.providers) {
+      for (const providerUrl of Object.values(endpoint.providers)) {
+        if (providerUrl === url) {
+          return endpoint.ui;
+        }
+      }
+    }
+
+    // Also check linked endpoints (parachains)
+    if (endpoint.linked) {
+      const linkedUi = findUiForUrl(url, endpoint.linked);
+
+      if (linkedUi && (linkedUi.color || linkedUi.logo || linkedUi.identityIcon)) {
+        return linkedUi;
+      }
+    }
+  }
+
+  return {};
+}
+
+export function createCustom (t: TFunction, endpoints: EndpointOption[] = []): LinkOption[] {
   const WS_URL = (
     (typeof process !== 'undefined' ? process.env?.WS_URL : undefined) ||
     (typeof window !== 'undefined' ? (window as EnvWindow).process_env?.WS_URL : undefined)
   );
 
-  return WS_URL
-    ? [
-      {
-        isHeader: true,
-        text: t('rpc.dev.custom', 'Custom environment', { ns: 'apps-config' }),
-        textBy: '',
-        ui: {},
-        value: ''
-      },
-      {
-        info: 'WS_URL',
-        text: t('rpc.dev.custom.entry', 'Custom {{WS_URL}}', { ns: 'apps-config', replace: { WS_URL } }),
-        textBy: WS_URL,
-        ui: {},
-        value: WS_URL
-      }
-    ]
-    : [];
+  if (!WS_URL) {
+    return [];
+  }
+
+  // Try to find UI configuration from existing endpoint with matching URL
+  const ui = findUiForUrl(WS_URL, endpoints);
+
+  return [
+    {
+      isHeader: true,
+      text: t('rpc.dev.custom', 'Custom environment', { ns: 'apps-config' }),
+      textBy: '',
+      ui: {},
+      value: ''
+    },
+    {
+      info: 'WS_URL',
+      text: t('rpc.dev.custom.entry', 'Custom {{WS_URL}}', { ns: 'apps-config', replace: { WS_URL } }),
+      textBy: WS_URL,
+      ui,
+      value: WS_URL
+    }
+  ];
 }
 
 export function createOwn (t: TFunction): LinkOption[] {

--- a/packages/apps-config/src/endpoints/index.ts
+++ b/packages/apps-config/src/endpoints/index.ts
@@ -23,8 +23,18 @@ function defaultT (keyOrText: string, text?: string | TOptions, options?: TOptio
 }
 
 export function createWsEndpoints (t: TFunction = defaultT, firstOnly = false, withSort = true): LinkOption[] {
+  // Collect all endpoint configs to pass to createCustom for UI lookup
+  const allEndpoints = [
+    prodRelayPolkadot,
+    prodRelayKusama,
+    testRelayWestend,
+    testRelayPaseo,
+    ...prodChains,
+    ...testChains
+  ];
+
   return [
-    ...createCustom(t),
+    ...createCustom(t, allEndpoints),
     {
       isDisabled: false,
       isHeader: true,


### PR DESCRIPTION
fixes https://github.com/polkadot-js/apps/issues/9431

## Problem
When `WS_URL` was set to an endpoint that already existed in the config, it created a duplicate entry with empty `ui: {}`, causing incorrect colors to display (orange instead of url endpoint color).

## Solution
The custom endpoint now inherits the `ui` property from any matching endpoint configuration, preserving the correct chain colors and branding. Tested and confirmed using the Westend Asset Hub URL; it works as expected.

## Preview
<img width="1466" height="691" alt="Screenshot 2025-11-21 at 4 31 27 PM" src="https://github.com/user-attachments/assets/d933ca6f-0263-4507-a8e0-958576fe241d" />
