### PR TITLE
Derive proxy type name from `addProxy` call arguments

### DIFF
--- a/packages/page-accounts/src/modals/ProxyOverview.tsx
+++ b/packages/page-accounts/src/modals/ProxyOverview.tsx
@@ -148,8 +148,12 @@ function NewProxy ({ index, onChangeAccount, onChangeType, onRemove, proxiedAcco
 }
 
 function getProxyTypeInstance (api: ApiPromise, index = 0): KitchensinkRuntimeProxyType {
-  // This is not perfect, but should work for `{Kusama, Node, Polkadot}RuntimeProxyType`
-  const proxyNames = api.registry.lookup.names.filter((name) => name.endsWith('RuntimeProxyType'));
+  // This is not perfect, but should work for most chains coz thier type ends with ProxyType`
+  // const proxyNames = api.registry.lookup.names.filter((name) => name.endsWith('ProxyType'));
+
+  // Better: derive the type name directly from the args of the addProxy call.
+  // This works consistently across Polkadot SDK chains.
+  const proxyNames = [api.tx.proxy.addProxy.meta.args[1].type.toString()];
 
   // fallback to previous version (may be Substrate default), when not found
   return api.createType<KitchensinkRuntimeProxyType>(proxyNames.length ? proxyNames[0] : 'ProxyType', index);


### PR DESCRIPTION
## 📝 Description

Previously, the UI attempted to detect all available proxy types using the logic implemented [here](https://github.com/polkadot-js/apps/blob/master/packages/page-accounts/src/modals/ProxyOverview.tsx#L152). However, on **Bittensor**, the proxy type ends with `RuntimeCommonProxyType` instead of `RuntimeProxyType`, causing the UI to miss some proxy types.

Additionally, not all proxy types were being populated for **Kusama** and **Polkadot Relay** networks.

This PR updates the detection logic to correctly infer available proxy types across different chains and prevents these inconsistencies going forward.

---

https://github.com/user-attachments/assets/2f9d05d0-c249-46f2-83b3-5350c0cea3d7