### PR TITLE
Remove PAsset Hub from Paseo

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -547,23 +547,6 @@ export const testParasPaseoCommon: EndpointOption[] = [
     }
   },
   {
-    info: 'PAssetHub - Contracts',
-    isPeopleForIdentity: true,
-    paraId: 1111,
-    providers: {
-      IBP1: 'wss://passet-hub-paseo.ibp.network',
-      IBP2: 'wss://passet-hub-paseo.dotters.network',
-      Parity: 'wss://testnet-passet-hub.polkadot.io'
-    },
-    relayName: 'paseo',
-    teleport: [-1, 1000],
-    text: 'PAssetHub - Contracts',
-    ui: {
-      color: '#77bb77',
-      logo: nodesAssetHubSVG
-    }
-  },
-  {
     info: 'PaseoPeopleChain',
     isPeople: true,
     isPeopleForIdentity: false,


### PR DESCRIPTION
PAsset Hub was deprecated on 2026/02/18. As the chain's collators are permanently shut down, the PR removes its mention from Polkadot JS. 