### PR TITLE
Remove IBP endpoints for `kilt` on Polkadot

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -443,8 +443,6 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'kilt',
     paraId: 2086,
     providers: {
-      IBP1: 'wss://kilt.ibp.network',
-      IBP2: 'wss://kilt.dotters.network'
       // 'KILT Foundation': 'wss://spiritnet.kilt.io/' // https://github.com/polkadot-js/apps/issues/12076
     },
     text: 'KILT Spiritnet',


### PR DESCRIPTION
Dear team, 

Please consider this PR to remove IBP endpoints foe the `kilt` parachain in Polkadot.

Reasoning for this request is that Kilt is no longer eligible to receive RPC endpoint support from the Infrastructure Builders' Programme.

Many thanks!!

Best regards

**_Milos_**