### PR TITLE
Disable 18 endpoints with no DNS resolution

### DIFF
--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -37,8 +37,8 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: '3dpass',
     providers: {
-      '3dpass': 'wss://rpc.3dpass.org',
-      Lzmz: 'wss://rpc.p3d.top'
+      '3dpass': 'wss://rpc.3dpass.org'
+      // Lzmz: 'wss://rpc.p3d.top' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: '3DPass',
     ui: {
@@ -166,7 +166,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'chainx',
     providers: {
-      ChainX: 'wss://mainnet.chainx.org/ws'
+      // ChainX: 'wss://mainnet.chainx.org/ws' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'ChainX',
     ui: {
@@ -338,7 +338,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'joystream',
     providers: {
       Joyutils: 'wss://rpc.joyutils.org',
-      Jsgenesis: 'wss://rpc.joystream.org',
+      // Jsgenesis: 'wss://rpc.joystream.org', // https://github.com/polkadot-js/apps/issues/12425
       'l1.media': 'wss://rpc.l1.media'
     },
     text: 'Joystream',
@@ -529,7 +529,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'sora-substrate',
     providers: {
-      OnFinality: 'wss://sora.api.onfinality.io/public-ws',
+      // OnFinality: 'wss://sora.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/12425
       'SORA Parliament Ministry of Finance': 'wss://ws.mof.sora.org',
       'SORA Parliament Ministry of Finance #2': 'wss://mof2.sora.org'
       // 'SORA Parliament Ministry of Finance #3': 'wss://mof3.sora.org' // https://github.com/polkadot-js/apps/issues/12007
@@ -598,7 +598,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'tangle',
     providers: {
-      Dwellir: 'wss://tangle-mainnet-rpc.n.dwellir.com',
+      // Dwellir: 'wss://tangle-mainnet-rpc.n.dwellir.com', // https://github.com/polkadot-js/apps/issues/12425
       Webb: 'wss://rpc.tangle.tools'
     },
     text: 'Tangle',
@@ -611,7 +611,7 @@ export const prodChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'tanssi',
     isPeople: true,
     providers: {
-      'Tanssi Foundation': 'wss://services.tanssi-mainnet.network/tanssi'
+      // 'Tanssi Foundation': 'wss://services.tanssi-mainnet.network/tanssi' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'Tanssi',
     ui: {

--- a/packages/apps-config/src/endpoints/productionRelayKusama.ts
+++ b/packages/apps-config/src/endpoints/productionRelayKusama.ts
@@ -410,7 +410,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     paraId: 2241,
     providers: {
       // Krest: 'wss://wss-krest.peaq.network/', // https://github.com/polkadot-js/apps/issues/12018
-      OnFinality: 'wss://krest.api.onfinality.io/public-ws'
+      // OnFinality: 'wss://krest.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/12425
       // UnitedBloc: 'wss://krest.unitedbloc.com/' https://github.com/polkadot-js/apps/issues/10997
     },
     text: 'Krest',
@@ -574,7 +574,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     providers: {
       // Dwellir: 'wss://quartz-rpc.n.dwellir.com', // https://github.com/polkadot-js/apps/issues/11513
       // OnFinality: 'wss://quartz.api.onfinality.io/public-ws', // https://github.com/polkadot-js/apps/issues/9972
-      'Geo Load Balancer': 'wss://ws-quartz.unique.network'
+      // 'Geo Load Balancer': 'wss://ws-quartz.unique.network' // https://github.com/polkadot-js/apps/issues/12425
       // 'Unique America': 'wss://us-ws-quartz.unique.network', // https://github.com/polkadot-js/apps/issues/11477
       // 'Unique Asia': 'wss://asia-ws-quartz.unique.network', // https://github.com/polkadot-js/apps/issues/11846
       // 'Unique Europe': 'wss://eu-ws-quartz.unique.network'
@@ -707,7 +707,7 @@ export const prodParasKusama: Omit<EndpointOption, 'teleport'>[] = [
     info: 'sora',
     paraId: 2011,
     providers: {
-      Soramitsu: 'wss://ws.parachain-collator-2.c2.sora2.soramitsu.co.jp'
+      // Soramitsu: 'wss://ws.parachain-collator-2.c2.sora2.soramitsu.co.jp' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'SORA',
     ui: {

--- a/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
+++ b/packages/apps-config/src/endpoints/productionRelayPolkadot.ts
@@ -230,10 +230,10 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'darwinia',
     paraId: 2046,
     providers: {
-      Darwinia: 'wss://rpc.darwinia.network',
+      Darwinia: 'wss://rpc.darwinia.network'
       // Dcdao: 'wss://darwinia-rpc.dcdao.box', https://github.com/polkadot-js/apps/issues/11157
       // Dwellir: 'wss://darwinia-rpc.n.dwellir.com', // https://github.com/polkadot-js/apps/issues/11965
-      Subquery: 'wss://darwinia.rpc.subquery.network/public/ws'
+      // Subquery: 'wss://darwinia.rpc.subquery.network/public/ws' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'Darwinia',
     ui: {
@@ -657,7 +657,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'phala',
     paraId: 2035,
     providers: {
-      Dwellir: 'wss://phala-rpc.n.dwellir.com'
+      // Dwellir: 'wss://phala-rpc.n.dwellir.com' // https://github.com/polkadot-js/apps/issues/12425
       // Helikon: 'wss://rpc.helikon.io/phala',
       // OnFinality: 'wss://phala.api.onfinality.io/public-ws',
       // Phala: 'wss://api.phala.network/ws', // https://github.com/polkadot-js/apps/issues/11251
@@ -716,7 +716,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'sora',
     paraId: 2025,
     providers: {
-      Soramitsu: 'wss://ws.parachain-collator-3.pc3.sora2.soramitsu.co.jp'
+      // Soramitsu: 'wss://ws.parachain-collator-3.pc3.sora2.soramitsu.co.jp' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'SORA',
     ui: {
@@ -843,7 +843,7 @@ export const prodParasPolkadot: Omit<EndpointOption, 'teleport'>[] = [
     info: 'zeitgeist',
     paraId: 2092,
     providers: {
-      OnFinality: 'wss://zeitgeist.api.onfinality.io/public-ws'
+      // OnFinality: 'wss://zeitgeist.api.onfinality.io/public-ws' // https://github.com/polkadot-js/apps/issues/12425
       // ZeitgeistPM: 'wss://main.rpc.zeitgeist.pm/ws' // https://github.com/polkadot-js/apps/issues/11215
     },
     text: 'Zeitgeist',
@@ -999,7 +999,7 @@ export const prodRelayPolkadot: EndpointOption = {
     // RockX: 'wss://rockx-dot.w3node.com/polka-public-dot/ws', // https://github.com/polkadot-js/apps/issues/11439
     Spectrum: 'wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/LjwBJpV3dIKyWQ/polkadot/mainnet/',
     // Stakeworld: 'wss://rpc-polkadot.stakeworld.io',
-    SubQuery: 'wss://polkadot.rpc.subquery.network/public/ws',
+    // SubQuery: 'wss://polkadot.rpc.subquery.network/public/ws', // https://github.com/polkadot-js/apps/issues/12425
     interweb: 'wss://rpc.interweb-it.com/polkadot',
     'light client': 'light://substrate-connect/polkadot'
   },

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -271,7 +271,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
     info: 'Dancelight',
     isPeople: true,
     providers: {
-      'Tanssi Foundation': 'wss://services.tanssi-testnet.network/dancelight'
+      // 'Tanssi Foundation': 'wss://services.tanssi-testnet.network/dancelight' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'Dancelight',
     ui: {
@@ -783,7 +783,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'qf-testnet',
     providers: {
-      'QF Network': 'wss://test.qfnetwork.xyz'
+      // 'QF Network': 'wss://test.qfnetwork.xyz' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'QF Network Testnet',
     ui: {
@@ -1060,7 +1060,7 @@ export const testChains: Omit<EndpointOption, 'teleport'>[] = [
   {
     info: 'vara-testnet',
     providers: {
-      Gear: 'wss://testnet.vara.network'
+      // Gear: 'wss://testnet.vara.network' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'Vara Testnet',
     ui: {

--- a/packages/apps-config/src/endpoints/testingRelayPaseo.ts
+++ b/packages/apps-config/src/endpoints/testingRelayPaseo.ts
@@ -74,7 +74,7 @@ export const testParasPaseo: Omit<EndpointOption, 'teleport'>[] = [
     info: 'bulletin',
     paraId: 5118,
     providers: {
-      Parity: 'wss://paseo-bulletin-rpc.polkadot.io'
+      // Parity: 'wss://paseo-bulletin-rpc.polkadot.io' // https://github.com/polkadot-js/apps/issues/12425
     },
     text: 'Bulletin (Paseo)',
     ui: {


### PR DESCRIPTION
Addresses part of #12425.

The nightly list has 57 entries. I probed every one with a real WebSocket handshake plus a `chain_getBlockHash` call, twice, and they are not all the same kind of failure. This PR takes **only the 18 that fail DNS resolution**, which is the subset that cannot be transient and that resolves identically from any vantage point.

Each was re-checked against four independent public resolvers (Google, Cloudflare, Quad9, OpenDNS) — unanimous. 16 return NXDOMAIN; `ws-quartz.unique.network` and `paseo-bulletin-rpc.polkadot.io` return NOERROR with no records of any type (no A, AAAA, CNAME or TXT), so the name exists but publishes no address.

| Chain | Provider |
|---|---|
| Polkadot Relay | `polkadot.rpc.subquery.network` |
| Darwinia | `darwinia.rpc.subquery.network` |
| Krest | `krest.api.onfinality.io` |
| SORA (solochain) | `sora.api.onfinality.io` |
| Zeitgeist | `zeitgeist.api.onfinality.io` |
| Phala Network | `phala-rpc.n.dwellir.com` |
| Tangle | `tangle-mainnet-rpc.n.dwellir.com` |
| ChainX | `mainnet.chainx.org` |
| 3DPass | `rpc.p3d.top` |
| Joystream | `rpc.joystream.org` |
| Tanssi | `services.tanssi-mainnet.network` |
| Dancelight | `services.tanssi-testnet.network` |
| Vara Testnet | `testnet.vara.network` |
| QUARTZ by UNIQUE | `ws-quartz.unique.network` |
| QF Network Testnet | `test.qfnetwork.xyz` |
| SORA (Kusama 2011) | `ws.parachain-collator-2…soramitsu.co.jp` |
| SORA (Polkadot 2025) | `ws.parachain-collator-3…soramitsu.co.jp` |
| Bulletin (Paseo) | `paseo-bulletin-rpc.polkadot.io` |

Each is commented out with an issue reference, matching the existing convention. `tsc --noEmit` and `eslint` pass.

### Please note: 12 chains lose their last active provider

They become unreachable through the `isUnreachable: isUnreachable || !hasProviders` derivation in `endpoints/util.ts`:

**ChainX · Tanssi · Dancelight · QF Network Testnet · Vara Testnet · Krest · QUARTZ by UNIQUE · SORA (Kusama) · SORA (Polkadot) · Bulletin (Paseo) · Phala Network · Zeitgeist**

This matches the ~180 chains already in this state, but it is worth a look — particularly **Bulletin (Paseo)**, which is Parity-operated.

I also probed all 13 already-commented-out providers on these 12 chains, to see whether any could be uncommented instead of letting the chain go dark. None can — every one is also down. But they fail in two different ways, which may matter to whoever owns these:

- **Phala** (`api.phala.network/ws`, Cloudflare 526 — origin reached, invalid certificate) and **Zeitgeist** (`main.rpc.zeitgeist.pm/ws`, TLS `EPROTO`) still have something listening. These look misconfigured rather than decommissioned, so a working provider may just need restoring.
- **QUARTZ by UNIQUE** is the opposite: all four alternates (`us-`/`asia-`/`eu-ws-quartz.unique.network`, `quartz-rpc.n.dwellir.com`, `quartz.api.onfinality.io`) are NXDOMAIN. The DNS has been removed wholesale.
- **Krest** sits in between — `wss-krest.peaq.network` returns 522 and `krest.unitedbloc.com` resets the connection.

To be explicit about the limit of that: a TLS-layer error proves a server is listening, not that the chain is producing blocks.

### Deliberately not included

- **Three endpoints are alive right now** and should not be touched: `rpc-polkadot.helixstreet.io` (returns the correct Polkadot genesis `0x91b171bb…`), `hk.p.bifrost-rpc.liebi.com`, `parachain.curioinvest.com`. `acala-rpc.n.dwellir.com` is flapping — alive, then 503.
- **onFinality public endpoints are rate-limited, not down.** `altair` answers `-32029: Too Many Requests, Please apply an OnFinality API key or contact us to receive a higher rate limit`. Dropping them is a policy call, not a liveness one.
- **~19 "server up, endpoint broken"** (Cloudflare 521/522/525/526, 502s, 404s) and **7 timeouts** — real but potentially recoverable, and I tested from one network rather than from CI. They deserve a separate pass.

Caveat on the excluded groups: my probes ran from a single host, whereas CI runs from GitHub Actions runners, so IP-based rate limiting and geo-blocking could differ. That confounder does not apply to the 18 in this PR, since DNS resolution is not vantage-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
