### PR TITLE
Add SIK and TunaStaking RPC providers to Bulletin (Paseo)

### DIFF
--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -501,7 +501,9 @@ export const testParasPaseoCommon: EndpointOption[] = [
     isPeopleForIdentity: true,
     paraId: 1010,
     providers: {
-      StakingLand: 'wss://bulletin-paseo.tservices.es:8443'
+      SIK: 'wss://bullet.sik.rocks',
+      StakingLand: 'wss://bulletin-paseo.tservices.es:8443',
+      TunaStaking: 'wss://bullet.tunastaking.eu'
     },
     relayName: 'paseo',
     teleport: [-1, 1000],


### PR DESCRIPTION
## Summary

Adds two more RPC providers to the Bulletin system chain entry on Paseo: SIK and TunaStaking.