### PR TITLE
No mortality era check

### DIFF
--- a/packages/page-explorer/src/BlockInfo/Extrinsic.tsx
+++ b/packages/page-explorer/src/BlockInfo/Extrinsic.tsx
@@ -28,7 +28,7 @@ interface Props {
 const BN_TEN_THOUSAND = new BN(10_000);
 
 function getEra ({ era }: Extrinsic, blockNumber?: BlockNumber): [number, number] | null {
-  if (blockNumber && era.isMortalEra) {
+  if (blockNumber && era?.isMortalEra) {
     const mortalEra = era.asMortalEra;
 
     return [mortalEra.birth(blockNumber.toNumber()), mortalEra.death(blockNumber.toNumber())];


### PR DESCRIPTION
## Description

Minor fix to prevent block explore window from crashing if a transaction is missing mortality era extension.

The error can be easily reproduced if substrate example node is modified to exclude the `CheckMortality` extension, and try to submit an extrinsic.