### PR TITLE
Update QF testnet RPC URL

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -783,7 +783,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'qf-testnet',
     providers: {
-      'QF Network': 'wss://test.qfnetwork.xyz'
+      'QF Network': 'wss://testnet.qfnode.net'
     },
     text: 'QF Network Testnet',
     ui: {


### PR DESCRIPTION
Updates the QF Network testnet endpoint from the deprecated `test.qfnetwork.xyz` URL to the new `testnet.qfnode.net` RPC endpoint.
