### PR TITLE
Keep Sidebar Buttons outside the scrollable content

### DIFF
--- a/packages/apps/src/Endpoints/index.tsx
+++ b/packages/apps/src/Endpoints/index.tsx
@@ -424,7 +424,6 @@ function Endpoints ({ className = '', offset, onClose }: Props): React.ReactElem
 
 const StyledSidebar = styled(Sidebar)`
   color: var(--color-text);
-  padding-top: 3.5rem;
 
   .customButton {
     position: absolute;

--- a/packages/react-components/src/Sidebar.tsx
+++ b/packages/react-components/src/Sidebar.tsx
@@ -34,7 +34,9 @@ function Sidebar ({ buttons, children, className = '', dataTestId = '', onClose,
           onClick={onClose}
         />
       </Button.Group>
-      {children}
+      <div className='ui--Sidebar-children'>
+        {children}
+      </div>
     </StyledDiv>
   );
 }
@@ -46,10 +48,10 @@ const StyledDiv = styled.div`
   max-width: 24rem;
   min-width: 24rem;
   position: fixed;
-  padding: 1rem;
-  overflow-y: auto;
   top: 0;
   z-index: 999;
+  display: flex;
+  flex-direction: column;
 
   &.leftPosition {
     box-shadow: 6px 0px 20px 0px rgba(0, 0, 0, 0.3);
@@ -63,9 +65,20 @@ const StyledDiv = styled.div`
 
   .ui--Sidebar-buttons {
     margin: 0;
-    position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
+    padding: .75rem 1rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    flex-shrink: 0;
+  }
+
+  .ui--Sidebar-children {
+    padding: 0 1rem;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+    padding-bottom: 4rem;
   }
 `;
 


### PR DESCRIPTION
uses flex column layout with dedicated scrollable area just for chains and keeping the header visible at the top for easy access of the actual controls available in the sidebar.

Before:

https://github.com/user-attachments/assets/ffc7d98e-abad-467d-9f03-f12aa744f306

After:

https://github.com/user-attachments/assets/e6b7c884-4cfb-4331-a035-a4d71a0d0fdc

