### PR TITLE
Add QF Mainnet endpoint

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -512,7 +512,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     providers: {
       'QF Network': 'wss://mainnet.qfnode.net'
     },
-    text: 'QF Mainnet',
+    text: 'QF Network',
     ui: {
       color: '#2E2E5C',
       logo: chainsQfNetworkPNG


### PR DESCRIPTION
### Summary
Adds QF Mainnet endpoint to the Live Networks section.

### Motivation
Allows users to connect to QF Mainnet directly from Polkadot.js Apps.

### Scope
Configuration-only change, no logic modifications.
