### PR TITLE
Fix handling of v1 weights for historical blocks

### DIFF
--- a/packages/page-explorer/src/BlockInfo/Summary.tsx
+++ b/packages/page-explorer/src/BlockInfo/Summary.tsx
@@ -30,9 +30,20 @@ function accumulateWeights (
   const totalRefTime = new BN(0);
   const totalProofSize = new BN(0);
 
+  if (!weight) {
+    return { totalProofSize, totalRefTime };
+  }
+
   (['normal', 'operational', 'mandatory'] as const).forEach((cls) => {
-    totalRefTime.iadd(weight?.[cls].refTime.toBn() ?? new BN(0));
-    totalProofSize.iadd(weight?.[cls].proofSize.toBn() ?? new BN(0));
+    const classWeight = weight[cls];
+
+    if (classWeight) {
+      // convertWeight handles both V1 and V2 weights
+      const { v2Weight } = convertWeight(classWeight as V2Weight);
+
+      totalRefTime.iadd(isBn(v2Weight.refTime) ? v2Weight.refTime : v2Weight.refTime.toBn());
+      totalProofSize.iadd(isBn(v2Weight.proofSize) ? v2Weight.proofSize : v2Weight.proofSize.toBn());
+    }
   });
 
   return { totalProofSize, totalRefTime };

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -216,7 +216,7 @@ export interface Preimage extends PreimageBytes, PreimageStatus {
 
 export interface V2WeightConstruct {
   refTime: BN | ICompact<INumber>;
-  proofSize?: BN | ICompact<INumber>;
+  proofSize: BN | ICompact<INumber>;
 }
 
 export interface WeightResult {

--- a/packages/react-hooks/src/useTxBatch.ts
+++ b/packages/react-hooks/src/useTxBatch.ts
@@ -32,13 +32,11 @@ interface Known {
 // converts a weight construct to only contain BN values
 function bnWeight (a: WeightSimple): BNWeight {
   return {
-    proofSize: a.proofSize
-      ? bnToBn(
-        isCompact(a.proofSize)
-          ? a.proofSize.unwrap()
-          : a.proofSize
-      )
-      : BN_ZERO,
+    proofSize: bnToBn(
+      isCompact(a.proofSize)
+        ? a.proofSize.unwrap()
+        : a.proofSize
+    ),
     refTime: bnToBn(
       isCompact(a.refTime)
         ? a.refTime.unwrap()

--- a/packages/react-hooks/src/useWeight.ts
+++ b/packages/react-hooks/src/useWeight.ts
@@ -33,7 +33,7 @@ export const ZERO_ACCOUNT = '0x9876543210abcdef9876543210abcdef9876543210abcdef9
 const EMPTY_STATE: Partial<Result> = {
   encodedCallLength: 0,
   v1Weight: BN_ZERO,
-  v2Weight: { refTime: BN_ZERO },
+  v2Weight: { proofSize: BN_ZERO, refTime: BN_ZERO },
   weight: BN_ZERO
 };
 


### PR DESCRIPTION
Visiting a histroical block e.g. https://polkadot.js.org/apps/#/explorer/query/1 was throwing an error due to the legacy v1 weight. `Cannot read properties of undefined (reading 'toBn')`. This fix ensure both v1 and v2 weights are correctly handled.