### PR TITLE
fix: use asMulti for first multisig approval to store call data

### DIFF
--- a/packages/react-signer/src/TxSigned.tsx
+++ b/packages/react-signer/src/TxSigned.tsx
@@ -173,7 +173,11 @@ async function wrapTx (api: ApiPromise, currentItem: QueueTx, { isMultiCall, mul
       timepoint = info.unwrap().when;
     }
 
-    tx = isMultiCall
+    // Check if this is the first approval (no existing multisig)
+    const isFirstApproval = info.isNone;
+    const shouldUseAsMulti = isFirstApproval || isMultiCall;
+
+    tx = shouldUseAsMulti
       ? api.tx[multiModule].asMulti.meta.args.length === 5
         // We are doing toHex here since we have a Vec<u8> input
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
fixes #12042 

## Problem
Multisig transactions created via `Developer > Extrinsics` fail to commit call data on-chain.

### Root Cause
The first signatory incorrectly uses `multisig.approveAsMulti` instead of `multisig.asMulti`.

This happens because `isMultiCall` is hardcoded to [false](https://github.com/polkadot-js/apps/blob/30b1a50adb0cf62809280747023e386b38e17ba9/packages/react-signer/src/Address.tsx#L167) for new multisigs (when `info.isNone`), causing the wrong extrinsic to be selected:
- `approveAsMulti`: Only passes call hash (no data stored)
- `asMulti`: Passes full call data (stores on-chain)

## Solution
Detect first approval explicitly using `info.isNone` and use `asMulti` for first approval to ensure call data is stored while keeping the same flow to for intermediate approvals (`approveAsMulti`).

## Testing
Tested using the flow described in [issue #12042](https://github.com/polkadot-js/apps/issues/12042) with Chopsticks environment:
1. Created accounts A, B, and C
2. Created multisig M with signatories A and B
3. Created proxy P for account C
4. Submitted extrinsic from proxy P using multisig M with the [provided calldata](https://github.com/polkadot-js/apps/issues/12042#issuecomment-3625775764)
5. First signatory A now correctly calls `asMulti` instead of `approveAsMulti`, storing call data on-chain
6. Subsequent approvals work without requiring manual call data input