### PR TITLE
Pin axios to safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,9 @@
     "@polkadot/x-textencoder": "^13.5.9",
     "@polkadot/x-ws": "^13.5.9",
     "@zondax/ledger-substrate": "1.1.1",
-    "axios": "1.9.0",
+    "@pinata/sdk/axios": "0.21.4",
+    "@polkadot/app-files/axios": "1.9.0",
+    "@zondax/ledger-substrate/axios": "1.9.0",
     "typescript": "^5.5.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,7 +2959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:7.5.3, @polkadot/wasm-util@npm:^7.5.3":
+"@polkadot/wasm-util@npm:7.5.3, @polkadot/wasm-util@npm:^7.4.1, @polkadot/wasm-util@npm:^7.5.3":
   version: 7.5.3
   resolution: "@polkadot/wasm-util@npm:7.5.3"
   dependencies:
@@ -2967,17 +2967,6 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: 10/82c2149c7db0c9cc566aea6caad51e6048d1ee6b9bb7ac06f59c3c28bb94f0d0678f6ee4e51becd241105ba37a6d9e30653f74d630d1bc685ceb18b601f9acda
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-util@npm:^7.4.1":
-  version: 7.5.1
-  resolution: "@polkadot/wasm-util@npm:7.5.1"
-  dependencies:
-    tslib: "npm:^2.7.0"
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: 10/7e96be99a275f6e4a68b92b6439b70aa7d80f1209031d4f7e7f7c00dee65272aabaaee43ec153c969a72a02792c2bf271e266bccd60e83e9a1450c5c5e7b06ee
   languageName: node
   linkType: hard
 
@@ -5552,6 +5541,15 @@ __metadata:
   version: 1.11.0
   resolution: "aws4@npm:1.11.0"
   checksum: 10/54886f07b3f9555f7f3ae9fb2aef7abbac302e892263ec4d9901f4502e667bb302a0639672f6bc8453033102ddd2512b79886a7de417dc0c24ecce003a888297
+  languageName: node
+  linkType: hard
+
+"axios@npm:0.21.4":
+  version: 0.21.4
+  resolution: "axios@npm:0.21.4"
+  dependencies:
+    follow-redirects: "npm:^1.14.0"
+  checksum: 10/da644592cb6f8f9f8c64fdabd7e1396d6769d7a4c1ea5f8ae8beb5c2eb90a823e3a574352b0b934ac62edc762c0f52647753dc54f7d07279127a7e5c4cd20272
   languageName: node
   linkType: hard
 
@@ -9488,13 +9486,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.6":
+  version: 1.15.11
+  resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/70c7612c4cab18e546e36b991bbf8009a1a41cf85354afe04b113d1117569abf760269409cb3eb842d9f7b03d62826687086b081c566ea7b1e6613cf29030bf7
+  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
~~This is really just me being proactive since the "bad" versions have already been pulled from the registry. The question is though there are multiple versions needed and if we pin to one version does it potential break the IPFS release process? (Thinking outloud)~~

^Solved, by pinning necessary versions seperately. In this case Pinata, and substrate-ledger