### PR TITLE
Remove IBP endpoints for Mythos

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -550,8 +550,6 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 3369,
     providers: {
       Helikon: 'wss://rpc.helikon.io/mythos',
-      IBP1: 'wss://mythos.ibp.network',
-      IBP2: 'wss://mythos.dotters.network',
       parity: 'wss://polkadot-mythos-rpc.polkadot.io'
     },
     text: 'Mythos',


### PR DESCRIPTION
Dear team, 

Please consider the following pull request to remove the `mythos` endpoints served by the Infrastructure Builders' Programme (IBP).

The reasoning for this request is that the Mythos project is no longer eligible to be supported by the IBP.

Many thanks!!

Best regards

**_Milos_**