### PR TITLE
Fix: Show referenda approval/support curves on Kusama, Paseo & Westend (no more blank charts)

### DIFF
--- a/packages/page-referenda/src/useTracks.ts
+++ b/packages/page-referenda/src/useTracks.ts
@@ -16,7 +16,7 @@ const zeroGraph = { approval: [BN_ZERO], support: [BN_ZERO], x: [BN_ZERO] };
 
 function expandTracks (tracks: [BN, PalletReferendaTrackDetails][]): TrackDescription[] {
   return tracks.map(([id, info]) => ({
-    graph: info.decisionDeposit && info.minApproval && info.minSupport ? calcCurves(info) : zeroGraph,
+    graph: info.decisionPeriod && info.minApproval && info.minSupport ? calcCurves(info) : zeroGraph,
     id,
     info
   }));


### PR DESCRIPTION
### Summary
Approval and support curves were not rendered for referenda on Kusama (and similarly on Paseo and Westend), while they appeared correctly on Polkadot. This PR fixes that by gating curve calculation on the fields that are actually used for the curves instead of decisionDeposit.
Fixes #https://github.com/polkadot-js/apps/issues/12155

### Root cause
Curve data is computed in expandTracks() in useTracks.ts. The condition for calling calcCurves(info) was:
```
info.decisionDeposit && info.minApproval && info.minSupport
```

- calcCurves() (in util.ts) only uses decisionPeriod, minApproval, and minSupport from the track. It does not use decisionDeposit.

- On chains like Kusama, some tracks have decisionDeposit set to 0. In JavaScript, 0 is falsy, so the condition failed and the code fell back to zeroGraph, which produces no visible curves.

- Polkadot tracks often have a non-zero decisionDeposit, so the condition passed there and curves were shown.

So the bug was: we required a field that isn’t used for the curves (decisionDeposit) and that can be zero on some chains, which hid the curves on those chains.


### Change
File: packages/page-referenda/src/useTracks.ts
**Before:**
```
graph: info.decisionDeposit && info.minApproval && info.minSupport ? calcCurves(info) : zeroGraph,
```

**After:**
```
graph: info.decisionPeriod && info.minApproval && info.minSupport ? calcCurves(info) : zeroGraph,
```
<img width="1512" height="982" alt="Screenshot 2026-02-15 at 10 25 06 PM" src="https://github.com/user-attachments/assets/6bcdd85b-ae3d-4cd3-951a-bcb201d1b287" />


We now require exactly the three fields that calcCurves() uses and that come from the Referenda.Tracks runtime constant:

- decisionPeriod – used for the time axis and curve math.

- minApproval – approval curve

- minSupport – support curve

We no longer require decisionDeposit, so tracks with zero decision deposit (e.g. on Kusama) still get curves when they have valid decisionPeriod, minApproval, and minSupport.