### PR TITLE
Remove Helikon RPC endpoint for Mythos.

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -549,7 +549,6 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'mythos',
     paraId: 3369,
     providers: {
-      Helikon: 'wss://rpc.helikon.io/mythos',
       parity: 'wss://polkadot-mythos-rpc.polkadot.io'
     },
     text: 'Mythos',


### PR DESCRIPTION
This PR removes the Helikon RPC endpoint for the Mythos Polkadot parachain.