### PR TITLE
Remove Dwellir Tunisia endpoints (down since Jan 2026)

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -852,7 +852,6 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     paraId: 1000,
     providers: {
       Dwellir: 'wss://asset-hub-kusama-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
       IBP1: 'wss://asset-hub-kusama.ibp.network',
       IBP2: 'wss://asset-hub-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
@@ -875,7 +874,6 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     paraId: 1002,
     providers: {
       Dwellir: 'wss://bridge-hub-kusama-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://kusama-bridge-hub-rpc-tn.dwellir.com',
       IBP1: 'wss://bridge-hub-kusama.ibp.network',
       IBP2: 'wss://bridge-hub-kusama.dotters.network',
       LuckyFriday: 'wss://rpc-bridge-hub-kusama.luckyfriday.io',
@@ -976,7 +974,6 @@ export const prodRelayKusama: EndpointOption = {
     // 'Automata 1RPC': 'wss://1rpc.io/ksm',
     Allnodes: 'wss://kusama-rpc.publicnode.com',
     Dwellir: 'wss://kusama-rpc.n.dwellir.com',
-    'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
     Helixstreet: 'wss://rpc-kusama.helixstreet.io',
     IBP1: 'wss://kusama.ibp.network',
     IBP2: 'wss://kusama.dotters.network',

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -864,7 +864,6 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1000,
     providers: {
       Dwellir: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
       IBP1: 'wss://asset-hub-polkadot.ibp.network',
       IBP2: 'wss://asset-hub-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
@@ -887,7 +886,6 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1002,
     providers: {
       Dwellir: 'wss://bridge-hub-polkadot-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://polkadot-bridge-hub-rpc-tn.dwellir.com',
       IBP1: 'wss://bridge-hub-polkadot.ibp.network',
       IBP2: 'wss://bridge-hub-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-bridge-hub-polkadot.luckyfriday.io',
@@ -910,7 +908,6 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1001,
     providers: {
       Dwellir: 'wss://collectives-polkadot-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://polkadot-collectives-rpc-tn.dwellir.com',
       IBP1: 'wss://collectives-polkadot.ibp.network',
       IBP2: 'wss://collectives-polkadot.dotters.network',
       LuckyFriday: 'wss://rpc-collectives-polkadot.luckyfriday.io',
@@ -986,7 +983,6 @@ export const prodRelayPolkadot: EndpointOption = {
     // 'Geometry Labs': 'wss://polkadot.geometry.io/websockets', // https://github.com/polkadot-js/apps/pull/6746
     // 'Automata 1RPC': 'wss://1rpc.io/dot',
     Dwellir: 'wss://polkadot-rpc.n.dwellir.com',
-    'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
     Helixstreet: 'wss://rpc-polkadot.helixstreet.io',
     IBP1: 'wss://polkadot.ibp.network',
     IBP2: 'wss://polkadot.dotters.network',

--- a/packages/apps-config/src/endpoints/testingRelayWestend.ts
+++ b/packages/apps-config/src/endpoints/testingRelayWestend.ts
@@ -142,7 +142,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1000,
     providers: {
       Dwellir: 'wss://asset-hub-westend-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
       // OnFinality: 'wss://westmint.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9955
       Parity: 'wss://westend-asset-hub-rpc.polkadot.io'
       // 'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io'
@@ -162,7 +161,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1002,
     providers: {
       Dwellir: 'wss://bridge-hub-westend-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://westend-bridge-hub-rpc-tn.dwellir.com',
       // OnFinality: 'wss://bridgehub-westend.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9960
       Parity: 'wss://westend-bridge-hub-rpc.polkadot.io'
     },
@@ -179,7 +177,6 @@ export const testParasWestendCommon: EndpointOption[] = [
     paraId: 1001,
     providers: {
       Dwellir: 'wss://collectives-westend-rpc.n.dwellir.com',
-      'Dwellir Tunisia': 'wss://westend-collectives-rpc-tn.dwellir.com',
       Parity: 'wss://westend-collectives-rpc.polkadot.io'
     },
     relayName: 'westend',
@@ -236,7 +233,6 @@ export const testRelayWestend: EndpointOption = {
   ],
   providers: {
     Dwellir: 'wss://westend-rpc.n.dwellir.com',
-    'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
     // LuckyFriday: 'wss://rpc-westend.luckyfriday.io', // https://github.com/polkadot-js/apps/issues/10728
     OnFinality: 'wss://westend.api.onfinality.io/public-ws',
     Parity: 'wss://westend-rpc.polkadot.io',


### PR DESCRIPTION
## Summary

All `*-tn.dwellir.com` (Dwellir Tunisia) endpoints have been unreachable for **3+ months**, confirmed by continuous nightly CI failures since [#12112](https://github.com/polkadot-js/apps/issues/12112) (Jan 14, 2026) through the latest [#12225](https://github.com/polkadot-js/apps/issues/12225) (Apr 2, 2026).

Direct connectivity tests against all 11 endpoints today confirmed they are completely down (connection refused/timeout), while the non-Tunisia Dwellir endpoints (`*.n.dwellir.com`) remain healthy.

## Changes

Removed `Dwellir Tunisia` provider entries from:

| File | Endpoints removed |
|---|---|
| `productionRelayPolkadot.ts` | Polkadot relay, Asset Hub, Bridge Hub, Collectives (4) |
| `productionRelayKusama.ts` | Kusama relay, Asset Hub, Bridge Hub (3) |
| `testingRelayWestend.ts` | Westend relay, Asset Hub, Bridge Hub, Collectives (4) |

## Related

- Closes #12225
- Related #12112, #12153, #12159, #12162, #12176