### PR TITLE
Add Helixstreet RPC endpoints for Polkadot AssetHub and People chains

### DIFF
--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -1008,4 +1008,3 @@ export const prodRelayPolkadot: EndpointOption = {
     logo: chainsPolkadotCircleSVG
   }
 };
-  

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -862,6 +862,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1000,
     providers: {
       Dwellir: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
+      Helixstreet: 'wss://rpc-asset-hub-polkadot.helixstreet.io',
       LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
       OnFinality: 'wss://statemint.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
@@ -957,6 +958,7 @@ export const prodParasPolkadotCommon: EndpointOption[] = [
     paraId: 1004,
     providers: {
       Dwellir: 'wss://people-polkadot-rpc.n.dwellir.com',
+      Helixstreet: 'wss://rpc-people-polkadot.helixstreet.io',
       LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
       OnFinality: 'wss://people-polkadot.api.onfinality.io/public-ws',
       Parity: 'wss://polkadot-people-rpc.polkadot.io',
@@ -1006,3 +1008,4 @@ export const prodRelayPolkadot: EndpointOption = {
     logo: chainsPolkadotCircleSVG
   }
 };
+  


### PR DESCRIPTION
Adding Helixstreet public RPC endpoints for Polkadot AssetHub and People chains. Helixstreet won RPC Tender 5 for public RPC nodes.