### PR TITLE
 Add QF Network parachain endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -671,19 +671,6 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     }
   },
   {
-    homepage: 'https://qfnetwork.xyz',
-    info: 'qf-network',
-    paraId: 3426,
-    providers: {
-      'QF Network': 'wss://archive.para.mainnet.qfnode.net'
-    },
-    text: 'QF Network',
-    ui: {
-      color: '#2E2E5C',
-      logo: chainsQfNetworkPNG
-    }
-  },
-  {
     homepage: 'https://polkadex.trade/crowdloans',
     info: 'polkadex',
     paraId: 3363,
@@ -709,6 +696,19 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     ui: {
       color: '#7C30DD',
       logo: nodesPolkadexSVG
+    }
+  },
+  {
+    homepage: 'https://qfnetwork.xyz',
+    info: 'qf-network',
+    paraId: 3426,
+    providers: {
+      'QF Network': 'wss://archive.para.mainnet.qfnode.net'
+    },
+    text: 'QF Network',
+    ui: {
+      color: '#2E2E5C',
+      logo: chainsQfNetworkPNG
     }
   },
   {


### PR DESCRIPTION
## Summary
Adds QF Network parachain endpoint to the Polkadot & Parachains section.

## Motivation
Allows users to connect to QF Network directly from Polkadot.js Apps.

## Scope
Configuration-only change, no logic modifications.
