### PR TITLE
Replace `toHuman()` with `toBoolArray()` for availability votes (Parachains Page)

### DIFF
--- a/packages/page-parachains/src/Overview/Parachain.tsx
+++ b/packages/page-parachains/src/Overview/Parachain.tsx
@@ -74,12 +74,9 @@ function Parachain ({ bestNumber, className = '', id, lastBacked, lastInclusion,
   useEffect((): void => {
     if (sessionValidators) {
       if (paraInfo.pendingAvail) {
-        const list = paraInfo.pendingAvail.availabilityVotes.toHuman()
-          .slice(2)
-          .replace(/_/g, '')
-          .split('')
-          .map((c, index) => c === '0' ? sessionValidators[index] : null)
-          .filter((v, index): v is AccountId => !!v && index < sessionValidators.length);
+        const list = paraInfo.pendingAvail.availabilityVotes.toBoolArray()
+          .map((voted, index) => !voted && index < sessionValidators.length ? sessionValidators[index] : null)
+          .filter((v): v is AccountId => !!v);
 
         list.length !== sessionValidators.length && setNonBacked(list);
       } else {


### PR DESCRIPTION
fixes https://github.com/polkadot-js/apps/issues/9315

## Description
Refactor parachain availability votes processing to use `toBoolArray()` instead of `toHuman()` string manipulation.