### PR TITLE
update xcavate endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -428,7 +428,7 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'Xcavate',
     paraId: 4683,
     providers: {
-       Xcavate: 'wss://rpc2-paseo.xcavate.io'
+      Xcavate: 'wss://rpc2-paseo.xcavate.io'
     },
     text: 'Xcavate',
     ui: {


### PR DESCRIPTION
Unavailable xcavate chain endpoints due to [link](https://github.com/polkadot-js/apps/issues/12007)
We'd like to update now.

Thank you.