### PR TITLE
Add BlockMachine (Lite) endpoint for Bittensor

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -108,6 +108,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'bittensor',
     providers: {
+      'blockmachine (Lite)': 'wss://rpc.blockmachine.io',
       'Latent Holdings (Lite)': 'wss://lite.sub.latent.to:443',
       'OnFinality (Archive)': 'wss://bittensor-finney.api.onfinality.io/public-ws',
       'Opentensor Fdn (Archive)': 'wss://entrypoint-finney.opentensor.ai:443'


### PR DESCRIPTION
Adds BlockMachine as a public RPC provider for Bittensor.

- `blockmachine (Lite)`: `wss://rpc.blockmachine.io`

BlockMachine is a decentralized RPC service on Bittensor (SN19); this is its public, no-API-key lite endpoint. Verified live: connects, reports `system_chain: Bittensor`, and tracks the finney chain head. Listed first in the Bittensor providers.