### PR TITLE
Maintenance of IBP endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -868,7 +868,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://asset-hub-kusama-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/asset-hub-kusama',
+      IBP1: 'wss://asset-hub-kusama.ibp.network',
       IBP2: 'wss://asset-hub-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
       OnFinality: 'wss://assethub-kusama.api.onfinality.io/public-ws',
@@ -891,7 +891,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://bridge-hub-kusama-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://kusama-bridge-hub-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/bridgehub-kusama',
+      IBP1: 'wss://bridge-hub-kusama.ibp.network',
       IBP2: 'wss://bridge-hub-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-bridge-hub-kusama.luckyfriday.io',
       OnFinality: 'wss://bridgehub-kusama.api.onfinality.io/public-ws',
@@ -912,7 +912,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     paraId: 1005,
     providers: {
       Dwellir: 'wss://coretime-kusama-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/coretime-kusama',
+      IBP1: 'wss://coretime-kusama.ibp.network',
       IBP2: 'wss://coretime-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-coretime-kusama.luckyfriday.io',
       OnFinality: 'wss://coretime-kusama.api.onfinality.io/public-ws',
@@ -935,7 +935,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://encointer-kusama-rpc.n.dwellir.com',
       'Encointer Association': 'wss://kusama.api.encointer.org',
-      IBP1: 'wss://sys.ibp.network/encointer-kusama',
+      IBP1: 'wss://encointer-kusama.ibp.network',
       IBP2: 'wss://encointer-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-encointer-kusama.luckyfriday.io'
       // OnFinality: 'wss://encointer.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9986
@@ -957,7 +957,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://people-kusama-rpc.n.dwellir.com',
       Helixstreet: 'wss://rpc-people-kusama.helixstreet.io',
-      IBP1: 'wss://sys.ibp.network/people-kusama',
+      IBP1: 'wss://people-kusama.ibp.network',
       IBP2: 'wss://people-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-people-kusama.luckyfriday.io',
       OnFinality: 'wss://people-kusama.api.onfinality.io/public-ws',
@@ -991,7 +991,7 @@ export const prodRelayKusama: EndpointOption = {
     Dwellir: 'wss://kusama-rpc.n.dwellir.com',
     'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
     Helixstreet: 'wss://rpc-kusama.helixstreet.io',
-    IBP1: 'wss://rpc.ibp.network/kusama',
+    IBP1: 'wss://kusama.ibp.network',
     IBP2: 'wss://kusama.dotters.network',
     LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',
     OnFinality: 'wss://kusama.api.onfinality.io/public-ws',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -862,7 +862,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
+      IBP1: 'wss://asset-hub-polkadot.ibp.network',
       IBP2: 'wss://asset-hub-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
@@ -886,7 +886,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://bridge-hub-polkadot-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://polkadot-bridge-hub-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/bridgehub-polkadot',
+      IBP1: 'wss://bridge-hub-polkadot.ibp.network',
       IBP2: 'wss://bridge-hub-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-bridge-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://bridgehub-polkadot.api.onfinality.io/public-ws',
@@ -908,7 +908,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://collectives-polkadot-rpc.n.dwellir.com',
       'Dwellir Tunisia': 'wss://polkadot-collectives-rpc-tn.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/collectives-polkadot',
+      IBP1: 'wss://collectives-polkadot.ibp.network',
       IBP2: 'wss://collectives-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-collectives-polkadot.luckyfriday.io',
       OnFinality: 'wss://collectives.api.onfinality.io/public-ws',
@@ -930,7 +930,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1005,
     providers: {
       Dwellir: 'wss://coretime-polkadot-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/coretime-polkadot',
+      IBP1: 'wss://coretime-polkadot.ibp.network',
       IBP2: 'wss://coretime-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-coretime-polkadot.luckyfriday.io',
       OnFinality: 'wss://coretime-polkadot.api.onfinality.io/public-ws',
@@ -949,7 +949,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1004,
     providers: {
       Dwellir: 'wss://people-polkadot-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/people-polkadot',
+      IBP1: 'wss://people-polkadot.ibp.network',
       IBP2: 'wss://people-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
       OnFinality: 'wss://people-polkadot.api.onfinality.io/public-ws',
@@ -984,7 +984,7 @@ export const prodRelayPolkadot: EndpointOption = {
     Dwellir: 'wss://polkadot-rpc.n.dwellir.com',
     'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
     Helixstreet: 'wss://rpc-polkadot.helixstreet.io',
-    IBP1: 'wss://rpc.ibp.network/polkadot',
+    IBP1: 'wss://polkadot.ibp.network',
     IBP2: 'wss://polkadot.dotters.network',
     LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -472,7 +472,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     paraId: 1000,
     providers: {
       Dwellir: 'wss://asset-hub-paseo-rpc.n.dwellir.com',
-      IBP1: 'wss://sys.ibp.network/asset-hub-paseo',
+      IBP1: 'wss://asset-hub-paseo.ibp.network',
       IBP2: 'wss://asset-hub-paseo.dotters.network',
       // StakeWorld: 'wss://rpc-assethub-paseo.stakeworld.io',
       TurboFlakes: 'wss://sys.turboflakes.io/asset-hub-paseo'
@@ -490,7 +490,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     isPeopleForIdentity: true,
     paraId: 1002,
     providers: {
-      IBP1: 'wss://sys.ibp.network/bridgehub-paseo',
+      IBP1: 'wss://bridge-hub-paseo.ibp.network',
       IBP2: 'wss://bridge-hub-paseo.dotters.network'
     },
     relayName: 'paseo',
@@ -506,7 +506,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     isPeopleForIdentity: true,
     paraId: 1001,
     providers: {
-      IBP1: 'wss://collectives-paseo.rpc.amforc.com',
+      IBP1: 'wss://collectives-paseo.ibp.network',
       IBP2: 'wss://collectives-paseo.dotters.network'
     },
     relayName: 'paseo',
@@ -522,7 +522,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     isPeopleForIdentity: true,
     paraId: 1005,
     providers: {
-      IBP1: 'wss://sys.ibp.network/coretime-paseo',
+      IBP1: 'wss://coretime-paseo.ibp.network',
       IBP2: 'wss://coretime-paseo.dotters.network'
       // ParaNodes: 'wss://paseo-coretime.paranodes.io', // https://github.com/polkadot-js/apps/issues/11587
     },
@@ -558,7 +558,7 @@ export const testParasPaseoCommon: EndpointOption[] = [
     paraId: 1004,
     providers: {
       Amforc: 'wss://people-paseo.rpc.amforc.com',
-      IBP1: 'wss://sys.ibp.network/people-paseo',
+      IBP1: 'wss://people-paseo.ibp.network',
       IBP2: 'wss://people-paseo.dotters.network'
     },
     relayName: 'paseo',
@@ -584,7 +584,7 @@ export const testRelayPaseo: EndpointOption = {
   providers: {
     Amforc: 'wss://paseo.rpc.amforc.com',
     Dwellir: 'wss://paseo-rpc.n.dwellir.com',
-    IBP1: 'wss://rpc.ibp.network/paseo',
+    IBP1: 'wss://paseo.ibp.network',
     IBP2: 'wss://paseo.dotters.network'
     // StakeWorld: 'wss://rpc-paseo.stakeworld.io'
     // Zondax: 'wss://api2.zondax.ch/pas/node/rpc' // https://github.com/polkadot-js/apps/issues/11199


### PR DESCRIPTION
Dear team, hello, 

This is a request for the maintenance of RPC endpoints provided by the Infrastructure Builders Programme (IBP).

It mainly upgrades the endpoints named "IBP1" to subdomains (e.g. `polkadot.ibp.network`, instead of paths: `rpc.ibp.network/polkadot`) in order to better monitor each of these endpoints individually via the `/health/readiness` procedure.

It also includes the removal of support to `xcavate` parachain, which no longer meet the requirements for this support.

Many thanks!! best regards...

**_Milos_**