### PR TITLE
Add Heima Explorer external link

### DIFF
--- a/packages/apps-config/src/links/heimaExplorer.ts
+++ b/packages/apps-config/src/links/heimaExplorer.ts
@@ -1,0 +1,25 @@
+// Copyright 2017-2026 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { BN } from '@polkadot/util';
+import type { ExternalDef } from './types.js';
+
+import { nodesHeimaSVG } from '../ui/logos/nodes/index.js';
+
+export const HeimaExplorer: ExternalDef = {
+  chains: {
+    Heima: 'heima'
+  },
+  create: (_chain: string, path: string, data: BN | number | string): string =>
+    `https://explorer.heima.network/${path}/${data.toString()}`,
+  homepage: 'https://explorer.heima.network/',
+  isActive: true,
+  paths: {
+    address: 'sub/account',
+    block: 'sub/block',
+    extrinsic: 'sub/extrinsic'
+  },
+  ui: {
+    logo: nodesHeimaSVG
+  }
+};

--- a/packages/apps-config/src/links/index.ts
+++ b/packages/apps-config/src/links/index.ts
@@ -7,6 +7,7 @@ import { CereStats } from './cerestats.js';
 import { Commonwealth } from './commonwealth.js';
 import { Dotreasury } from './dotreasury.js';
 import { Edgscan } from './edgscan.js';
+import { HeimaExplorer } from './heimaExplorer.js';
 import { KodaDot } from './kodadot.js';
 import { MoonbeamApps } from './moonbeamApps.js';
 import { PolkassemblyIo, PolkassemblyNetwork } from './polkassembly.js';
@@ -20,6 +21,7 @@ export const externalLinks: Record<string, ExternalDef> = {
   Commonwealth,
   Dotreasury,
   Edgscan,
+  'Heima Explorer': HeimaExplorer,
   KodaDot,
   MoonbeamApps,
   PolkassemblyIo,

--- a/packages/apps-config/src/links/subscan.ts
+++ b/packages/apps-config/src/links/subscan.ts
@@ -45,7 +45,6 @@ export const Subscan: ExternalDef = {
     Dock: 'dock',
     'Dolphin Parachain Testnet': 'dolphin',
     'Energy Web X': 'energywebx',
-    Heima: 'heima',
     Humanode: 'humanode',
     'Humanode Mainnet': 'humanode',
     Hydration: 'hydration',


### PR DESCRIPTION
## Summary

This PR replaces the Heima Subscan external link with the project-hosted Heima Explorer:

https://explorer.heima.network

Heima previously used `https://heima.subscan.io` as the external explorer target. The Heima team now maintains a self-hosted explorer for the network, based on Subscan Essentials, and would like Polkadot Apps users to be directed to the canonical Heima explorer.

## Changes

- Add a dedicated `Heima Explorer` external link definition.
- Route Heima block, extrinsic, and account links to `https://explorer.heima.network`.
- Remove Heima from the generic Subscan external link mapping so Polkadot Apps no longer generates `https://heima.subscan.io/...` URLs for Heima.

## Link mapping

- Blocks: `https://explorer.heima.network/sub/block/{hash}`
- Extrinsics: `https://explorer.heima.network/sub/extrinsic/{id}`
- Accounts: `https://explorer.heima.network/sub/account/{id}`

## Verification

- Confirmed the Heima explorer is live at https://explorer.heima.network
- Confirmed the explorer serves Heima Substrate block, extrinsic, and account routes.
