### PR TITLE
fix: disable ASCII decoding for binary data in chain state display

### DIFF
--- a/packages/page-storage/src/Query.tsx
+++ b/packages/page-storage/src/Query.tsx
@@ -131,7 +131,7 @@ function getCachedComponent (registry: Registry, query: QueryTypes): CacheInstan
     const defaultProps = { className: 'ui--output' };
     const Component = renderHelper(
       // By default we render a simple div node component with the query results in it
-      (value: unknown) => <pre>{valueToText(type, value as null)}</pre>,
+      (value: unknown) => <pre>{valueToText(type, value as null, undefined, true)}</pre>,
       defaultProps
     );
 

--- a/packages/react-params/src/valueToText.tsx
+++ b/packages/react-params/src/valueToText.tsx
@@ -33,12 +33,12 @@ function formatKeys (keys: [ValidatorId, Keys][]): string {
   );
 }
 
-function toHuman (value: Codec | Codec[]): unknown {
+function toHuman (value: Codec | Codec[], isExtended?: boolean, disableAscii?: boolean): unknown {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   return isFunction((value as Codec).toHuman)
-    ? (value as Codec).toHuman()
+    ? (value as Codec).toHuman(isExtended, disableAscii)
     : Array.isArray(value)
-      ? value.map((v) => toHuman(v))
+      ? value.map((v) => toHuman(v, isExtended, disableAscii))
       : value.toString();
 }
 
@@ -50,7 +50,7 @@ export function toHumanJson (value: unknown): string {
     .replace(/\],\[/g, '],\n[');
 }
 
-export default function valueToText (type: string, value: Codec | undefined | null): React.ReactNode {
+export default function valueToText (type: string, value: Codec | undefined | null, isExtended?: boolean, disableAscii?: boolean): React.ReactNode {
   if (isNull(value) || isUndefined(value)) {
     const { cName, key, values } = div({}, '<unknown>');
 
@@ -78,7 +78,7 @@ export default function valueToText (type: string, value: Codec | undefined | nu
             : value.toString()
           : (value instanceof Option) && value.isNone
             ? '<none>'
-            : toHumanJson(toHuman(value))
+            : toHumanJson(toHuman(value, isExtended, disableAscii))
   );
 
   const { cName, key, values } = div({}, renderedValue);


### PR DESCRIPTION
fixes https://github.com/polkadot-js/apps/issues/10343

## Problem
Core masks in chain state queries were being incorrectly decoded as UTF-8 text, causing them to display as random characters (e.g., `@@@@@@@@@@`,`UUUUUUUUUU`, or whitespace) instead of their proper hexadecimal representation. This occurred when binary values happened to form valid UTF-8 byte sequences, making the data unreadable while inspecting `broker.regions`.

### Solution
Added optional `disableAscii` and `isExtended` parameters to `valueToText()` to control UTF-8 decoding behavior. Storage queries now explicitly pass `disableAscii: true` to prevent automatic text conversion, ensuring binary data is consistently rendered as hexadecimal. This leverages the `disableAscii` option from the underlying codec's `toHuman()` method, originally added in polkadot-js/api#5831.

## Preview
### Before (showing UTF-8 decoded text)
<img width="1666" height="914" alt="image" src="https://github.com/user-attachments/assets/dd6b6bee-54a7-4344-ade3-6cff9d1878b1" />

### After fix (showing proper hex values)
<img width="1671" height="944" alt="Screenshot 2025-11-26 at 1 35 10 PM" src="https://github.com/user-attachments/assets/631f3d6e-146b-45bc-b7ee-b14ea3573a8e" />

