### PR TITLE
Add LinkPool Polkadot RPC endpoint to productionRelayPolkadot.ts

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -989,6 +989,7 @@ export const prodRelayPolkadot: EndpointOption = {
     // 'Automata 1RPC': 'wss://1rpc.io/dot',
     Dwellir: 'wss://polkadot-rpc.n.dwellir.com',
     Helixstreet: 'wss://rpc-polkadot.helixstreet.io',
+    LinkPool: 'wss://polkadot-mainnet.linkpool.com',
     LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
     OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
     // RadiumBlock: 'wss://polkadot.public.curie.radiumblock.co/ws',


### PR DESCRIPTION
Adds LinkPool's public Polkadot relay RPC endpoint (wss://polkadot-mainnet.linkpool.com)
to the Polkadot Relay provider list.
