### PR TITLE
Added column header for 'inclusion delay' with tooltip on parachains page

### DIFF
--- a/packages/page-parachains/src/Overview/Parachains.tsx
+++ b/packages/page-parachains/src/Overview/Parachains.tsx
@@ -6,7 +6,7 @@ import type { LeasePeriod, QueuedAction, ScheduledProposals } from '../types.js'
 
 import React, { useMemo, useRef } from 'react';
 
-import { Table } from '@polkadot/react-components';
+import { Icon, Table, Tooltip } from '@polkadot/react-components';
 import { useBestNumber, useIsParasLinked } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate.js';
@@ -63,8 +63,24 @@ function Parachains ({ actionsQueue, ids, leasePeriod, scheduled }: Props): Reac
     ['', 'media--1400'],
     [t('head'), 'start media--1500'],
     [t('lifecycle'), 'start'],
-    [],
-    [t('included'), undefined, 2],
+    [
+      <>
+        {t('inclusion delay')}
+        <Icon
+          icon='info-circle'
+          isPadded
+          tooltip='inclusion-delay-info'
+        />
+        <Tooltip
+          place='top'
+          text={t('Time since this parachain was last included in a relay chain block')}
+          trigger='inclusion-delay-info'
+        />
+      </>,
+      undefined,
+      2
+    ],
+    [t('included'), 'no-pad-left'],
     [t('backed'), 'no-pad-left media--900'],
     [t('timeout'), 'no-pad-left media--1600'],
     [t('chain'), 'no-pad-left'],


### PR DESCRIPTION
fixes https://github.com/polkadot-js/apps/issues/10182

## Description
Added an "inclusion delay" column header with a tooltip to clarify that the metric shows the time since the parachain was last included in a relay chain block, not the parachain's own block production time.

This addresses user confusion where the timing metric was being misinterpreted as the parachain's block time.

### Preview
<img width="1457" height="757" alt="Screenshot 2025-11-26 at 5 35 02 PM" src="https://github.com/user-attachments/assets/bc9fe302-302a-44a4-a3d3-358e02e15271" />
