### PR TITLE
DNM-yet: Add VerifyMultiSignature custom signed extension for people-paseo-next

### DIFF
--- a/packages/apps-config/src/api/spec/index.ts
+++ b/packages/apps-config/src/api/spec/index.ts
@@ -96,6 +96,7 @@ import opportunity from './opportunity.js';
 import parallel from './parallel.js';
 import parami from './parami.js';
 import peaq from './peaq.js';
+import people from './people.js';
 import peerplays from './peerplays.js';
 import pendulum from './pendulum.js';
 import phoenix from './phoenix.js';
@@ -272,6 +273,7 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'peaq-node': peaq,
   'peaq-node-dev': peaq,
   'peaq-node-krest': peaq,
+  'people-paseo-next': people,
   peerplays,
   pendulum,
   'phoenix-node': phoenix,

--- a/packages/apps-config/src/api/spec/people.ts
+++ b/packages/apps-config/src/api/spec/people.ts
@@ -1,0 +1,35 @@
+// Copyright 2017-2026 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      minmax: [0, undefined],
+      types: {
+        VerifyMultiSignature: {
+          _enum: {
+            Signed: {
+              signature: 'MultiSignature',
+              account: 'AccountId'
+            },
+            Disabled: 'Null'
+          }
+        }
+      }
+    }
+  ],
+  signedExtensions: {
+    VerifyMultiSignature: {
+      extrinsic: {
+        verifySignature: 'VerifyMultiSignature'
+      },
+      payload: {}
+    }
+  }
+};
+
+export default definitions;

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -63230,6 +63230,35 @@ export const typesBundle = {
         }
       }
     },
+    "people-paseo-next": {
+      "types": [
+        {
+          "minmax": [
+            0,
+            null
+          ],
+          "types": {
+            "VerifyMultiSignature": {
+              "_enum": {
+                "Signed": {
+                  "signature": "MultiSignature",
+                  "account": "AccountId"
+                },
+                "Disabled": "Null"
+              }
+            }
+          }
+        }
+      ],
+      "signedExtensions": {
+        "VerifyMultiSignature": {
+          "extrinsic": {
+            "verifySignature": "VerifyMultiSignature"
+          },
+          "payload": {}
+        }
+      }
+    },
     "peerplays": {
       "rpc": {
         "fractionalNft": {


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/blob/129a48aa9f17a3d5ccbcb8cb4167dd505165d35f/substrate/frame/verify-signature/src/extension.rs#L43


cc: @peetzweg just PoC not sure if I match the runtime spec_name= people-paseo-next, you should be able to run my branch locally and see if it is working for you, then we can finish this PR,

but I think this TX is general and not related to the people, so it should go directly here: https://github.com/polkadot-js/api/blob/master/packages/types/src/extrinsic/signedExtensions/substrate.ts (when can do it afterwards, when we verify that it is working)