### PR TITLE
Add Rotko endpoints to Polkadot & Kusama system chains

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -854,7 +854,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       Dwellir: 'wss://asset-hub-kusama-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
       OnFinality: 'wss://assethub-kusama.api.onfinality.io/public-ws',
-      Parity: 'wss://kusama-asset-hub-rpc.polkadot.io'
+      Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',
+      Rotko: 'wss://asset-hub-kusama.rotko.net'
       // RadiumBlock: 'wss://statemine.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-assethub-kusama.stakeworld.io'
     },
@@ -875,6 +876,7 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-bridge-hub-kusama.luckyfriday.io',
       OnFinality: 'wss://bridgehub-kusama.api.onfinality.io/public-ws',
       Parity: 'wss://kusama-bridge-hub-rpc.polkadot.io',
+      Rotko: 'wss://bridge-hub-kusama.rotko.net',
       // RadiumBlock: 'wss://bridgehub-kusama.public.curie.radiumblock.co/ws',
       Spectrum: 'wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/balkpUVauqyv8g/kusamabridgehub/mainnet/'
       // Stakeworld: 'wss://rpc-bridgehub-kusama.stakeworld.io'
@@ -894,7 +896,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       Dwellir: 'wss://coretime-kusama-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-coretime-kusama.luckyfriday.io',
       OnFinality: 'wss://coretime-kusama.api.onfinality.io/public-ws',
-      Parity: 'wss://kusama-coretime-rpc.polkadot.io'
+      Parity: 'wss://kusama-coretime-rpc.polkadot.io',
+      Rotko: 'wss://coretime-kusama.rotko.net'
       // Stakeworld: 'wss://rpc-coretime-kusama.stakeworld.io'
     },
     relayName: 'kusama',
@@ -913,7 +916,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
     providers: {
       Dwellir: 'wss://encointer-kusama-rpc.n.dwellir.com',
       'Encointer Association': 'wss://kusama.api.encointer.org',
-      LuckyFriday: 'wss://rpc-encointer-kusama.luckyfriday.io'
+      LuckyFriday: 'wss://rpc-encointer-kusama.luckyfriday.io',
+      Rotko: 'wss://encointer-kusama.rotko.net'
       // OnFinality: 'wss://encointer.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9986
       // Stakeworld: 'wss://ksm-rpc.stakeworld.io/encointer'
     },
@@ -935,7 +939,8 @@ export const prodParasKusamaCommon: EndpointOption[] = [
       Helixstreet: 'wss://rpc-people-kusama.helixstreet.io',
       LuckyFriday: 'wss://rpc-people-kusama.luckyfriday.io',
       OnFinality: 'wss://people-kusama.api.onfinality.io/public-ws',
-      Parity: 'wss://kusama-people-rpc.polkadot.io'
+      Parity: 'wss://kusama-people-rpc.polkadot.io',
+      Rotko: 'wss://people-kusama.rotko.net'
       // RadiumBlock: 'wss://people-kusama.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-people-kusama.stakeworld.io'
     },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -885,6 +885,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-bridge-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://bridgehub-polkadot.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-bridge-hub-rpc.polkadot.io',
+      Rotko: 'wss://bridge-hub-polkadot.rotko.net',
       // RadiumBlock: 'wss://bridgehub-polkadot.public.curie.radiumblock.co/ws',
       Spectrum: 'wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/mgX--uWlEtmNKw/polkadotbridgehub/mainnet/'
       // Stakeworld: 'wss://rpc-bridge-hub-polkadot.stakeworld.io'
@@ -921,7 +922,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://collectives-polkadot-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-collectives-polkadot.luckyfriday.io',
       OnFinality: 'wss://collectives.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-collectives-rpc.polkadot.io'
+      Parity: 'wss://polkadot-collectives-rpc.polkadot.io',
+      Rotko: 'wss://collectives-polkadot.rotko.net'
       // RadiumBlock: 'wss://collectives.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-collectives-polkadot.stakeworld.io'
     },
@@ -941,7 +943,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://coretime-polkadot-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-coretime-polkadot.luckyfriday.io',
       OnFinality: 'wss://coretime-polkadot.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-coretime-rpc.polkadot.io'
+      Parity: 'wss://polkadot-coretime-rpc.polkadot.io',
+      Rotko: 'wss://coretime-polkadot.rotko.net'
       // RadiumBlock: 'wss://coretime-polkadot.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-coretime-polkadot.stakeworld.io'
     },
@@ -959,7 +962,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://people-polkadot-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
       OnFinality: 'wss://people-polkadot.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-people-rpc.polkadot.io'
+      Parity: 'wss://polkadot-people-rpc.polkadot.io',
+      Rotko: 'wss://people-polkadot.rotko.net'
       // RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-people-polkadot.stakeworld.io'
     },

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -887,6 +887,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       LuckyFriday: 'wss://rpc-bridge-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://bridgehub-polkadot.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-bridge-hub-rpc.polkadot.io',
+      Rotko: 'wss://bridge-hub-polkadot.rotko.net',
       // RadiumBlock: 'wss://bridgehub-polkadot.public.curie.radiumblock.co/ws',
       Spectrum: 'wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/mgX--uWlEtmNKw/polkadotbridgehub/mainnet/',
       Stakeworld: 'wss://rpc-bridge-hub-polkadot.stakeworld.io'
@@ -923,7 +924,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://collectives-polkadot-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-collectives-polkadot.luckyfriday.io',
       OnFinality: 'wss://collectives.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-collectives-rpc.polkadot.io'
+      Parity: 'wss://polkadot-collectives-rpc.polkadot.io',
+      Rotko: 'wss://collectives-polkadot.rotko.net'
       // RadiumBlock: 'wss://collectives.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-collectives-polkadot.stakeworld.io'
     },
@@ -943,7 +945,8 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       Dwellir: 'wss://coretime-polkadot-rpc.n.dwellir.com',
       LuckyFriday: 'wss://rpc-coretime-polkadot.luckyfriday.io',
       OnFinality: 'wss://coretime-polkadot.api.onfinality.io/public-ws',
-      Parity: 'wss://polkadot-coretime-rpc.polkadot.io'
+      Parity: 'wss://polkadot-coretime-rpc.polkadot.io',
+      Rotko: 'wss://coretime-polkadot.rotko.net'
       // RadiumBlock: 'wss://coretime-polkadot.public.curie.radiumblock.co/ws'
       // Stakeworld: 'wss://rpc-coretime-polkadot.stakeworld.io'
     },
@@ -964,6 +967,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
       OnFinality: 'wss://people-polkadot.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-people-rpc.polkadot.io',
       // RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws'
+      Rotko: 'wss://people-polkadot.rotko.net',
       Stakeworld: 'wss://rpc-people-polkadot.stakeworld.io'
     },
     relayName: 'polkadot',


### PR DESCRIPTION
Adds Rotko Networks (`Rotko`) as an RPC provider for the Polkadot and Kusama system chains it operates:

- **Polkadot:** Bridge Hub, Collectives, Coretime, People
- **Kusama:** Asset Hub, Bridge Hub, Coretime, Encointer, People

Endpoints are `wss://<chain>.rotko.net`, served over native IPv4/IPv6 from Rotko's own ASN (AS142108) in Bangkok. Each entry is placed alphabetically within the chain's `providers`.