### PR TITLE
Add Permanence DAO EU Polkadot Asset Hub RPC endpoint.

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -874,6 +874,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
+      'Permanence DAO EU': 'wss://asset-hub-polkadot.rpc.permanence.io',
       RadiumBlock: 'wss://statemint.public.curie.radiumblock.co/ws',
       Stakeworld: 'wss://dot-rpc.stakeworld.io/assethub'
     },


### PR DESCRIPTION
This PR adds Permanence DAO ([X](https://x.com/PermanenceDAO), [web](https://permanence.io/)) public RPC endpoint for Polkadot Asset Hub.

RPC endpoints are load balanced with two archive nodes, running on servers in Germany and Poland. Services are monitored 24/7 at software (node), hardware (disk, CPU, memory) and network level.

Thanks.